### PR TITLE
Get the game working on 64bit systems

### DIFF
--- a/LEGO1/lego/sources/3dmanager/lego3dview.cpp
+++ b/LEGO1/lego/sources/3dmanager/lego3dview.cpp
@@ -154,7 +154,7 @@ double Lego3DView::Render(double p_und)
 }
 
 // FUNCTION: LEGO1 0x100ab2b0
-ViewROI* Lego3DView::Pick(unsigned long x, unsigned long y)
+ViewROI* Lego3DView::Pick(unsigned int x, unsigned int y)
 {
 	return m_pViewManager->Pick(GetView(), x, y);
 }

--- a/LEGO1/lego/sources/3dmanager/lego3dview.h
+++ b/LEGO1/lego/sources/3dmanager/lego3dview.h
@@ -27,7 +27,7 @@ public:
 
 	double Render(double p_und);
 
-	ViewROI* Pick(unsigned long x, unsigned long y);
+	ViewROI* Pick(unsigned int x, unsigned int y);
 
 	ViewROI* GetPointOfView();
 	ViewManager* GetViewManager();

--- a/LEGO1/lego/sources/3dmanager/tglsurface.cpp
+++ b/LEGO1/lego/sources/3dmanager/tglsurface.cpp
@@ -204,9 +204,9 @@ double TglSurface::Render()
 		{
 #if 0
 			// FIXME: Tgl::Device::GetDrawnTriangleCount does not exist
-			unsigned long triangleCount = m_pDevice->GetDrawnTriangleCount();
+			unsigned int triangleCount = m_pDevice->GetDrawnTriangleCount();
 #else
-			unsigned long triangleCount = 0;
+			unsigned int triangleCount = 0;
 #endif
 
 			m_triangleRateMeter.IncreaseOperationCount(triangleCount - m_triangleCount - 1);

--- a/LEGO1/lego/sources/3dmanager/tglsurface.h
+++ b/LEGO1/lego/sources/3dmanager/tglsurface.h
@@ -51,14 +51,14 @@ public:
 	Tgl::Group* GetScene() const { return m_pScene; }
 
 	// FUNCTION: BETA10 0x1017cbc0
-	unsigned long GetWidth() const { return m_width; }
+	unsigned int GetWidth() const { return m_width; }
 
 	// FUNCTION: BETA10 0x1017cbe0
-	unsigned long GetHeight() const { return m_height; }
+	unsigned int GetHeight() const { return m_height; }
 
 	double GetRenderingRate() const { return m_renderingRateMeter.Frequency(); }
 	double GetFrameRate() const { return m_frameRateMeter.Frequency(); }
-	unsigned long GetFrameCount() const { return m_frameCount; }
+	unsigned int GetFrameCount() const { return m_frameCount; }
 #ifdef _DEBUG
 	double GetTriangleRate() const { return m_triangleRateMeter.Frequency(); }
 #endif
@@ -73,8 +73,8 @@ private:
 	Tgl::View* m_pView;         // 0x10
 	Tgl::Group* m_pScene;       // 0x14
 
-	unsigned long m_width;  // 0x18
-	unsigned long m_height; // 0x1c
+	unsigned int m_width;  // 0x18
+	unsigned int m_height; // 0x1c
 
 	BOOL m_isInitialized; // 0x20
 	BOOL m_stopRendering; // 0x24
@@ -82,10 +82,10 @@ private:
 	// statistics
 	MxFrequencyMeter m_renderingRateMeter; // 0x28
 	MxFrequencyMeter m_frameRateMeter;     // 0x48
-	unsigned long m_frameCount;            // 0x68
+	unsigned int m_frameCount;             // 0x68
 #ifdef _DEBUG
 	MxFrequencyMeter m_triangleRateMeter;
-	unsigned long m_triangleCount;
+	unsigned int m_triangleCount;
 #endif
 };
 

--- a/LEGO1/lego/sources/misc/legotypes.h
+++ b/LEGO1/lego/sources/misc/legotypes.h
@@ -29,16 +29,27 @@
 #endif
 
 typedef char LegoS8;
+static_assert(sizeof(LegoS8) == 1, "Incorrect size");
 typedef unsigned char LegoU8;
+static_assert(sizeof(LegoU8) == 1, "Incorrect size");
 typedef short LegoS16;
+static_assert(sizeof(LegoS16) == 2, "Incorrect size");
 typedef unsigned short LegoU16;
-typedef long LegoS32;
-typedef unsigned long LegoU32;
+static_assert(sizeof(LegoU16) == 2, "Incorrect size");
+typedef int LegoS32;
+static_assert(sizeof(LegoS32) == 4, "Incorrect size");
+typedef unsigned int LegoU32;
+static_assert(sizeof(LegoU32) == 4, "Incorrect size");
 typedef float LegoFloat;
+static_assert(sizeof(LegoFloat) == 4, "Incorrect size");
 typedef char LegoChar;
+static_assert(sizeof(LegoChar) == 1, "Incorrect size");
 
 typedef LegoU8 LegoBool;
+static_assert(sizeof(LegoChar) == 1, "Incorrect size");
 typedef LegoS32 LegoTime;
+static_assert(sizeof(LegoTime) == 4, "Incorrect size");
 typedef LegoS32 LegoResult;
+static_assert(sizeof(LegoResult) == 4, "Incorrect size");
 
 #endif // __LEGOTYPES_H

--- a/LEGO1/lego/sources/misc/legotypes.h
+++ b/LEGO1/lego/sources/misc/legotypes.h
@@ -29,27 +29,28 @@
 #endif
 
 typedef char LegoS8;
-static_assert(sizeof(LegoS8) == 1, "Incorrect size");
 typedef unsigned char LegoU8;
-static_assert(sizeof(LegoU8) == 1, "Incorrect size");
 typedef short LegoS16;
-static_assert(sizeof(LegoS16) == 2, "Incorrect size");
 typedef unsigned short LegoU16;
-static_assert(sizeof(LegoU16) == 2, "Incorrect size");
 typedef int LegoS32;
-static_assert(sizeof(LegoS32) == 4, "Incorrect size");
 typedef unsigned int LegoU32;
-static_assert(sizeof(LegoU32) == 4, "Incorrect size");
 typedef float LegoFloat;
-static_assert(sizeof(LegoFloat) == 4, "Incorrect size");
 typedef char LegoChar;
-static_assert(sizeof(LegoChar) == 1, "Incorrect size");
 
 typedef LegoU8 LegoBool;
-static_assert(sizeof(LegoChar) == 1, "Incorrect size");
 typedef LegoS32 LegoTime;
-static_assert(sizeof(LegoTime) == 4, "Incorrect size");
 typedef LegoS32 LegoResult;
-static_assert(sizeof(LegoResult) == 4, "Incorrect size");
+
+static_assert(sizeof(LegoS8) == 1, "sizeof(LegoS8) == 1");
+static_assert(sizeof(LegoU8) == 1, "sizeof(LegoU8) == 1");
+static_assert(sizeof(LegoS16) == 2, "sizeof(LegoS16) == 2");
+static_assert(sizeof(LegoU16) == 2, "sizeof(LegoU16) == 2");
+static_assert(sizeof(LegoS32) == 4, "sizeof(LegoS32) == 4");
+static_assert(sizeof(LegoU32) == 4, "sizeof(LegoU32) == 4");
+static_assert(sizeof(LegoFloat) == 4, "sizeof(LegoFloat) == 4");
+static_assert(sizeof(LegoChar) == 1, "sizeof(LegoChar) == 1");
+static_assert(sizeof(LegoChar) == 1, "sizeof(LegoChar) == 1");
+static_assert(sizeof(LegoTime) == 4, "sizeof(LegoTime) == 4");
+static_assert(sizeof(LegoResult) == 4, "sizeof(LegoResult) == 4");
 
 #endif // __LEGOTYPES_H

--- a/LEGO1/mxdirectx/mxstopwatch.h
+++ b/LEGO1/mxdirectx/mxstopwatch.h
@@ -111,14 +111,14 @@ public:
 	double Frequency() const;
 	void Reset();
 
-	unsigned long OperationCount() const;
+	unsigned int OperationCount() const;
 	double ElapsedSeconds() const;
 
-	void IncreaseOperationCount(unsigned long);
+	void IncreaseOperationCount(unsigned int);
 
 private:
-	unsigned long m_operationCount; // 0x00
-	MxStopWatch m_stopWatch;        // 0x08
+	unsigned int m_operationCount; // 0x00
+	MxStopWatch m_stopWatch;       // 0x08
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -170,13 +170,13 @@ inline void MxFrequencyMeter::Reset()
 	m_operationCount = 0;
 }
 
-inline unsigned long MxFrequencyMeter::OperationCount() const
+inline unsigned int MxFrequencyMeter::OperationCount() const
 {
 	return m_operationCount;
 }
 
 // FUNCTION: BETA10 0x1017df40
-inline void MxFrequencyMeter::IncreaseOperationCount(unsigned long delta)
+inline void MxFrequencyMeter::IncreaseOperationCount(unsigned int delta)
 {
 	m_operationCount += delta;
 }

--- a/LEGO1/mxgeometry/mxquaternion.h
+++ b/LEGO1/mxgeometry/mxquaternion.h
@@ -13,7 +13,7 @@ public:
 
 	MxQuaternionTransformer() : m_flags(0) {}
 
-	inline long NormalizeDirection();
+	inline int NormalizeDirection();
 	inline void SetStartEnd(Matrix4& p_m1, Matrix4& p_m2);
 	inline void SetStart(Matrix4& p_m);
 	inline void SetEnd(Matrix4& p_m);
@@ -38,7 +38,7 @@ private:
 };
 
 // FUNCTION: LEGO1 0x10004520
-long MxQuaternionTransformer::NormalizeDirection()
+int MxQuaternionTransformer::NormalizeDirection()
 {
 	if (!m_flags) {
 		return -1;

--- a/LEGO1/omni/include/mxtypes.h
+++ b/LEGO1/omni/include/mxtypes.h
@@ -4,36 +4,22 @@
 #include <stdint.h>
 
 typedef unsigned char MxU8;
-static_assert(sizeof(MxU8) == 1, "Incorrect size");
 typedef signed char MxS8;
-static_assert(sizeof(MxS8) == 1, "Incorrect size");
 typedef unsigned short MxU16;
-static_assert(sizeof(MxU16) == 2, "Incorrect size");
 typedef signed short MxS16;
-static_assert(sizeof(MxS16) == 2, "Incorrect size");
 typedef unsigned int MxU32;
-static_assert(sizeof(MxU32) == 4, "Incorrect size");
 typedef signed int MxS32;
-static_assert(sizeof(MxS32) == 4, "Incorrect size");
 typedef uint64_t MxU64;
-static_assert(sizeof(MxU64) == 8, "Incorrect size");
 typedef int64_t MxS64;
-static_assert(sizeof(MxS64) == 8, "Incorrect size");
 typedef float MxFloat;
-static_assert(sizeof(MxFloat) == 4, "Incorrect size");
 typedef double MxDouble;
-static_assert(sizeof(MxDouble) == 8, "Incorrect size");
 
 typedef int MxLong;
-static_assert(sizeof(MxLong) == 4, "Incorrect size");
 typedef unsigned int MxULong;
-static_assert(sizeof(MxULong) == 4, "Incorrect size");
 
 typedef MxS32 MxTime;
-static_assert(sizeof(MxTime) == 4, "Incorrect size");
 
 typedef MxLong MxResult;
-static_assert(sizeof(MxResult) == 4, "Incorrect size");
 
 #ifndef SUCCESS
 #define SUCCESS 0
@@ -75,5 +61,20 @@ typedef union {
 	};
 	// BYTE all; // ?
 } FlagBitfield;
+
+static_assert(sizeof(MxU8) == 1, "sizeof(MxU8) == 1");
+static_assert(sizeof(MxS8) == 1, "sizeof(MxS8) == 1");
+static_assert(sizeof(MxU16) == 2, "sizeof(MxU16) == 2");
+static_assert(sizeof(MxS16) == 2, "sizeof(MxS16) == 2");
+static_assert(sizeof(MxU32) == 4, "sizeof(MxU32) == 4");
+static_assert(sizeof(MxS32) == 4, "sizeof(MxS32) == 4");
+static_assert(sizeof(MxU64) == 8, "sizeof(MxU64) == 8");
+static_assert(sizeof(MxS64) == 8, "sizeof(MxS64) == 8");
+static_assert(sizeof(MxFloat) == 4, "sizeof(MxFloat) == 4");
+static_assert(sizeof(MxDouble) == 8, "sizeof(MxDouble) == 8");
+static_assert(sizeof(MxLong) == 4, "sizeof(MxLong) == 4");
+static_assert(sizeof(MxULong) == 4, "sizeof(MxULong) == 4");
+static_assert(sizeof(MxTime) == 4, "sizeof(MxTime) == 4");
+static_assert(sizeof(MxResult) == 4, "sizeof(MxResult) == 4");
 
 #endif // MXTYPES_H

--- a/LEGO1/omni/include/mxtypes.h
+++ b/LEGO1/omni/include/mxtypes.h
@@ -1,38 +1,39 @@
 #ifndef MXTYPES_H
 #define MXTYPES_H
 
-typedef unsigned char MxU8;
-typedef signed char MxS8;
-typedef unsigned short MxU16;
-typedef signed short MxS16;
-typedef unsigned int MxU32;
-typedef signed int MxS32;
-#ifdef _MSC_VER
-typedef unsigned __int64 MxU64;
-typedef signed __int64 MxS64;
-#else
-typedef unsigned long long int MxU64;
-typedef signed long long int MxS64;
-#endif
-typedef float MxFloat;
-typedef double MxDouble;
+#include <stdint.h>
 
-// On MSVC, a long is 32-bit, but on GCC/Clang, it's 64-bit. LEGO Island obviously
-// assumes the former in all cases, which could become an issue in the future.
-// The "longs" can't all be changed to "ints" (which are 32-bit on both) because
-// this will break DLL export compatibility. Therefore, we define MxLong/MxULong,
-// which is guaranteed to be 32-bit, and guaranteed to be a "long" on MSVC.
-#if defined(_MSC_VER)
-typedef long MxLong;
-typedef unsigned long MxULong;
-#else
+typedef unsigned char MxU8;
+static_assert(sizeof(MxU8) == 1, "Incorrect size");
+typedef signed char MxS8;
+static_assert(sizeof(MxS8) == 1, "Incorrect size");
+typedef unsigned short MxU16;
+static_assert(sizeof(MxU16) == 2, "Incorrect size");
+typedef signed short MxS16;
+static_assert(sizeof(MxS16) == 2, "Incorrect size");
+typedef unsigned int MxU32;
+static_assert(sizeof(MxU32) == 4, "Incorrect size");
+typedef signed int MxS32;
+static_assert(sizeof(MxS32) == 4, "Incorrect size");
+typedef uint64_t MxU64;
+static_assert(sizeof(MxU64) == 8, "Incorrect size");
+typedef int64_t MxS64;
+static_assert(sizeof(MxS64) == 8, "Incorrect size");
+typedef float MxFloat;
+static_assert(sizeof(MxFloat) == 4, "Incorrect size");
+typedef double MxDouble;
+static_assert(sizeof(MxDouble) == 8, "Incorrect size");
+
 typedef int MxLong;
+static_assert(sizeof(MxLong) == 4, "Incorrect size");
 typedef unsigned int MxULong;
-#endif
+static_assert(sizeof(MxULong) == 4, "Incorrect size");
 
 typedef MxS32 MxTime;
+static_assert(sizeof(MxTime) == 4, "Incorrect size");
 
 typedef MxLong MxResult;
+static_assert(sizeof(MxResult) == 4, "Incorrect size");
 
 #ifndef SUCCESS
 #define SUCCESS 0
@@ -43,6 +44,7 @@ typedef MxLong MxResult;
 #endif
 
 typedef MxU8 MxBool;
+static_assert(sizeof(MxBool) == 1, "Incorrect size");
 
 #ifndef TRUE
 #define TRUE 1

--- a/LEGO1/tgl/d3drm/device.cpp
+++ b/LEGO1/tgl/d3drm/device.cpp
@@ -17,13 +17,13 @@ void* DeviceImpl::ImplementationDataPtr()
 }
 
 // FUNCTION: LEGO1 0x100a2c00
-unsigned long DeviceImpl::GetWidth()
+unsigned int DeviceImpl::GetWidth()
 {
 	return m_data->GetWidth();
 }
 
 // FUNCTION: LEGO1 0x100a2c10
-unsigned long DeviceImpl::GetHeight()
+unsigned int DeviceImpl::GetHeight()
 {
 	return m_data->GetHeight();
 }
@@ -51,7 +51,7 @@ Result DeviceImpl::SetShadingModel(ShadingModel model)
 }
 
 // FUNCTION: LEGO1 0x100a2ca0
-Result DeviceImpl::SetShadeCount(unsigned long shadeCount)
+Result DeviceImpl::SetShadeCount(unsigned int shadeCount)
 {
 	return ResultVal(m_data->SetShades(shadeCount));
 }

--- a/LEGO1/tgl/d3drm/impl.h
+++ b/LEGO1/tgl/d3drm/impl.h
@@ -64,10 +64,10 @@ public:
 	View* CreateView(
 		const Device*,
 		const Camera*,
-		unsigned long x,
-		unsigned long y,
-		unsigned long width,
-		unsigned long height
+		unsigned int x,
+		unsigned int y,
+		unsigned int width,
+		unsigned int height
 	) override;
 	Camera* CreateCamera() override;
 	Light* CreateLight(LightType, float r, float g, float b) override;
@@ -86,10 +86,10 @@ public:
 	) override;
 	Texture* CreateTexture() override;
 
-	Result SetTextureDefaultShadeCount(unsigned long) override;
+	Result SetTextureDefaultShadeCount(unsigned int) override;
 
 	// vtable+0x30
-	Result SetTextureDefaultColorCount(unsigned long) override;
+	Result SetTextureDefaultColorCount(unsigned int) override;
 
 	HRESULT CreateTextureFromSurface(LPDIRECTDRAWSURFACE pSurface, LPDIRECT3DRMTEXTURE2* pTexture2)
 	{
@@ -110,10 +110,10 @@ public:
 	inline Result CreateView(
 		const DeviceImpl& rDevice,
 		const CameraImpl& rCamera,
-		unsigned long x,
-		unsigned long y,
-		unsigned long width,
-		unsigned long height,
+		unsigned int x,
+		unsigned int y,
+		unsigned int width,
+		unsigned int height,
 		ViewImpl& rView
 	);
 	inline Result CreateMeshBuilder(MeshBuilderImpl& rMesh);
@@ -170,13 +170,13 @@ public:
 	void* ImplementationDataPtr() override;
 
 	// vtable+0x08
-	unsigned long GetWidth() override;
-	unsigned long GetHeight() override;
+	unsigned int GetWidth() override;
+	unsigned int GetHeight() override;
 
 	// vtable+0x10
 	Result SetColorModel(ColorModel) override;
 	Result SetShadingModel(ShadingModel) override;
-	Result SetShadeCount(unsigned long) override;
+	Result SetShadeCount(unsigned int) override;
 	Result SetDither(int) override;
 
 	// vtable+0x20
@@ -243,14 +243,14 @@ public:
 	Result GetBackgroundColor(float* r, float* g, float* b) override;
 	Result Clear() override;
 	Result Render(const Group*) override;
-	Result ForceUpdate(unsigned long x, unsigned long y, unsigned long width, unsigned long height) override;
+	Result ForceUpdate(unsigned int x, unsigned int y, unsigned int width, unsigned int height) override;
 
 	// vtable+0x30
 	Result TransformWorldToScreen(const float world[3], float screen[4]) override;
 	Result TransformScreenToWorld(const float screen[4], float world[3]) override;
 	Result Pick(
-		unsigned long x,
-		unsigned long y,
+		unsigned int x,
+		unsigned int y,
 		const Group** ppGroupsToPickFrom,
 		int groupsToPickFromCount,
 		const Group**& rppPickedGroups,
@@ -274,8 +274,8 @@ public:
 	Result SetCamera(const CameraImpl& rCamera);
 	Result Render(const GroupImpl& rScene);
 	Result Pick(
-		unsigned long x,
-		unsigned long y,
+		unsigned int x,
+		unsigned int y,
 		const GroupImpl** ppGroupsToPickFrom,
 		int groupsToPickFromCount,
 		const Group**& rppPickedGroups,
@@ -533,13 +533,13 @@ public:
 
 	// vtable+0x08
 	Mesh* CreateMesh(
-		unsigned long faceCount,
-		unsigned long vertexCount,
+		unsigned int faceCount,
+		unsigned int vertexCount,
 		float (*pPositions)[3],
 		float (*pNormals)[3],
 		float (*pTextureCoordinates)[2],
-		unsigned long (*pFaceIndices)[3],
-		unsigned long (*pTextureIndices)[3],
+		unsigned int (*pFaceIndices)[3],
+		unsigned int (*pTextureIndices)[3],
 		ShadingModel shadingModel
 	) override;
 	Result GetBoundingBox(float min[3], float max[3]) const override;
@@ -562,13 +562,13 @@ public:
 private:
 	inline Result CreateMeshImpl(
 		MeshImpl* pMeshImpl,
-		unsigned long faceCount,
-		unsigned long vertexCount,
+		unsigned int faceCount,
+		unsigned int vertexCount,
 		float (*pPositions)[3],
 		float (*pNormals)[3],
 		float (*pTextureCoordinates)[2],
-		unsigned long (*pFaceIndices)[3],
-		unsigned long (*pTextureIndices)[3],
+		unsigned int (*pFaceIndices)[3],
+		unsigned int (*pTextureIndices)[3],
 		ShadingModel shadingModel
 	);
 

--- a/LEGO1/tgl/d3drm/meshbuilder.cpp
+++ b/LEGO1/tgl/d3drm/meshbuilder.cpp
@@ -16,13 +16,13 @@ void* MeshBuilderImpl::ImplementationDataPtr()
 
 // FUNCTION: LEGO1 0x100a3840
 Mesh* MeshBuilderImpl::CreateMesh(
-	unsigned long faceCount,
-	unsigned long vertexCount,
+	unsigned int faceCount,
+	unsigned int vertexCount,
 	float (*pPositions)[3],
 	float (*pNormals)[3],
 	float (*pTextureCoordinates)[2],
-	unsigned long (*pFaceIndices)[3],
-	unsigned long (*pTextureIndices)[3],
+	unsigned int (*pFaceIndices)[3],
+	unsigned int (*pTextureIndices)[3],
 	ShadingModel shadingModel
 )
 {
@@ -57,18 +57,18 @@ inline Result MeshSetTextureMappingMode(MeshImpl::MeshData* pMesh, TextureMappin
 
 inline Result CreateMesh(
 	IDirect3DRMMesh* pD3DRM,
-	unsigned long faceCount,
-	unsigned long vertexCount,
+	unsigned int faceCount,
+	unsigned int vertexCount,
 	float (*pPositions)[3],
 	float (*pNormals)[3],
 	float (*pTextureCoordinates)[2],
-	unsigned long (*pFaceIndices)[3],
-	unsigned long (*pTextureIndices)[3],
+	unsigned int (*pFaceIndices)[3],
+	unsigned int (*pTextureIndices)[3],
 	ShadingModel shadingModel,
 	MeshImpl::MeshDataType& rpMesh
 )
 {
-	unsigned long* faceIndices = (unsigned long*) pFaceIndices;
+	unsigned int* faceIndices = (unsigned int*) pFaceIndices;
 	D3DRMGROUPINDEX groupIndex = 0;
 	int count = faceCount * 3;
 	int index = 0;
@@ -83,7 +83,7 @@ inline Result CreateMesh(
 
 	for (int i = 0; i < count; i++) {
 		if ((*((unsigned short*) &faceIndices[i] + 1) >> 0x0f) & 0x01) {
-			unsigned long j = *(unsigned short*) &faceIndices[i];
+			unsigned int j = *(unsigned short*) &faceIndices[i];
 			vertices[index].position.x = pPositions[j][0];
 			vertices[index].position.y = pPositions[j][1];
 			vertices[index].position.z = pPositions[j][2];
@@ -93,7 +93,7 @@ inline Result CreateMesh(
 			vertices[index].normal.z = pNormals[j][2];
 
 			if (pTextureIndices != NULL && pTextureCoordinates != NULL) {
-				j = ((unsigned long*) pTextureIndices)[i];
+				j = ((unsigned int*) pTextureIndices)[i];
 				vertices[index].tu = pTextureCoordinates[j][0];
 				vertices[index].tv = pTextureCoordinates[j][1];
 			}
@@ -137,13 +137,13 @@ inline Result CreateMesh(
 
 inline Result MeshBuilderImpl::CreateMeshImpl(
 	MeshImpl* pMeshImpl,
-	unsigned long faceCount,
-	unsigned long vertexCount,
+	unsigned int faceCount,
+	unsigned int vertexCount,
 	float (*pPositions)[3],
 	float (*pNormals)[3],
 	float (*pTextureCoordinates)[2],
-	unsigned long (*pFaceIndices)[3],
-	unsigned long (*pTextureIndices)[3],
+	unsigned int (*pFaceIndices)[3],
+	unsigned int (*pTextureIndices)[3],
 	ShadingModel shadingModel
 )
 {

--- a/LEGO1/tgl/d3drm/renderer.cpp
+++ b/LEGO1/tgl/d3drm/renderer.cpp
@@ -130,10 +130,10 @@ inline Result RendererCreateView(
 	IDirect3DRM2* pRenderer,
 	const IDirect3DRMDevice2* pDevice,
 	const IDirect3DRMFrame2* pCamera,
-	unsigned long x,
-	unsigned long y,
-	unsigned long width,
-	unsigned long height,
+	unsigned int x,
+	unsigned int y,
+	unsigned int width,
+	unsigned int height,
 	IDirect3DRMViewport*& rpView
 )
 {
@@ -162,10 +162,10 @@ inline Result RendererCreateView(
 inline Result RendererImpl::CreateView(
 	const DeviceImpl& rDevice,
 	const CameraImpl& rCamera,
-	unsigned long x,
-	unsigned long y,
-	unsigned long width,
-	unsigned long height,
+	unsigned int x,
+	unsigned int y,
+	unsigned int width,
+	unsigned int height,
 	ViewImpl& rView
 )
 {
@@ -191,10 +191,10 @@ inline Result RendererImpl::CreateView(
 View* RendererImpl::CreateView(
 	const Device* pDevice,
 	const Camera* pCamera,
-	unsigned long x,
-	unsigned long y,
-	unsigned long width,
-	unsigned long height
+	unsigned int x,
+	unsigned int y,
+	unsigned int width,
+	unsigned int height
 )
 {
 	assert(m_data);
@@ -512,13 +512,13 @@ Texture* RendererImpl::CreateTexture()
 }
 
 // FUNCTION: LEGO1 0x100a2270
-Result RendererImpl::SetTextureDefaultShadeCount(unsigned long shadeCount)
+Result RendererImpl::SetTextureDefaultShadeCount(unsigned int shadeCount)
 {
 	return ResultVal(m_data->SetDefaultTextureShades(shadeCount));
 }
 
 // FUNCTION: LEGO1 0x100a2290
-Result RendererImpl::SetTextureDefaultColorCount(unsigned long colorCount)
+Result RendererImpl::SetTextureDefaultColorCount(unsigned int colorCount)
 {
 	return ResultVal(m_data->SetDefaultTextureColors(colorCount));
 }

--- a/LEGO1/tgl/d3drm/view.cpp
+++ b/LEGO1/tgl/d3drm/view.cpp
@@ -475,10 +475,10 @@ Result ViewImpl::Render(const Group* pGroup)
 // FUNCTION: BETA10 0x1016edd0
 inline Result ViewForceUpdate(
 	IDirect3DRMViewport* pViewport,
-	unsigned long x,
-	unsigned long y,
-	unsigned long width,
-	unsigned long height
+	unsigned int x,
+	unsigned int y,
+	unsigned int width,
+	unsigned int height
 )
 {
 	return ResultVal(pViewport->ForceUpdate(x, y, x + width - 1, y + height - 1));
@@ -486,7 +486,7 @@ inline Result ViewForceUpdate(
 
 // FUNCTION: LEGO1 0x100a3080
 // FUNCTION: BETA10 0x1016ed60
-Result ViewImpl::ForceUpdate(unsigned long x, unsigned long y, unsigned long width, unsigned long height)
+Result ViewImpl::ForceUpdate(unsigned int x, unsigned int y, unsigned int width, unsigned int height)
 {
 	assert(m_data);
 
@@ -495,8 +495,8 @@ Result ViewImpl::ForceUpdate(unsigned long x, unsigned long y, unsigned long wid
 
 // FUNCTION: BETA10 0x101710f0
 inline Result ViewImpl::Pick(
-	unsigned long x,
-	unsigned long y,
+	unsigned int x,
+	unsigned int y,
 	const GroupImpl** ppGroupsToPickFrom,
 	int groupsToPickFromCount,
 	const Group**& rppPickedGroups,
@@ -519,8 +519,8 @@ inline Result ViewImpl::Pick(
 // FUNCTION: LEGO1 0x100a30c0
 // FUNCTION: BETA10 0x1016ee10
 Result ViewImpl::Pick(
-	unsigned long x,
-	unsigned long y,
+	unsigned int x,
+	unsigned int y,
 	const Group** ppGroupsToPickFrom,
 	int groupsToPickFromCount,
 	const Group**& rppPickedGroups,

--- a/LEGO1/tgl/tgl.h
+++ b/LEGO1/tgl/tgl.h
@@ -140,10 +140,10 @@ public:
 	virtual View* CreateView(
 		const Device*,
 		const Camera*,
-		unsigned long x,
-		unsigned long y,
-		unsigned long width,
-		unsigned long height
+		unsigned int x,
+		unsigned int y,
+		unsigned int width,
+		unsigned int height
 	) = 0;
 	virtual Camera* CreateCamera() = 0;
 	virtual Light* CreateLight(LightType, float r, float g, float b) = 0;
@@ -161,10 +161,10 @@ public:
 		const PaletteEntry* pEntries
 	) = 0;
 	virtual Texture* CreateTexture() = 0;
-	virtual Result SetTextureDefaultShadeCount(unsigned long) = 0;
+	virtual Result SetTextureDefaultShadeCount(unsigned int) = 0;
 
 	// vtable+0x30
-	virtual Result SetTextureDefaultColorCount(unsigned long) = 0;
+	virtual Result SetTextureDefaultColorCount(unsigned int) = 0;
 
 	// SYNTHETIC: BETA10 0x10169ae0
 	// Tgl::Renderer::Renderer
@@ -185,13 +185,13 @@ Renderer* CreateRenderer();
 class Device : public Object {
 public:
 	// vtable+0x08
-	virtual unsigned long GetWidth() = 0;
-	virtual unsigned long GetHeight() = 0;
+	virtual unsigned int GetWidth() = 0;
+	virtual unsigned int GetHeight() = 0;
 
 	// vtable+0x10
 	virtual Result SetColorModel(ColorModel) = 0;
 	virtual Result SetShadingModel(ShadingModel) = 0;
-	virtual Result SetShadeCount(unsigned long) = 0;
+	virtual Result SetShadeCount(unsigned int) = 0;
 	virtual Result SetDither(int) = 0;
 
 	// vtable+0x20
@@ -228,7 +228,7 @@ public:
 	virtual Result GetBackgroundColor(float* r, float* g, float* b) = 0;
 	virtual Result Clear() = 0;
 	virtual Result Render(const Group*) = 0;
-	virtual Result ForceUpdate(unsigned long x, unsigned long y, unsigned long width, unsigned long height) = 0;
+	virtual Result ForceUpdate(unsigned int x, unsigned int y, unsigned int width, unsigned int height) = 0;
 
 	// vtable+0x30
 	virtual Result TransformWorldToScreen(const float world[3], float screen[4]) = 0;
@@ -257,8 +257,8 @@ public:
 	//      output parameter
 	//      size of rppPickedGroups
 	virtual Result Pick(
-		unsigned long x,
-		unsigned long y,
+		unsigned int x,
+		unsigned int y,
 		const Group** ppGroupsToPickFrom,
 		int groupsToPickFromCount,
 		const Group**& rppPickedGroups,
@@ -382,13 +382,13 @@ public:
 class MeshBuilder : public Object {
 public:
 	virtual Mesh* CreateMesh(
-		unsigned long faceCount,
-		unsigned long vertexCount,
+		unsigned int faceCount,
+		unsigned int vertexCount,
 		float (*pPositions)[3],
 		float (*pNormals)[3],
 		float (*pTextureCoordinates)[2],
-		unsigned long (*pFaceIndices)[3],
-		unsigned long (*pTextureIndices)[3],
+		unsigned int (*pFaceIndices)[3],
+		unsigned int (*pTextureIndices)[3],
 		ShadingModel shadingModel
 	) = 0;
 	virtual Result GetBoundingBox(float min[3], float max[3]) const = 0;

--- a/LEGO1/viewmanager/viewmanager.cpp
+++ b/LEGO1/viewmanager/viewmanager.cpp
@@ -486,7 +486,7 @@ float ViewManager::ProjectedSize(const BoundingSphere& p_bounding_sphere)
 }
 
 // FUNCTION: LEGO1 0x100a6e00
-ViewROI* ViewManager::Pick(Tgl::View* p_view, unsigned long x, unsigned long y)
+ViewROI* ViewManager::Pick(Tgl::View* p_view, unsigned int x, unsigned int y)
 {
 	LPDIRECT3DRMPICKEDARRAY picked = NULL;
 	ViewROI* result = NULL;

--- a/LEGO1/viewmanager/viewmanager.h
+++ b/LEGO1/viewmanager/viewmanager.h
@@ -33,7 +33,7 @@ public:
 	void RemoveROIDetailFromScene(ViewROI* p_roi);
 	void SetPOVSource(const OrientableROI* point_of_view);
 	float ProjectedSize(const BoundingSphere& p_bounding_sphere);
-	ViewROI* Pick(Tgl::View* p_view, unsigned long x, unsigned long y);
+	ViewROI* Pick(Tgl::View* p_view, unsigned int x, unsigned int y);
 	void SetResolution(int width, int height);
 	void SetFrustrum(float fov, float front, float back);
 	inline void ManageVisibilityAndDetailRecursively(ViewROI* p_roi, int p_und);

--- a/miniwin/miniwin/include/miniwin.h
+++ b/miniwin/miniwin/include/miniwin.h
@@ -66,7 +66,7 @@ typedef DWORD* LPDWORD;
 typedef int BOOL, WINBOOL, INT;
 typedef unsigned int UINT;
 typedef unsigned short WORD;
-typedef long* LPLONG;
+typedef int* LPLONG;
 typedef void* LPVOID;
 typedef char* LPSTR;
 typedef const char* LPCSTR;
@@ -75,7 +75,7 @@ typedef HANDLE HICON, HFONT;
 typedef struct HINSTANCE__* HINSTANCE;
 typedef SDL_Window *HMENU, *HWND;
 typedef HANDLE HMODULE, HDC, HPALETTE, HFILE, HCURSOR;
-typedef LONG LSTATUS, HKEY, REGSAM;
+typedef int LSTATUS, HKEY, REGSAM;
 
 // --- Structs ---
 struct tagPOINT {
@@ -218,14 +218,14 @@ inline HFONT CreateFont(
 	int,
 	int,
 	int,
-	unsigned long,
-	unsigned long,
-	unsigned long,
-	unsigned long,
-	unsigned long,
-	unsigned long,
-	unsigned long,
-	unsigned long,
+	unsigned int,
+	unsigned int,
+	unsigned int,
+	unsigned int,
+	unsigned int,
+	unsigned int,
+	unsigned int,
+	unsigned int,
 	LPCSTR
 )
 {

--- a/miniwin/miniwin/include/miniwin_d3drm.h
+++ b/miniwin/miniwin/include/miniwin_d3drm.h
@@ -13,7 +13,7 @@
 // --- Typedefs ---
 typedef float D3DVAL;
 typedef void* LPD3DRM_APPDATA;
-typedef unsigned long D3DRMGROUPINDEX;
+typedef unsigned int D3DRMGROUPINDEX;
 typedef DWORD D3DCOLOR, *LPD3DCOLOR;
 typedef float D3DVALUE, *LPD3DVALUE;
 
@@ -306,11 +306,11 @@ struct IDirect3DRMWinDevice : virtual public IDirect3DRMObject {
 };
 
 struct IDirect3DRMDevice : virtual public IDirect3DRMObject {
-	virtual unsigned long GetWidth() = 0;
-	virtual unsigned long GetHeight() = 0;
+	virtual unsigned int GetWidth() = 0;
+	virtual unsigned int GetHeight() = 0;
 	virtual HRESULT SetBufferCount(int count) = 0;
 	virtual HRESULT GetBufferCount() = 0;
-	virtual HRESULT SetShades(unsigned long shadeCount) = 0;
+	virtual HRESULT SetShades(unsigned int shadeCount) = 0;
 	virtual HRESULT GetShades() = 0;
 	virtual HRESULT SetQuality(D3DRMRENDERQUALITY quality) = 0;
 	virtual D3DRMRENDERQUALITY GetQuality() = 0;

--- a/miniwin/miniwin/src/miniwin_d3drm.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drm.cpp
@@ -279,11 +279,11 @@ struct Direct3DRMDevice2Impl : public Direct3DRMObjectBase<IDirect3DRMDevice2> {
 		*ppObject = static_cast<void*>(new Direct3DRMDevice2Impl);
 		return DD_OK;
 	}
-	unsigned long GetWidth() override { return 640; }
-	unsigned long GetHeight() override { return 480; }
+	unsigned int GetWidth() override { return 640; }
+	unsigned int GetHeight() override { return 480; }
 	HRESULT SetBufferCount(int count) override { return DD_OK; }
 	HRESULT GetBufferCount() override { return DD_OK; }
-	HRESULT SetShades(unsigned long shadeCount) override { return DD_OK; }
+	HRESULT SetShades(unsigned int shadeCount) override { return DD_OK; }
 	HRESULT GetShades() override { return DD_OK; }
 	HRESULT SetQuality(D3DRMRENDERQUALITY quality) override { return DD_OK; }
 	D3DRMRENDERQUALITY GetQuality() override { return D3DRMRENDERQUALITY::GOURAUD; }


### PR DESCRIPTION
Fixes #118

This gets the game working on 64bit Linux. I simply replaced all instances of `long` with `int` except for the two places where we get the video size from libsmacker which uses `long`.

This should only have a "negative" effect when targeting 16bit systems, which isn't easy in the first place. If that becomes relevant then probably you should go over the src and change to more sane types like `std::uint32_t` where needed..