### PR TITLE
minimfc: Fix config app

### DIFF
--- a/miniwin/minimfc/include/minimfc.h
+++ b/miniwin/minimfc/include/minimfc.h
@@ -130,8 +130,8 @@ struct CMenu {
 
 struct CWinApp {
 	CWinApp();
-	virtual ~CWinApp();
-	virtual BOOL InitInstance();
+	virtual ~CWinApp() = default;
+	virtual BOOL InitInstance() = 0;
 	virtual int ExitInstance();
 };
 
@@ -188,10 +188,7 @@ inline int GetSystemMetrics(int nIndex)
 	return 0;
 }
 
-inline BOOL GetVersionEx(OSVERSIONINFOA* version)
-{
-	return TRUE;
-}
+BOOL GetVersionEx(OSVERSIONINFOA* version);
 
 void GlobalMemoryStatus(MEMORYSTATUS* memory_status);
 

--- a/miniwin/minimfc/src/minimfc.cpp
+++ b/miniwin/minimfc/src/minimfc.cpp
@@ -21,20 +21,13 @@ CWinApp::CWinApp()
 		abort();
 	}
 	wndTop = this;
-}
 
-CWinApp::~CWinApp() = default;
-
-BOOL CWinApp::InitInstance()
-{
 	if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK)) {
 		SDL_Log("SDL_Init: %s\n", SDL_GetError());
-		return FALSE;
+		return;
 	}
 
 	window = SDL_CreateWindow(title, 640, 480, 0);
-
-	return TRUE;
 }
 
 int CWinApp::ExitInstance()
@@ -73,9 +66,7 @@ int main(int argc, char* argv[])
 		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No CWinApp created");
 		abort();
 	}
-	if (!wndTop->InitInstance()) {
-		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "CWinApp::InitInstance failed");
-	}
+	wndTop->InitInstance();
 
 	SDL_Event event;
 	bool running = true;
@@ -134,6 +125,15 @@ BOOL GetWindowRect(HWND hWnd, RECT* Rect)
 	Rect->left = w + x;
 	Rect->bottom = h + y;
 
+	return TRUE;
+}
+
+BOOL GetVersionEx(OSVERSIONINFOA* version)
+{
+	version->dwOSVersionInfoSize = sizeof(OSVERSIONINFOA);
+	version->dwMajorVersion = 5; // Win2k/XP
+	version->dwPlatformId = 2;   // NT
+	version->dwBuildNumber = 0x500;
 	return TRUE;
 }
 


### PR DESCRIPTION
It broke during the refactor in https://github.com/isledecomp/isle-portable/pull/75

- InitInstance() always return false so lets not check it as a sign of life :/
- CWinApp::InitInstance() is no longer called so move it's logic to the constructor so the app no longer freezes
- Implement OS detection cause I'm tired of the "no directx 5" message

I'm thinking about maybe expanding this to the point where it can at least show the info it pulls from the lego1 lib as it could be helpful as a sanity check.