### PR TITLE
Fix initilization and overlapping memcpy

### DIFF
--- a/LEGO1/omni/src/stream/mxramstreamprovider.cpp
+++ b/LEGO1/omni/src/stream/mxramstreamprovider.cpp
@@ -140,7 +140,7 @@ MxU32 ReadData(MxU8* p_buffer, MxU32 p_size)
 					}
 
 					data2 = MxDSChunk::End(data2);
-					memcpy(data2, data3, MxDSChunk::Size(data3));
+					memmove(data2, data3, MxDSChunk::Size(data3));
 
 					if (*MxStreamChunk::IntoObjectId(data2) == id &&
 						(*MxStreamChunk::IntoFlags(data2) & DS_CHUNK_END_OF_STREAM)) {

--- a/miniwin/miniwin/src/miniwin.cpp
+++ b/miniwin/miniwin/src/miniwin.cpp
@@ -1,5 +1,7 @@
 #include "miniwin.h"
 
+#include "miniwin_p.h"
+
 #include <SDL3/SDL.h>
 #include <vector>
 
@@ -21,6 +23,7 @@ ULONG IUnknown::Release()
 
 HRESULT IUnknown::QueryInterface(const GUID& riid, void** ppvObject)
 {
+	SDL_LogError(LOG_CATEGORY_MINIWIN, "IUnknown does not implement guid");
 	return E_NOINTERFACE;
 }
 

--- a/miniwin/miniwin/src/miniwin_d3drm.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drm.cpp
@@ -183,7 +183,7 @@ struct Direct3DRMObjectBase : public T {
 
 private:
 	std::vector<std::pair<D3DRMOBJECTCALLBACK, void*>> m_callbacks;
-	LPD3DRM_APPDATA m_appData = NULL;
+	LPD3DRM_APPDATA m_appData = nullptr;
 	char* m_name = nullptr;
 };
 
@@ -206,7 +206,8 @@ struct Direct3DRMMeshImpl : public Direct3DRMObjectBase<IDirect3DRMMesh> {
 	HRESULT AddGroup(int vertexCount, int faceCount, int vertexPerFace, void* faceBuffer, D3DRMGROUPINDEX* groupIndex)
 		override
 	{
-		return DD_OK;
+		assert(false && "Unimplemented");
+		return DDERR_GENERIC;
 	}
 	HRESULT GetGroup(
 		int groupIndex,
@@ -244,7 +245,7 @@ struct Direct3DRMMeshImpl : public Direct3DRMObjectBase<IDirect3DRMMesh> {
 	HRESULT GetVertices(int groupIndex, int startIndex, int count, D3DRMVERTEX* vertices) override { return DD_OK; }
 
 private:
-	IDirect3DRMTexture* m_groupTexture;
+	IDirect3DRMTexture* m_groupTexture = nullptr;
 };
 
 struct Direct3DRMTextureImpl : public Direct3DRMObjectBase<IDirect3DRMTexture2> {
@@ -375,7 +376,7 @@ private:
 	IDirect3DRMFrameArray* m_children;
 	IDirect3DRMLightArray* m_lights;
 	IDirect3DRMVisualArray* m_visuals;
-	IDirect3DRMTexture* m_texture;
+	IDirect3DRMTexture* m_texture = nullptr;
 };
 
 struct Direct3DRMViewportImpl : public Direct3DRMObjectBase<IDirect3DRMViewport> {
@@ -412,7 +413,7 @@ struct Direct3DRMViewportImpl : public Direct3DRMObjectBase<IDirect3DRMViewport>
 	HRESULT Pick(float x, float y, LPDIRECT3DRMPICKEDARRAY* pickedArray) override { return DD_OK; }
 
 private:
-	IDirect3DRMFrame* m_camera;
+	IDirect3DRMFrame* m_camera = nullptr;
 };
 
 struct Direct3DRMLightImpl : public Direct3DRMObjectBase<IDirect3DRMLight> {


### PR DESCRIPTION
- This fixes trying to fix a garbage address
- Adds errors/logging/assert to a bit of unimplemented paths
- Fixes an original bug with an overlapping data copy