### PR TITLE
Add support for 8bit color key

### DIFF
--- a/miniwin/miniwin/src/miniwin_ddsurface.cpp
+++ b/miniwin/miniwin/src/miniwin_ddsurface.cpp
@@ -236,6 +236,17 @@ HRESULT DirectDrawSurfaceImpl::SetClipper(LPDIRECTDRAWCLIPPER lpDDClipper)
 
 HRESULT DirectDrawSurfaceImpl::SetColorKey(DDColorKeyFlags dwFlags, LPDDCOLORKEY lpDDColorKey)
 {
+	if (!lpDDColorKey) {
+		return DDERR_INVALIDPARAMS;
+	}
+	if (m_surface->format != SDL_PIXELFORMAT_INDEX8) {
+		return DDERR_GENERIC; // Not currently supported
+	}
+
+	if (SDL_SetSurfaceColorKey(m_surface, true, lpDDColorKey->dwColorSpaceLowValue) != 0) {
+		return DDERR_GENERIC;
+	}
+
 	return DD_OK;
 }
 


### PR DESCRIPTION
The game _can_ now look fully correct:
![image](https://github.com/user-attachments/assets/c1e1a59e-07db-44c1-812c-0da4a6b92a6b)
