### PR TITLE
Let CMake automatically fetch libsmacker and miniaudio

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,9 +1,20 @@
 set(CMAKE_C_CLANG_TIDY)
 
-add_library(miniaudio STATIC
-    miniaudio/extras/miniaudio_split/miniaudio.c
-)
-target_include_directories(miniaudio PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/miniaudio/extras/miniaudio_split")
+if(DOWNLOAD_DEPENDENCIES)
+    include(FetchContent)
+    FetchContent_Declare(
+        miniaudio
+        URL https://github.com/mackron/miniaudio/archive/refs/tags/0.11.22.tar.gz
+        URL_MD5 4944268151ad037f148b089237566d05
+    )
+    FetchContent_MakeAvailable(miniaudio)
+else()
+    add_library(miniaudio STATIC
+        miniaudio/extras/miniaudio_split/miniaudio.c
+    )
+    target_include_directories(miniaudio PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/miniaudio/extras/miniaudio_split")
+endif()
+
 set_property(TARGET miniaudio PROPERTY ARCHIVE_OUTPUT_NAME "miniaudio$<$<CONFIG:Debug>:d>")
 # Disable most features since we don't need them.
 target_compile_definitions(miniaudio PUBLIC
@@ -19,8 +30,20 @@ target_compile_definitions(miniaudio PUBLIC
     MA_NO_THREADING
 )
 
+if(DOWNLOAD_DEPENDENCIES)
+    include(FetchContent)
+    FetchContent_Declare(
+        libsmacker
+        URL https://github.com/foxtacles/libsmacker/archive/b3d4e97e0c95d5259d858495a5addd2d93bce5f4.tar.gz
+        URL_MD5 7f822319c489ec1a8e41c9f1e2629195
+    )
+    FetchContent_MakeAvailable(libsmacker)
+else()
+    set(libsmacker_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libsmacker")
+endif()
+
 add_library(libsmacker STATIC
-    libsmacker/smacker.c
+    ${libsmacker_SOURCE_DIR}/smacker.c
 )
 set_property(TARGET libsmacker PROPERTY ARCHIVE_OUTPUT_NAME "libsmacker$<$<CONFIG:Debug>:d>")
-target_include_directories(libsmacker PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/libsmacker")
+target_include_directories(libsmacker PUBLIC ${libsmacker_SOURCE_DIR})


### PR DESCRIPTION
The installation of libsmacker didn't happen automatically and instead of giving up I implemented it.

Hope this is the way you like it, if not let me know and I'll try and adjust.

This allows me (on Linux) to configure the project and start compiling (71% successful) by just simply running:
```bash
cmake -S . -B build
cmake --build build -j 32
```
No need to manually install deps or read extra setup instructions :)

Now I can look into the Windows dependencies that are currently the cause of the build failing.