### PR TITLE
Use SDL_EVENT_QUIT to detect if the window was closed

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -416,15 +416,15 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 			);
 		}
 		break;
+	case SDL_EVENT_QUIT:
+		return SDL_APP_SUCCESS;
+		break;
 	}
 
 	if (event->user.type == g_legoSdlEvents.m_windowsMessage) {
 		switch (event->user.code) {
 		case WM_ISLE_SETCURSOR:
 			g_isle->SetupCursor((Cursor) (uintptr_t) event->user.data1);
-			break;
-		case WM_QUIT:
-			return SDL_APP_SUCCESS;
 			break;
 		case WM_TIMER:
 			if (InputManager()) {

--- a/LEGO1/lego/legoomni/include/legomain.h
+++ b/LEGO1/lego/legoomni/include/legomain.h
@@ -8,6 +8,7 @@
 #include "mxomni.h"
 
 #include <SDL3/SDL_events.h>
+#include <SDL3/SDL_timer.h>
 
 class Isle;
 class LegoAnimationManager;
@@ -192,11 +193,13 @@ public:
 
 	void CloseMainWindow()
 	{
+		SDL_QuitEvent quit;
+		quit.type = SDL_EVENT_QUIT;
+		quit.timestamp = SDL_GetTicksNS();
+
 		SDL_Event event;
-		event.user.type = g_legoSdlEvents.m_windowsMessage;
-		event.user.code = WM_QUIT;
-		event.user.data1 = NULL;
-		event.user.data2 = NULL;
+		event.quit = quit;
+
 		SDL_PushEvent(&event);
 	}
 


### PR DESCRIPTION
I hope this makes sense. If you close the window, SDL should give you an SDL_EVENT_QUIT event. I think this looks cleaner. In my testing on Linux this worked and I had miniwin enabled.