### PR TITLE
replace directinput joystick APIs with SDL

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -236,7 +236,7 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char** argv)
 {
 	*appstate = NULL;
 
-	if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO)) {
+	if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK)) {
 		SDL_ShowSimpleMessageBox(
 			SDL_MESSAGEBOX_ERROR,
 			"LEGO® Island Error",

--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -9,7 +9,7 @@
 
 #include <SDL3/SDL_joystick.h>
 #include <SDL3/SDL_keyboard.h>
-#include <dinput.h>
+#include <windows.h>
 
 class LegoCameraController;
 class LegoControlManager;

--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -7,6 +7,7 @@
 #include "mxpresenter.h"
 #include "mxqueue.h"
 
+#include <SDL3/SDL_joystick.h>
 #include <SDL3/SDL_keyboard.h>
 #include <dinput.h>
 
@@ -95,8 +96,8 @@ public:
 
 	MxResult Create(HWND p_hwnd);
 	void Destroy() override;
-	MxResult GetJoystickId();
-	MxResult GetJoystickState(MxU32* p_joystickX, MxU32* p_joystickY, DWORD* p_buttonsState, MxU32* p_povPosition);
+	MxResult GetJoystick();
+	MxResult GetJoystickState(MxU32* p_joystickX, MxU32* p_joystickY, MxU32* p_povPosition);
 	void StartAutoDragTimer();
 	void StopAutoDragTimer();
 	void EnableInputProcessing();
@@ -150,10 +151,10 @@ private:
 	LegoControlManager* m_controlManager; // 0x84
 	MxBool m_unk0x88;                     // 0x88
 	const bool* m_keyboardState;
-	MxBool m_unk0x195;     // 0x195
-	MxS32 m_joyid;         // 0x198
+	MxBool m_unk0x195; // 0x195
+	SDL_JoystickID* m_joyids;
+	SDL_Joystick* m_joystick;
 	MxS32 m_joystickIndex; // 0x19c
-	JOYCAPS m_joyCaps;     // 0x200
 	MxBool m_useJoystick;  // 0x334
 	MxBool m_unk0x335;     // 0x335
 	MxBool m_unk0x336;     // 0x336

--- a/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
@@ -499,12 +499,10 @@ MxResult LegoNavController::ProcessJoystickInput(MxBool& p_und)
 	if (instance->GetInputManager()) {
 		MxS32 joystickX;
 		MxS32 joystickY;
-		DWORD buttonState;
 		MxS32 povPosition;
 
 		if (instance->GetInputManager()
-				->GetJoystickState((MxU32*) &joystickX, (MxU32*) &joystickY, &buttonState, (MxU32*) &povPosition) !=
-			FAILURE) {
+				->GetJoystickState((MxU32*) &joystickX, (MxU32*) &joystickY, (MxU32*) &povPosition) != FAILURE) {
 			MxU32 yVal = (joystickY * m_vMax) / 100;
 			MxU32 xVal = (joystickX * m_hMax) / 100;
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To achieve our goal of platform independence, we need to replace any Windows-onl
 | Filesystem | [SDL3](https://www.libsdl.org/) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Afilesystem%5D%22&type=code) |
 | Threads, Mutexes (Synchronization) | [SDL3](https://www.libsdl.org/) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Asynchronization%5D%22&type=code) |
 | Keyboard/Mouse, DirectInput (Input) | [SDL3](https://www.libsdl.org/) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Ainput%5D%22&type=code) |
-| Joystick/Gamepad, DirectInput (Input) | [SDL3](https://www.libsdl.org/) | ❌ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Ainput%5D%22&type=code) |
+| Joystick/Gamepad, DirectInput (Input) | [SDL3](https://www.libsdl.org/) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Ainput%5D%22&type=code) |
 | WinMM, DirectSound (Audio) | [SDL3](https://www.libsdl.org/), [miniaudio](https://miniaud.io/) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Aaudio%5D%22&type=code) |
 | DirectDraw (2D video) | [SDL3](https://www.libsdl.org/) | ❌ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3A2d%5D%22&type=code) |
 | [Smacker](https://github.com/isledecomp/isle/tree/master/3rdparty/smacker) | [libsmacker](https://github.com/foxtacles/libsmacker) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable%20%22%2F%2F%20%5Blibrary%3Alibsmacker%5D%22&type=code) |


### PR DESCRIPTION
Functional.

I've renamed `GetJoystickId()` to `GetJoystick()` since we don't always globally grab the handle to the joystick from its id anymore like we did with DirectInput. Instead, we use the joystick id once to grab and store the handle to the joystick in an `SDL_Joystick` object, which I have made a member of LegoInputManager named `m_joystick`.

I've removed `buttonState` since it is effectively unused. LEGO Island does not support any joystick buttons *except* for hat button input for POV switching which gets handled in a separate manner.

The reason for the switch statement in `GetJoystickState()` is because SDL's definitions for joystick hat values do not correspond to those in DirectInput, so conversion is necessary to keep the POV switching identical to how it was in the original game. If you have a better or cleaner way of doing this, by all means let me know.

Since SDL's API is vastly superior to DirectInput, this enables hotswapping of joysticks:

https://github.com/user-attachments/assets/82e9c1c8-197a-45b0-95b2-78a806457e7d

Just like the original, the game does not accept any joystick input if "Use Joystick" is set to `FALSE`, and the keyboard remains available even if "Use Joystick" is set to `TRUE`.
