### PR TITLE
fix: update libiniparser repository link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(DOWNLOAD_DEPENDENCIES)
 
     FetchContent_Declare(
         iniparser
-        GIT_REPOSITORY "https://github.com/ndevilla/iniparser.git"
+        GIT_REPOSITORY "https://gitlab.com/iniparser/iniparser.git"
         GIT_TAG "main"
         EXCLUDE_FROM_ALL
     )

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To achieve our goal of platform independence, we need to replace any Windows-onl
 | Library/subsystem | Substitution | Status | |
 | - | - | - | - |
 | Window, Events | [SDL3](https://www.libsdl.org/) | WIP | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Awindow%5D%22&type=code) |
-| Windows Registry (Configuration) | [libiniparser](https://github.com/ndevilla/iniparser) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Aconfig%5D%22&type=code) |
+| Windows Registry (Configuration) | [libiniparser](https://gitlab.com/iniparser/iniparser) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Aconfig%5D%22&type=code) |
 | Filesystem | [SDL3](https://www.libsdl.org/) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Afilesystem%5D%22&type=code) |
 | Threads, Mutexes (Synchronization) | [SDL3](https://www.libsdl.org/) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Asynchronization%5D%22&type=code) |
 | Keyboard/Mouse, DirectInput (Input) | [SDL3](https://www.libsdl.org/) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Ainput%5D%22&type=code) |


### PR DESCRIPTION
The libiniparser maintainers have appeared to move to a GitLab repository. I have updated the link accordingly.