### PR TITLE
Fix repeating sounds in `MxWavePresenter` (again)

### DIFF
--- a/LEGO1/omni/include/mxwavepresenter.h
+++ b/LEGO1/omni/include/mxwavepresenter.h
@@ -90,13 +90,14 @@ protected:
 	WaveFormat* m_waveFormat; // 0x54
 
 	// [library:audio]
-	// If MxDSAction::looping is set, we keep the entire audio in memory and use the paged buffer `m_pb`.
+	// If MxDSAction::looping is set, we keep the entire audio in memory and use `m_ab`.
 	// In (most) other cases, data is streamed through the ring buffer `m_rb`.
 	ma_pcm_rb m_rb;
 	struct {
-		ma_paged_audio_buffer buffer;
-		ma_paged_audio_buffer_data data;
-	} m_pb;
+		ma_audio_buffer buffer;
+		MxU8* data;
+		MxU32 offset;
+	} m_ab;
 
 	ma_sound m_sound;
 	MxU32 m_chunkLength; // 0x5c

--- a/LEGO1/omni/include/mxwavepresenter.h
+++ b/LEGO1/omni/include/mxwavepresenter.h
@@ -94,10 +94,10 @@ protected:
 	// In (most) other cases, data is streamed through the ring buffer `m_rb`.
 	ma_pcm_rb m_rb;
 	struct {
-		ma_audio_buffer buffer;
-		MxU8* data;
-		MxU32 length;
-		MxU32 offset;
+		ma_audio_buffer m_buffer;
+		MxU8* m_data;
+		MxU32 m_length;
+		MxU32 m_offset;
 	} m_ab;
 
 	ma_sound m_sound;

--- a/LEGO1/omni/include/mxwavepresenter.h
+++ b/LEGO1/omni/include/mxwavepresenter.h
@@ -38,7 +38,6 @@ public:
 	void ReadyTickle() override;      // vtable+0x18
 	void StartingTickle() override;   // vtable+0x1c
 	void StreamingTickle() override;  // vtable+0x20
-	void RepeatingTickle() override;  // added by isle-portable
 	void DoneTickle() override;       // vtable+0x2c
 	void ParseExtra() override;       // vtable+0x30
 	MxResult AddToManager() override; // vtable+0x34
@@ -89,7 +88,16 @@ protected:
 	static const MxU32 g_supportedFormatTag = 1;
 
 	WaveFormat* m_waveFormat; // 0x54
+
+	// [library:audio]
+	// If MxDSAction::looping is set, we keep the entire audio in memory and use the paged buffer `m_pb`.
+	// In (most) other cases, data is streamed through the ring buffer `m_rb`.
 	ma_pcm_rb m_rb;
+	struct {
+		ma_paged_audio_buffer buffer;
+		ma_paged_audio_buffer_data data;
+	} m_pb;
+
 	ma_sound m_sound;
 	MxU32 m_chunkLength; // 0x5c
 	MxBool m_started;    // 0x65

--- a/LEGO1/omni/include/mxwavepresenter.h
+++ b/LEGO1/omni/include/mxwavepresenter.h
@@ -96,6 +96,7 @@ protected:
 	struct {
 		ma_audio_buffer buffer;
 		MxU8* data;
+		MxU32 length;
 		MxU32 offset;
 	} m_ab;
 

--- a/LEGO1/omni/src/audio/mxwavepresenter.cpp
+++ b/LEGO1/omni/src/audio/mxwavepresenter.cpp
@@ -59,6 +59,7 @@ void MxWavePresenter::Destroy(MxBool p_fromDestructor)
 MxBool MxWavePresenter::WriteToSoundBuffer(void* p_audioPtr, MxU32 p_length)
 {
 	if (m_action->IsLooping()) {
+		assert(m_ab.offset + p_length <= m_ab.length);
 		memcpy(m_ab.data + m_ab.offset, p_audioPtr, p_length);
 		m_ab.offset += p_length;
 		return TRUE;
@@ -136,7 +137,8 @@ void MxWavePresenter::StartingTickle()
 				sampleRate
 			);
 
-			m_ab.data = new MxU8[ma_get_bytes_per_frame(format, channels) * sizeInFrames];
+			m_ab.length = ma_get_bytes_per_frame(format, channels) * sizeInFrames;
+			m_ab.data = new MxU8[m_ab.length];
 
 			ma_audio_buffer_config config =
 				ma_audio_buffer_config_init(format, channels, sizeInFrames, m_ab.data, NULL);

--- a/LEGO1/omni/src/audio/mxwavepresenter.cpp
+++ b/LEGO1/omni/src/audio/mxwavepresenter.cpp
@@ -41,8 +41,8 @@ void MxWavePresenter::Destroy(MxBool p_fromDestructor)
 {
 	ma_sound_uninit(&m_sound);
 	ma_pcm_rb_uninit(&m_rb);
-	ma_audio_buffer_uninit(&m_ab.buffer);
-	delete[] m_ab.data;
+	ma_audio_buffer_uninit(&m_ab.m_buffer);
+	delete[] m_ab.m_data;
 
 	if (m_waveFormat) {
 		delete[] ((MxU8*) m_waveFormat);
@@ -59,9 +59,9 @@ void MxWavePresenter::Destroy(MxBool p_fromDestructor)
 MxBool MxWavePresenter::WriteToSoundBuffer(void* p_audioPtr, MxU32 p_length)
 {
 	if (m_action->IsLooping()) {
-		assert(m_ab.offset + p_length <= m_ab.length);
-		memcpy(m_ab.data + m_ab.offset, p_audioPtr, p_length);
-		m_ab.offset += p_length;
+		assert(m_ab.m_offset + p_length <= m_ab.m_length);
+		memcpy(m_ab.m_data + m_ab.m_offset, p_audioPtr, p_length);
+		m_ab.m_offset += p_length;
 		return TRUE;
 	}
 	else {
@@ -137,14 +137,14 @@ void MxWavePresenter::StartingTickle()
 				sampleRate
 			);
 
-			m_ab.length = ma_get_bytes_per_frame(format, channels) * sizeInFrames;
-			m_ab.data = new MxU8[m_ab.length];
+			m_ab.m_length = ma_get_bytes_per_frame(format, channels) * sizeInFrames;
+			m_ab.m_data = new MxU8[m_ab.m_length];
 
 			ma_audio_buffer_config config =
-				ma_audio_buffer_config_init(format, channels, sizeInFrames, m_ab.data, NULL);
+				ma_audio_buffer_config_init(format, channels, sizeInFrames, m_ab.m_data, NULL);
 			config.sampleRate = sampleRate;
 
-			if (ma_audio_buffer_init(&config, &m_ab.buffer) != MA_SUCCESS) {
+			if (ma_audio_buffer_init(&config, &m_ab.m_buffer) != MA_SUCCESS) {
 				goto done;
 			}
 		}
@@ -165,7 +165,7 @@ void MxWavePresenter::StartingTickle()
 
 		if (ma_sound_init_from_data_source(
 				MSoundManager()->GetEngine(),
-				m_action->IsLooping() ? (ma_data_source*) &m_ab.buffer : (ma_data_source*) &m_rb,
+				m_action->IsLooping() ? (ma_data_source*) &m_ab.m_buffer : (ma_data_source*) &m_rb,
 				m_is3d ? 0 : MA_SOUND_FLAG_NO_SPATIALIZATION,
 				NULL,
 				&m_sound


### PR DESCRIPTION
Reference: https://github.com/isledecomp/isle-portable/pull/35

Turns out that repeating sounds with a loop count greater than 1 do exist after all. One example is the `Rotate_Sound` that is played in the building minigame when you rotate the current construction. Note that "loop count greater than 1" means "loop indefinitely" in case of audio - this is the same logic that the original game uses as well, so we are not making any changes to that.

In order to fully support this we now have to use two different buffers - for all the streaming audio the ring buffer is still used, and for looping/repeating sounds a plain old memory buffer is used instead.

Tested and verified it works as expected.