### PR TITLE
Correct check for lighting support legovideomanager.cpp

### DIFF
--- a/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
+++ b/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
@@ -136,9 +136,9 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 	m_direct3d->SetDevice(deviceEnumerate, driver, device);
 	/*
 	 * BUG: should be:
-	 *  if ((driver->m_ddCaps.dwCaps2 & DDCAPS2_CERTIFIED) == 0 && driver->m_ddCaps.dwSVBRops[7] != 2) { 
-	 */
-	if (driver->m_ddCaps.dwCaps2 != DDCAPS2_CERTIFIED && driver->m_ddCaps.dwSVBRops[7] != 2) { 
+	 *  if ((driver->m_ddCaps.dwCaps2 & DDCAPS2_CERTIFIED) == 0 && driver->m_ddCaps.dwSVBRops[7] != 2) {
+ 	 */
+	if (driver->m_ddCaps.dwCaps2 != DDCAPS2_CERTIFIED && driver->m_ddCaps.dwSVBRops[7] != 2) {
 		p_videoParam.Flags().SetF2bit0(TRUE);
 	}
 	else {

--- a/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
+++ b/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
@@ -134,8 +134,11 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 	}
 
 	m_direct3d->SetDevice(deviceEnumerate, driver, device);
-
-	if (!driver->m_ddCaps.dwCaps2 && driver->m_ddCaps.dwSVBRops[7] != 2) {
+	/*
+	 * BUG: should be:
+	 *  if ((driver->m_ddCaps.dwCaps2 & DDCAPS2_CERTIFIED) == 0 && driver->m_ddCaps.dwSVBRops[7] != 2) { 
+	 */
+	if (driver->m_ddCaps.dwCaps2 != DDCAPS2_CERTIFIED && driver->m_ddCaps.dwSVBRops[7] != 2) { 
 		p_videoParam.Flags().SetF2bit0(TRUE);
 	}
 	else {


### PR DESCRIPTION
It's pure luck this worked, `DDCAPS2_CERTIFIED` happens to be `1` so the compiler boils it down to an inverse boolean check which then means lighting is enabled on all hardware that sets _any_ `DDCAPS2_*` flag.
Microsoft defines `BOOL` the same as `DWORD` and `DDCAPS2_CERTIFIED` and `TRUE` are both `1`, so it makes sens that there compiler would have this as an optimization.

I feel this is a general trend, who ever was in charge of integrating with DirectX didn't know how to work with bitflags or at least forgot a lot.