### PR TITLE
Remove `dynamic_cast` to `LegoLocomotionAnimPresenter`

### DIFF
--- a/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legopathboundary.cpp
@@ -356,14 +356,7 @@ MxU32 LegoPathBoundary::FUN_10057fe0(LegoAnimPresenter* p_presenter)
 		return 0;
 	}
 
-	// TODO: This only seems to match if the type is not the same as the type of the
-	// key value of the set. Figure out which type the set (or parameter) actually uses.
-	// Also see call to .find in LegoPathController::FUN_10046050
-	if (auto* locomotionPresenter = dynamic_cast<LegoLocomotionAnimPresenter*>(p_presenter)) {
-		m_presenters.insert(locomotionPresenter);
-		return 1;
-	}
-	SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Invalid locomotion");
+	m_presenters.insert(p_presenter);
 	return 0;
 }
 
@@ -372,17 +365,8 @@ MxU32 LegoPathBoundary::FUN_10057fe0(LegoAnimPresenter* p_presenter)
 MxU32 LegoPathBoundary::FUN_100586e0(LegoAnimPresenter* p_presenter)
 {
 	if (p_presenter != NULL) {
-		// TODO: This only seems to match if the type is not the same as the type of the
-		// key value of the set. Figure out which type the set (or parameter) actually uses.
-		// Also see call to .find in LegoPathController::FUN_10046050
-		auto* locomotionPresenter = dynamic_cast<LegoLocomotionAnimPresenter*>(p_presenter);
-		if (!locomotionPresenter) {
-			SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Invalid locomotion");
-			return 0;
-		}
-		auto it = m_presenters.find(locomotionPresenter);
-		if (it != m_presenters.end()) {
-			m_presenters.erase(it);
+		if (m_presenters.find(p_presenter) != m_presenters.end()) {
+			m_presenters.erase(p_presenter);
 			return 1;
 		}
 	}


### PR DESCRIPTION
The underlying type of the element that the list accepts is `LegoAnimPresenter*`. In the decomp, the casts never fail (since they are `static_cast`'s). The only reason we added the casts in the decomp is because we wouldn't otherwise get the correct assembly generation. However, the behavior should remain unchanged so instead of replacing with a `dynamic_cast`, we do no cast.

The root problem is that we have trouble figuring out the type of the `m_presenters` list in the decomp. Different places in the code base imply different types based on the assembly. It might simply be the result of a refactor in the original source that hasn't been fully completed.