### PR TITLE
add arm64 MSVC toolchain to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         #- { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
         #- { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
         #- { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
-        - { name: 'MSVC (ARM64, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_arm64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Release' }
+        - { name: 'MSVC (ARM64, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_arm64',     dx5-libs: true,  d3drm-from-wine: false, build-type: 'Release' }
         #- { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         #- { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         # - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true, werror: true, dx5-libs: true, d3drm-from-wine: true }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
         toolchain:
         #- { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
         #- { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
-        #- { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
-        - { name: 'MSVC (ARM64, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_arm64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Release' }
+        - { name: 'MSVC (64-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Release' }
+        #- { name: 'MSVC (ARM64, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_arm64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Release' }
         #- { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         #- { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         # - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true, werror: true, dx5-libs: true, d3drm-from-wine: true }
@@ -79,7 +79,7 @@ jobs:
               ISLE.EXE LEGO1.DLL SDL3.dll
 
       - name: Upload Build Artifacts (MSVC (32-bit))
-        if: ${{ matrix.toolchain.name == 'MSVC (32-bit, Release)' || matrix.toolchain.name == 'MSVC (32-bit, Debug)' || matrix.toolchain.name == 'MSVC (ARM64, Release)' }}
+        if: ${{ matrix.toolchain.name == 'MSVC (64-bit, Release)' || matrix.toolchain.name == 'MSVC (32-bit, Debug)' || matrix.toolchain.name == 'MSVC (ARM64, Release)' }}
         uses: actions/upload-artifact@v3
         with:
           name: msvc32-artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-        - { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
-        - { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
-        - { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
+        #- { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
+        #- { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
+        #- { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
         - { name: 'MSVC (ARM64, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_arm64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Release' }
-        - { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
-        - { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
+        #- { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
+        #- { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         # - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true, werror: true, dx5-libs: true, d3drm-from-wine: true }
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
         toolchain:
         #- { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
         #- { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
-        - { name: 'MSVC (64-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Release' }
-        #- { name: 'MSVC (ARM64, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_arm64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Release' }
+        #- { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
+        - { name: 'MSVC (ARM64, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_arm64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Release' }
         #- { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         #- { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         # - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true, werror: true, dx5-libs: true, d3drm-from-wine: true }
@@ -79,7 +79,7 @@ jobs:
               ISLE.EXE LEGO1.DLL SDL3.dll
 
       - name: Upload Build Artifacts (MSVC (32-bit))
-        if: ${{ matrix.toolchain.name == 'MSVC (64-bit, Release)' || matrix.toolchain.name == 'MSVC (32-bit, Debug)' || matrix.toolchain.name == 'MSVC (ARM64, Release)' }}
+        if: ${{ matrix.toolchain.name == 'MSVC (32-bit, Release)' || matrix.toolchain.name == 'MSVC (32-bit, Debug)' || matrix.toolchain.name == 'MSVC (ARM64, Release)' }}
         uses: actions/upload-artifact@v3
         with:
           name: msvc32-artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         - { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
         - { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
         - { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
-        - { name: 'MSVC (ARM64, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'arm64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Release' }
+        - { name: 'MSVC (ARM64, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_arm64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Release' }
         - { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         - { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         # - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true, werror: true, dx5-libs: true, d3drm-from-wine: true }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-        #- { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
-        #- { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
-        #- { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
-        - { name: 'MSVC (ARM64, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_arm64',     dx5-libs: true,  d3drm-from-wine: false, build-type: 'Release' }
-        #- { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
-        #- { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
+        - { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
+        - { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
+        - { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
+        - { name: 'MSVC (ARM64, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_arm64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
+        - { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
+        - { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         # - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true, werror: true, dx5-libs: true, d3drm-from-wine: true }
 
     steps:
@@ -79,7 +79,7 @@ jobs:
               ISLE.EXE LEGO1.DLL SDL3.dll
 
       - name: Upload Build Artifacts (MSVC (32-bit))
-        if: ${{ matrix.toolchain.name == 'MSVC (32-bit, Release)' || matrix.toolchain.name == 'MSVC (32-bit, Debug)' || matrix.toolchain.name == 'MSVC (ARM64, Release)' }}
+        if: ${{ matrix.toolchain.name == 'MSVC (32-bit, Release)' || matrix.toolchain.name == 'MSVC (32-bit, Debug)' }}
         uses: actions/upload-artifact@v3
         with:
           name: msvc32-artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
         - { name: 'MSVC (32-bit, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Release' }
         - { name: 'MSVC (32-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64_x86', dx5-libs: true,   d3drm-from-wine: false, build-type: 'Debug' }
         - { name: 'MSVC (64-bit, Debug)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'amd64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Debug' }
+        - { name: 'MSVC (ARM64, Release)',  shell: 'sh',  setup-cmake: true, setup-ninja: true, setup-msvc: true, vc-arch: 'arm64',     dx5-libs: false,  d3drm-from-wine: true, build-type: 'Release' }
         - { name: 'msys2 mingw32 (Debug)',  shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686,        clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         - { name: 'msys2 mingw64 (Debug)',  shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,      clang-tidy: true, werror: true, dx5-libs: false, d3drm-from-wine: true, build-type: 'Debug' }
         # - { name: 'msys2 clang32',  shell: 'msys2 {0}', msystem: clang32, msys-env: mingw-w64-clang-i686,  clang-tidy: true, werror: true, dx5-libs: true, d3drm-from-wine: true }
@@ -78,7 +79,7 @@ jobs:
               ISLE.EXE LEGO1.DLL SDL3.dll
 
       - name: Upload Build Artifacts (MSVC (32-bit))
-        if: ${{ matrix.toolchain.name == 'MSVC (32-bit, Release)' || matrix.toolchain.name == 'MSVC (32-bit, Debug)' }}
+        if: ${{ matrix.toolchain.name == 'MSVC (32-bit, Release)' || matrix.toolchain.name == 'MSVC (32-bit, Debug)' || matrix.toolchain.name == 'MSVC (ARM64, Release)' }}
         uses: actions/upload-artifact@v3
         with:
           name: msvc32-artifacts


### PR DESCRIPTION
This PR adds a Windows ARM64 MSVC toolchain to the build CI. I found that the game compiles for ARM without any issues using the non-MSVC toolchain configuration and the 64-bit fixes that maarten established in #25 and #29 respectively.

Currently, the game does not run because d3drm lacks an ARM build. The x86 -> ARM64 emulation layer baked into Windows only supports executables in which both the binary and its modules are fully x86, so ARM64 `ISLE.EXE` cannot load x86 `d3drm.dll`. For this reason, these artifacts are not uploaded. However, I expect this build to work out of the box once the remaining DirectX components are replaced.

Windows does not support 32-bit ARM, so this is the only ARM target we can currently support.