### PR TITLE
add release builds to the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-        - { name: 'MSVC (32-bit)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false }
-        - { name: 'MSVC (64-bit)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true }
-        - { name: 'msys2 mingw32',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true }
-        - { name: 'msys2 mingw64',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true }
-        # - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true, werror: true, dx5-libs: true, d3drm-from-wine: true }
+      - { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
+      - { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
+      - { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
+      - { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
+      - { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
+      # - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true, werror: true, dx5-libs: true, d3drm-from-wine: true }
 
     steps:
       - name: Setup vcvars
@@ -59,7 +60,7 @@ jobs:
         # Add -DDOWNLOAD_DEPENDENCIES=OFF once setup-sdl works
         run: |
           cmake -S . -B build -GNinja \
-            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_BUILD_TYPE=${{ matrix.toolchain.build-type }} \
             -DISLE_USE_DX5=${{ matrix.toolchain.dx5-libs }} \
             -DISLE_D3DRM_FROM_WINE=${{ matrix.toolchain.d3drm-from-wine }} \
             -DENABLE_CLANG_TIDY=${{ !!matrix.toolchain.clang-tidy }} \
@@ -68,15 +69,21 @@ jobs:
           cmake --build build -- -k0
 
       # Needs to be reworked when cross-platform building is achieved
+
+      - name: Make Artifact Archive
+        shell: bash
+        run: |
+          cd build
+          zip isle-portable${{ matrix.toolchain.name }}${{ matrix.toolchain.build-type }}.zip \
+              ISLE.EXE LEGO1.DLL SDL3.dll
+
       - name: Upload Build Artifacts (MSVC (32-bit))
-        if: matrix.toolchain.name == 'MSVC (32-bit)'
+        if: ${{ matrix.toolchain.name == 'MSVC (32-bit, Release)' || matrix.toolchain.name == 'MSVC (32-bit, Debug)' }}
         uses: actions/upload-artifact@master
         with:
           name: msvc32-artifacts
           path: |
-            build/ISLE.EXE
-            build/LEGO1.DLL
-            build/SDL3.dll
+            build/isle-portable${{ matrix.toolchain.name }}${{ matrix.toolchain.build-type }}.zip
 
   upload:
     name: 'Upload artifacts'
@@ -99,6 +106,4 @@ jobs:
         UPLOAD_KEY: ${{ secrets.UPLOAD_KEY }}
       run: |
         ./upload.sh \
-          build/ISLE.EXE \
-          build/LEGO1.DLL \
-          build/SDL3.dll
+          build/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           cd build
-          zip isle-portable${{ matrix.toolchain.name }}${{ matrix.toolchain.build-type }}.zip \
+          zip isle-portable-${{ matrix.toolchain.name }}-${{ matrix.toolchain.build-type }}.zip \
               ISLE.EXE LEGO1.DLL SDL3.dll
 
       - name: Upload Build Artifacts (MSVC (32-bit))
@@ -83,7 +83,7 @@ jobs:
         with:
           name: msvc32-artifacts
           path: |
-            build/isle-portable${{ matrix.toolchain.name }}${{ matrix.toolchain.build-type }}.zip
+            build/isle-portable-${{ matrix.toolchain.name }}-${{ matrix.toolchain.build-type }}.zip
 
   upload:
     name: 'Upload artifacts'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           cd build
-          zip isle-portable-${{ matrix.toolchain.name }}-${{ matrix.toolchain.build-type }}.zip \
+          zip "isle-portable ${{ matrix.toolchain.name }}.zip" \
               ISLE.EXE LEGO1.DLL SDL3.dll
 
       - name: Upload Build Artifacts (MSVC (32-bit))
@@ -83,7 +83,7 @@ jobs:
         with:
           name: msvc32-artifacts
           path: |
-            build/isle-portable-${{ matrix.toolchain.name }}-${{ matrix.toolchain.build-type }}.zip
+            build/"isle-portable ${{ matrix.toolchain.name }}.zip"
 
   upload:
     name: 'Upload artifacts'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-      - { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
-      - { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
-      - { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
-      - { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
-      - { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
-      # - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true, werror: true, dx5-libs: true, d3drm-from-wine: true }
+        - { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
+        - { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
+        - { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
+        - { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
+        - { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
+        # - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true, werror: true, dx5-libs: true, d3drm-from-wine: true }
 
     steps:
       - name: Setup vcvars

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           cd build
-          7z a "isle-portable ${{ matrix.toolchain.name }}.zip" \
+          7z a "isle-portable (${{ matrix.toolchain.name }}).zip" \
               ISLE.EXE LEGO1.DLL SDL3.dll
 
       - name: Upload Build Artifacts (MSVC (32-bit))
@@ -83,7 +83,7 @@ jobs:
         with:
           name: msvc32-artifacts
           path: |
-            build/"isle-portable ${{ matrix.toolchain.name }}.zip"
+            build/isle-portable (${{ matrix.toolchain.name }}).zip
 
   upload:
     name: 'Upload artifacts'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload Build Artifacts (MSVC (32-bit))
         if: ${{ matrix.toolchain.name == 'MSVC (32-bit, Release)' || matrix.toolchain.name == 'MSVC (32-bit, Debug)' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3
         with:
           name: msvc32-artifacts
           path: |
@@ -95,7 +95,7 @@ jobs:
       with:
         repository: 'probonopd/uploadtool'
 
-    - uses: actions/download-artifact@master
+    - uses: actions/download-artifact@v3
       with:
         name: msvc32-artifacts
         path: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           cd build
-          zip "isle-portable ${{ matrix.toolchain.name }}.zip" \
+          7z a "isle-portable ${{ matrix.toolchain.name }}.zip" \
               ISLE.EXE LEGO1.DLL SDL3.dll
 
       - name: Upload Build Artifacts (MSVC (32-bit))


### PR DESCRIPTION
Following up to our exchange in #37 - it turns out we were actually *only* building Debug builds under all toolchains. The `CMAKE_BUILD_TYPE` flag was hardcoded to `Debug` in the workflow. 

This PR addresses this by adding a new flag for build type in the toolchain matrix. I kept every single toolchain at Debug for now just to keep it consistent with how it was before, but I added a new entry for making Release builds under MSVC 32-bit. We could define Release and Debug versions of every toolchain in the matrix, but my main concern with doing that is making the CI pass take an unreasonable amount of time. My reasons for prioritizing MSVC 32-bit in this case are largely the same as I described in #37.

I've also adjusted how the artifacts get uploaded and released. Because the names of the built binaries currently don't differ between Debug and Release builds, there would be a conflict in the continuous release if we uploaded both binary types. This is technically an inaccuracy inherited from the main isle repo, since we know from Beta 1.0 that Mindscape appended `D` to its debug builds; this should possibly be remedied in the original CMake project. For this reason, I have implemented a step in the workflow that creates a zip archive with the binaries (LEGO1, ISLE, and SDL3) and names it dynamically using the retrieved toolchain name. So in the continuous release, we would get, for example, `isle-portable (MSVC 32-bit, Release).zip` and `isle-portable (MSVC 32-bit, Debug).zip`.

For the record, even if we did account for the debug build naming inaccuracy, SDL3 does *not* append `d` to its debug builds as it's a non-standard naming convention, so we would need the archive solution anyways. Plus, I just think it is a little cleaner than having six floating binaries in a release that all need to be downloaded individually.