### PR TITLE
add automatic release uploads using CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
           path: |
             build/ISLE.EXE
             build/LEGO1.DLL
+            build/SDL3.dll
 
   upload:
     name: 'Upload artifacts'
@@ -99,4 +100,5 @@ jobs:
       run: |
         ./upload.sh \
           build/ISLE.EXE \
-          build/LEGO1.DLL
+          build/LEGO1.DLL \
+          build/SDL3.dll

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,3 +66,37 @@ jobs:
             -DISLE_WERROR=${{ !!matrix.toolchain.werror }} \
             -Werror=dev
           cmake --build build -- -k0
+
+      # Needs to be reworked when cross-platform building is achieved
+      - name: Upload Build Artifacts (MSVC (32-bit))
+        if: matrix.toolchain.name == 'MSVC (32-bit)'
+        uses: actions/upload-artifact@master
+        with:
+          name: msvc32-artifacts
+          path: |
+            build/ISLE.EXE
+            build/LEGO1.DLL
+
+  upload:
+    name: 'Upload artifacts'
+    needs: build-current-toolchain
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'isledecomp/isle-portable' }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: 'probonopd/uploadtool'
+
+    - uses: actions/download-artifact@master
+      with:
+        name: msvc32-artifacts
+        path: build
+
+    - name: Upload Continuous Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UPLOAD_KEY: ${{ secrets.UPLOAD_KEY }}
+      run: |
+        ./upload.sh \
+          build/ISLE.EXE \
+          build/LEGO1.DLL


### PR DESCRIPTION
This PR adds automatic release uploading of `ISLE.EXE` and `LEGO1.DLL` like we have in the main isle repo. `CONFIG.EXE` is not uploaded considering its redundancy.

Currently, I've written the workflow to only provide uploads of the binaries built by `MSVC (32-bit)` specifically. This means that the job gets skipped entirely when the CI produces builds under any other toolchain. The reason the initial artifact upload step is placed at the end of the build step is so the CI has the context necessary for this check; otherwise, it wouldn't know which toolchain in the matrix was used to build the game.

If there is any interest in uploading the binaries produced by *every* toolchain regardless of platform, I can refactor this and implement that. The reason I have done it this way is that I am not certain whether or not the other toolchains currently produce functional builds of the game.

The workflow will need to slowly be tweaked over time as we introduce more supported platforms. It should be relatively easy to adapt and maintain it going forward and I am willing to take this responsibility on.