### PR TITLE
Fix repeating sounds in `MxWavePresenter`

### DIFF
--- a/LEGO1/omni/include/mxwavepresenter.h
+++ b/LEGO1/omni/include/mxwavepresenter.h
@@ -38,6 +38,7 @@ public:
 	void ReadyTickle() override;      // vtable+0x18
 	void StartingTickle() override;   // vtable+0x1c
 	void StreamingTickle() override;  // vtable+0x20
+	void RepeatingTickle() override;  // added by isle-portable
 	void DoneTickle() override;       // vtable+0x2c
 	void ParseExtra() override;       // vtable+0x30
 	MxResult AddToManager() override; // vtable+0x34


### PR DESCRIPTION
Previously, I've made the following observation:

> 		// [library:audio]
> 		// The original game supported a looping/repeating action mode which apparently
> 		// went unused in the retail version of the game (at least for audio).
> 		// It is only ever "used" on startup to load two dummy sounds which are
> 		// initially disabled and never play: IsleScript::c_TransitionSound1 and IsleScript::c_TransitionSound2
> 		// If MxDSAction::c_looping was set, MxWavePresenter kept the entire sound track
> 		// in a buffer, presumably to allow random seeking and looping. This functionality
> 		// has most likely been superseded by the looping mechanism implemented in the streaming layer.
> 		// Since this has gone unused and to reduce complexity, we don't allow this anymore;
> 		// except for the two dummy sounds, which must be !IsEnabled()

However, it turns out repeating actions *are* used for some sounds, such as the horn of the ambulance. Until now, the sound would only play a single time when enabled - after that, there would be silence. This is because of the underlying buffer that I used to implement the chunk processing: it's a ring buffer that only contains 2 chunks worth of data at a time, and does not maintain the entire sound in memory. As such, once the sound was played, it would not play again.

The original game uses a hybrid approach where the DirectSound buffer is used both as a "streaming" buffer (also containing up to 2 seconds / chunks worth of data), or a regular buffer for an entire sound in case `MxDSAction::c_looping` was set. This made for some rather complex logic.

Instead of using a different kind of buffer, I've decided to leverage the already existing logic of "looping chunks" in the code base. Now, whenever a repeating sound is enabled, all chunks of the looping chunk list will be pushed into the buffer at once. This keeps the code reasonably straightforward. The only caveat is that loop counts greater than 1 are not supported, due to the fact that the data in the ring buffer is still ephemeral (read-once only).

However, it looks like loop counts greater than 1 aren't used at all. I've put an assertion into the code to verify this. If we do come across an action like this, we could switch to a paged memory buffer for repeating actions which would allow natively looping over the same sound in memory as many times as necessary.