### PR TITLE
extract d3drm{frame,mesh} to source file, and reduce prints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ foreach(shader_src IN LISTS miniwin_shaders)
         "--dxil" "${dxil}" "--msl" "${msl}" "--spirv" "${spirv}"
       DEPENDS "${py_gencshadersource}" "${dxil}" "${msl}" "${spirv}")
   endif()
-  target_sources(miniwin PRIVATE "${shader_src}" "${shader_header}")
+  target_sources(miniwin PRIVATE "${shader_header}")
   list(APPEND shader_names "${shader_name}")
   list(APPEND shader_variables "${shader_variable}")
   list(APPEND shader_headers "${shader_header}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,9 @@ add_library(miniwin STATIC EXCLUDE_FROM_ALL
   miniwin/miniwin/src/miniwin_ddraw.cpp
   miniwin/miniwin/src/miniwin_d3drm.cpp
   miniwin/miniwin/src/miniwin_d3drmdevice.cpp
+  miniwin/miniwin/src/miniwin_d3drmframe.cpp
+  miniwin/miniwin/src/miniwin_d3drmlight.cpp
+  miniwin/miniwin/src/miniwin_d3drmmesh.cpp
   miniwin/miniwin/src/miniwin_d3drmviewport.cpp
 )
 # Force reported render mods from MiniWin

--- a/miniwin/miniwin/src/include/miniwin_d3drmframe_p.h
+++ b/miniwin/miniwin/src/include/miniwin_d3drmframe_p.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "miniwin_d3drm_p.h"
+#include "miniwin_d3drmobject_p.h"
+
+struct Direct3DRMFrameImpl : public Direct3DRMObjectBase<IDirect3DRMFrame2> {
+	Direct3DRMFrameImpl();
+	~Direct3DRMFrameImpl() override;
+	HRESULT AddChild(IDirect3DRMFrame* child) override;
+	HRESULT DeleteChild(IDirect3DRMFrame* child) override;
+	HRESULT SetSceneBackgroundRGB(float r, float g, float b) override;
+	HRESULT AddLight(IDirect3DRMLight* light) override;
+	HRESULT GetLights(IDirect3DRMLightArray** lightArray) override;
+	HRESULT AddTransform(D3DRMCOMBINETYPE combine, D3DRMMATRIX4D matrix) override;
+	HRESULT GetPosition(int index, D3DVECTOR* position) override;
+	HRESULT AddVisual(IDirect3DRMVisual* visual) override;
+	HRESULT DeleteVisual(IDirect3DRMVisual* visual) override;
+	HRESULT AddVisual(IDirect3DRMMesh* visual) override;
+	HRESULT DeleteVisual(IDirect3DRMMesh* visual) override;
+	HRESULT AddVisual(IDirect3DRMFrame* visual) override;
+	HRESULT DeleteVisual(IDirect3DRMFrame* visual) override;
+	HRESULT GetVisuals(IDirect3DRMVisualArray** visuals) override;
+	HRESULT SetTexture(IDirect3DRMTexture* texture) override;
+	HRESULT GetTexture(IDirect3DRMTexture** texture) override;
+	HRESULT SetColor(float r, float g, float b, float a) override;
+	HRESULT SetColor(D3DCOLOR) override;
+	HRESULT SetColorRGB(float r, float g, float b) override;
+	HRESULT SetMaterialMode(D3DRMMATERIALMODE mode) override;
+	HRESULT GetChildren(IDirect3DRMFrameArray** children) override;
+
+private:
+	IDirect3DRMFrameArray* m_children;
+	IDirect3DRMLightArray* m_lights;
+	IDirect3DRMVisualArray* m_visuals;
+	IDirect3DRMTexture* m_texture = nullptr;
+};

--- a/miniwin/miniwin/src/include/miniwin_d3drmlight_p.h
+++ b/miniwin/miniwin/src/include/miniwin_d3drmlight_p.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "miniwin_d3drmobject_p.h"
+
+struct Direct3DRMLightImpl : public Direct3DRMObjectBase<IDirect3DRMLight> {
+	HRESULT SetColorRGB(float r, float g, float b) override;
+};

--- a/miniwin/miniwin/src/include/miniwin_d3drmmesh_p.h
+++ b/miniwin/miniwin/src/include/miniwin_d3drmmesh_p.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "miniwin_d3drmobject_p.h"
+
+struct Direct3DRMMeshImpl : public Direct3DRMObjectBase<IDirect3DRMMesh> {
+	HRESULT Clone(int flags, GUID iid, void** object) override;
+	HRESULT GetBox(D3DRMBOX* box) override;
+	HRESULT AddGroup(int vertexCount, int faceCount, int vertexPerFace, void* faceBuffer, D3DRMGROUPINDEX* groupIndex)
+		override;
+	HRESULT GetGroup(
+		int groupIndex,
+		DWORD* vertexCount,
+		DWORD* faceCount,
+		DWORD* vertexPerFace,
+		DWORD* dataSize,
+		DWORD* data
+	) override;
+	HRESULT SetGroupColor(int groupIndex, D3DCOLOR color) override;
+	HRESULT SetGroupColorRGB(int groupIndex, float r, float g, float b) override;
+	HRESULT SetGroupMaterial(int groupIndex, IDirect3DRMMaterial* material) override;
+	HRESULT SetGroupMapping(D3DRMGROUPINDEX groupIndex, D3DRMMAPPING mapping) override;
+	HRESULT SetGroupQuality(int groupIndex, D3DRMRENDERQUALITY quality) override;
+	HRESULT SetVertices(int groupIndex, int offset, int count, D3DRMVERTEX* vertices) override;
+	HRESULT SetGroupTexture(int groupIndex, IDirect3DRMTexture* texture) override;
+	;
+	HRESULT GetGroupTexture(int groupIndex, LPDIRECT3DRMTEXTURE* texture) override;
+	D3DRMMAPPING GetGroupMapping(int groupIndex) override;
+	D3DRMRENDERQUALITY GetGroupQuality(int groupIndex) override;
+	HRESULT GetGroupColor(D3DRMGROUPINDEX index) override;
+	HRESULT GetVertices(int groupIndex, int startIndex, int count, D3DRMVERTEX* vertices) override;
+
+private:
+	IDirect3DRMTexture* m_groupTexture = nullptr;
+};

--- a/miniwin/miniwin/src/include/miniwin_p.h
+++ b/miniwin/miniwin/src/include/miniwin_p.h
@@ -4,16 +4,30 @@
 
 #define LOG_CATEGORY_MINIWIN (SDL_LOG_CATEGORY_CUSTOM)
 
-#define MINIWIN_TRACE(FUNCTION, MSG, ...)                                                                              \
+#ifdef _MSC_VER
+#define MINIWIN_PRETTY_FUNCTION __FUNCSIG__
+#else
+#define MINIWIN_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#endif
+
+#define MINIWIN_NOT_IMPLEMENTED()                                                                                      \
 	do {                                                                                                               \
-		SDL_LogTrace(LOG_CATEGORY_MINIWIN, FUNCTION);                                                                  \
-	}
+		static bool visited = false;                                                                                   \
+		if (!visited) {                                                                                                \
+			SDL_LogError(LOG_CATEGORY_MINIWIN, "%s: Not implemented", MINIWIN_PRETTY_FUNCTION);                        \
+			visited = true;                                                                                            \
+		}                                                                                                              \
+	} while (0)
 
 #define MINIWIN_ERROR(MSG)                                                                                             \
 	do {                                                                                                               \
-		SDL_LogError(LOG_CATEGORY_MINIWIN, "%s:%s", __func__, MSG);                                                    \
+		SDL_LogError(LOG_CATEGORY_MINIWIN, "%s: %s", __func__, MSG);                                                   \
 	} while (0)
 
+#define MINIWIN_TRACE(...)                                                                                             \
+	do {                                                                                                               \
+		SDL_LogTrace(LOG_CATEGORY_MINIWIN, __VA_ARGS__);                                                               \
+	} while (0)
 static SDL_Rect ConvertRect(const RECT* r)
 {
 	return {r->left, r->top, r->right - r->left, r->bottom - r->top};

--- a/miniwin/miniwin/src/miniwin_d3drmdevice.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drmdevice.cpp
@@ -2,6 +2,7 @@
 #include "miniwin_d3drm_p.h"
 #include "miniwin_d3drmobject_p.h"
 #include "miniwin_d3drmviewport_p.h"
+#include "miniwin_p.h"
 
 #include <SDL3/SDL.h>
 
@@ -36,61 +37,73 @@ DWORD Direct3DRMDevice2Impl::GetHeight()
 
 HRESULT Direct3DRMDevice2Impl::SetBufferCount(int count)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 HRESULT Direct3DRMDevice2Impl::GetBufferCount()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 HRESULT Direct3DRMDevice2Impl::SetShades(DWORD shadeCount)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 HRESULT Direct3DRMDevice2Impl::GetShades()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 HRESULT Direct3DRMDevice2Impl::SetQuality(D3DRMRENDERQUALITY quality)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 D3DRMRENDERQUALITY Direct3DRMDevice2Impl::GetQuality()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return D3DRMRENDERQUALITY::GOURAUD;
 }
 
 HRESULT Direct3DRMDevice2Impl::SetDither(int dither)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 HRESULT Direct3DRMDevice2Impl::GetDither()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 HRESULT Direct3DRMDevice2Impl::SetTextureQuality(D3DRMTEXTUREQUALITY quality)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 D3DRMTEXTUREQUALITY Direct3DRMDevice2Impl::GetTextureQuality()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return D3DRMTEXTUREQUALITY::LINEAR;
 }
 
 HRESULT Direct3DRMDevice2Impl::SetRenderMode(D3DRMRENDERMODE mode)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 D3DRMRENDERMODE Direct3DRMDevice2Impl::GetRenderMode()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return D3DRMRENDERMODE::BLENDEDTRANSPARENCY;
 }
 
@@ -112,6 +125,7 @@ HRESULT Direct3DRMDevice2Impl::AddViewport(IDirect3DRMViewport* viewport)
 
 HRESULT Direct3DRMDevice2Impl::GetViewports(IDirect3DRMViewportArray** ppViewportArray)
 {
+	m_viewports->AddRef();
 	*ppViewportArray = m_viewports;
 	return DD_OK;
 }

--- a/miniwin/miniwin/src/miniwin_d3drmframe.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drmframe.cpp
@@ -1,0 +1,157 @@
+#include "miniwin_d3drmframe_p.h"
+#include "miniwin_p.h"
+
+Direct3DRMFrameImpl::Direct3DRMFrameImpl()
+{
+	m_children = new Direct3DRMFrameArrayImpl;
+	m_children->AddRef();
+	m_lights = new Direct3DRMLightArrayImpl;
+	m_lights->AddRef();
+	m_visuals = new Direct3DRMVisualArrayImpl;
+	m_visuals->AddRef();
+}
+
+Direct3DRMFrameImpl::~Direct3DRMFrameImpl()
+{
+	m_children->Release();
+	m_lights->Release();
+	m_visuals->Release();
+	if (m_texture) {
+		m_texture->Release();
+	}
+}
+
+HRESULT Direct3DRMFrameImpl::AddChild(IDirect3DRMFrame* child)
+{
+	return m_children->AddElement(child);
+}
+
+HRESULT Direct3DRMFrameImpl::DeleteChild(IDirect3DRMFrame* child)
+{
+	return m_children->DeleteElement(child);
+}
+
+HRESULT Direct3DRMFrameImpl::SetSceneBackgroundRGB(float r, float g, float b)
+{
+	return DD_OK;
+}
+
+HRESULT Direct3DRMFrameImpl::AddLight(IDirect3DRMLight* light)
+{
+	return m_lights->AddElement(light);
+}
+
+HRESULT Direct3DRMFrameImpl::GetLights(IDirect3DRMLightArray** lightArray)
+{
+	*lightArray = m_lights;
+	m_lights->AddRef();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMFrameImpl::AddTransform(D3DRMCOMBINETYPE combine, D3DRMMATRIX4D matrix)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMFrameImpl::GetPosition(int index, D3DVECTOR* position)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMFrameImpl::AddVisual(IDirect3DRMVisual* visual)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return m_visuals->AddElement(visual);
+}
+
+HRESULT Direct3DRMFrameImpl::DeleteVisual(IDirect3DRMVisual* visual)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return m_visuals->DeleteElement(visual);
+}
+
+HRESULT Direct3DRMFrameImpl::AddVisual(IDirect3DRMMesh* visual)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return m_visuals->AddElement(visual);
+}
+
+HRESULT Direct3DRMFrameImpl::DeleteVisual(IDirect3DRMMesh* visual)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return m_visuals->DeleteElement(visual);
+}
+
+HRESULT Direct3DRMFrameImpl::AddVisual(IDirect3DRMFrame* visual)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return m_visuals->AddElement(visual);
+}
+
+HRESULT Direct3DRMFrameImpl::DeleteVisual(IDirect3DRMFrame* visual)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return m_visuals->DeleteElement(visual);
+}
+
+HRESULT Direct3DRMFrameImpl::GetVisuals(IDirect3DRMVisualArray** visuals)
+{
+	*visuals = m_visuals;
+	m_visuals->AddRef();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMFrameImpl::SetTexture(IDirect3DRMTexture* texture)
+{
+	if (m_texture) {
+		m_texture->Release();
+	}
+
+	m_texture = texture;
+	m_texture->AddRef();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMFrameImpl::GetTexture(IDirect3DRMTexture** texture)
+{
+	if (!m_texture) {
+		return DDERR_GENERIC;
+	}
+
+	*texture = m_texture;
+	m_texture->AddRef();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMFrameImpl::SetColor(float r, float g, float b, float a)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMFrameImpl::SetColor(D3DCOLOR)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMFrameImpl::SetColorRGB(float r, float g, float b)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMFrameImpl::SetMaterialMode(D3DRMMATERIALMODE mode)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMFrameImpl::GetChildren(IDirect3DRMFrameArray** children)
+{
+	*children = m_children;
+	m_children->AddRef();
+	return DD_OK;
+}

--- a/miniwin/miniwin/src/miniwin_d3drmlight.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drmlight.cpp
@@ -1,0 +1,8 @@
+#include "miniwin_d3drmlight_p.h"
+#include "miniwin_p.h"
+
+HRESULT Direct3DRMLightImpl::SetColorRGB(float r, float g, float b)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}

--- a/miniwin/miniwin/src/miniwin_d3drmmesh.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drmmesh.cpp
@@ -1,0 +1,122 @@
+#include "miniwin_d3drmmesh_p.h"
+#include "miniwin_p.h"
+
+HRESULT Direct3DRMMeshImpl::Clone(int flags, GUID iid, void** object)
+{
+	if (SDL_memcmp(&iid, &IID_IDirect3DRMMesh, sizeof(GUID)) == 0) {
+		*object = static_cast<IDirect3DRMMesh*>(new Direct3DRMMeshImpl);
+		return DD_OK;
+	}
+
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMMeshImpl::GetBox(D3DRMBOX* box)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMMeshImpl::AddGroup(
+	int vertexCount,
+	int faceCount,
+	int vertexPerFace,
+	void* faceBuffer,
+	D3DRMGROUPINDEX* groupIndex
+)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMMeshImpl::GetGroup(
+	int groupIndex,
+	DWORD* vertexCount,
+	DWORD* faceCount,
+	DWORD* vertexPerFace,
+	DWORD* dataSize,
+	DWORD* data
+)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMMeshImpl::SetGroupColor(int groupIndex, D3DCOLOR color)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMMeshImpl::SetGroupColorRGB(int groupIndex, float r, float g, float b)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMMeshImpl::SetGroupMaterial(int groupIndex, IDirect3DRMMaterial* material)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMMeshImpl::SetGroupMapping(D3DRMGROUPINDEX groupIndex, D3DRMMAPPING mapping)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMMeshImpl::SetGroupQuality(int groupIndex, D3DRMRENDERQUALITY quality)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMMeshImpl::SetVertices(int groupIndex, int offset, int count, D3DRMVERTEX* vertices)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMMeshImpl::SetGroupTexture(int groupIndex, IDirect3DRMTexture* texture)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	m_groupTexture = texture;
+	return DD_OK;
+}
+
+HRESULT Direct3DRMMeshImpl::GetGroupTexture(int groupIndex, LPDIRECT3DRMTEXTURE* texture)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	if (!m_groupTexture) {
+		return DDERR_GENERIC;
+	}
+
+	m_groupTexture->AddRef();
+	*texture = m_groupTexture;
+	return DD_OK;
+}
+
+D3DRMMAPPING Direct3DRMMeshImpl::GetGroupMapping(int groupIndex)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return D3DRMMAP_PERSPCORRECT;
+}
+
+D3DRMRENDERQUALITY Direct3DRMMeshImpl::GetGroupQuality(int groupIndex)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return D3DRMRENDER_GOURAUD;
+}
+
+HRESULT Direct3DRMMeshImpl::GetGroupColor(D3DRMGROUPINDEX index)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMMeshImpl::GetVertices(int groupIndex, int startIndex, int count, D3DRMVERTEX* vertices)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}

--- a/miniwin/miniwin/src/miniwin_d3drmviewport.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drmviewport.cpp
@@ -1,5 +1,6 @@
 #include "miniwin_d3drm_p.h"
 #include "miniwin_d3drmviewport_p.h"
+#include "miniwin_p.h"
 
 #include <SDL3/SDL.h>
 
@@ -180,83 +181,106 @@ HRESULT Direct3DRMViewportImpl::ForceUpdate(int x, int y, int w, int h)
 
 HRESULT Direct3DRMViewportImpl::Clear()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 HRESULT Direct3DRMViewportImpl::SetCamera(IDirect3DRMFrame* camera)
 {
+	if (m_camera) {
+		m_camera->Release();
+	}
+	if (camera) {
+		camera->AddRef();
+	}
 	m_camera = camera;
 	return DD_OK;
 }
 
 HRESULT Direct3DRMViewportImpl::GetCamera(IDirect3DRMFrame** camera)
 {
+	if (m_camera) {
+		m_camera->AddRef();
+	}
 	*camera = m_camera;
 	return DD_OK;
 }
 
 HRESULT Direct3DRMViewportImpl::SetProjection(D3DRMPROJECTIONTYPE type)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 D3DRMPROJECTIONTYPE Direct3DRMViewportImpl::GetProjection()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return D3DRMPROJECTIONTYPE::PERSPECTIVE;
 }
 
 HRESULT Direct3DRMViewportImpl::SetFront(D3DVALUE z)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 D3DVALUE Direct3DRMViewportImpl::GetFront()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return 0;
 }
 
 HRESULT Direct3DRMViewportImpl::SetBack(D3DVALUE z)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 D3DVALUE Direct3DRMViewportImpl::GetBack()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return 0;
 }
 
 HRESULT Direct3DRMViewportImpl::SetField(D3DVALUE field)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 D3DVALUE Direct3DRMViewportImpl::GetField()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return 0;
 }
 
 DWORD Direct3DRMViewportImpl::GetWidth()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return m_width;
 }
 
 DWORD Direct3DRMViewportImpl::GetHeight()
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return m_height;
 }
 
 HRESULT Direct3DRMViewportImpl::Transform(D3DRMVECTOR4D* screen, D3DVECTOR* world)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 HRESULT Direct3DRMViewportImpl::InverseTransform(D3DVECTOR* world, D3DRMVECTOR4D* screen)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
 HRESULT Direct3DRMViewportImpl::Pick(float x, float y, LPDIRECT3DRMPICKEDARRAY* pickedArray)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 

--- a/miniwin/miniwin/src/miniwin_ddraw.cpp
+++ b/miniwin/miniwin/src/miniwin_ddraw.cpp
@@ -103,19 +103,19 @@ HRESULT DirectDrawImpl::CreateSurface(
 			return DD_OK;
 		}
 		if ((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_OFFSCREENPLAIN) == DDSCAPS_OFFSCREENPLAIN) {
-			SDL_Log("DDSCAPS_OFFSCREENPLAIN"); // 2D surfaces?
+			MINIWIN_TRACE("DDSCAPS_OFFSCREENPLAIN"); // 2D surfaces?
 		}
 		if ((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_SYSTEMMEMORY) == DDSCAPS_SYSTEMMEMORY) {
-			SDL_Log("DDSCAPS_SYSTEMMEMORY"); // Software rendering?
+			MINIWIN_TRACE("DDSCAPS_SYSTEMMEMORY"); // Software rendering?
 		}
 		if ((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_TEXTURE) == DDSCAPS_TEXTURE) {
-			SDL_Log("DDSCAPS_TEXTURE"); // Texture for use in 3D
+			MINIWIN_TRACE("DDSCAPS_TEXTURE"); // Texture for use in 3D
 		}
 		if ((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_3DDEVICE) == DDSCAPS_3DDEVICE) {
-			SDL_Log("DDSCAPS_3DDEVICE"); // back buffer
+			MINIWIN_TRACE("DDSCAPS_3DDEVICE"); // back buffer
 		}
 		if ((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY) == DDSCAPS_VIDEOMEMORY) {
-			SDL_Log("DDSCAPS_VIDEOMEMORY"); // front / back buffer
+			MINIWIN_TRACE("DDSCAPS_VIDEOMEMORY"); // front / back buffer
 		}
 	}
 

--- a/miniwin/miniwin/src/miniwin_ddsurface.cpp
+++ b/miniwin/miniwin/src/miniwin_ddsurface.cpp
@@ -42,6 +42,7 @@ HRESULT DirectDrawSurfaceImpl::QueryInterface(const GUID& riid, void** ppvObject
 // IDirectDrawSurface interface
 HRESULT DirectDrawSurfaceImpl::AddAttachedSurface(LPDIRECTDRAWSURFACE lpDDSAttachedSurface)
 {
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 


### PR DESCRIPTION
After this pr, the log below printed to stderr when starting the game until the information center.
I believe this is way more readable.
Also, the "Not implemented" functions lets us know what is missing next and needs to be worked on.


```
$ /home/maarten/projects/isle-portable/cmake-build-debug/isle --debug --ini /home/maarten/projects/isle-portable/cmake-build-debug/isle.ini
Press "Keypad 0" for pausing/stepping the game
Press "Keypad ." for resuming the game
Reading configuration from "/home/maarten/projects/isle-portable/cmake-build-debug/isle.ini"
Found 68 game files in /home/maarten/games/legoisland
Found 68 game files in /home/maarten/games/legoisland
Todo: Set 32bit Z-Buffer
ERROR: virtual HRESULT DirectDrawSurfaceImpl::AddAttachedSurface(LPDIRECTDRAWSURFACE): Not implemented
ERROR: virtual HRESULT Direct3DRMDevice2Impl::SetQuality(D3DRMRENDERQUALITY): Not implemented
ERROR: virtual HRESULT Direct3DRMDevice2Impl::SetShades(DWORD): Not implemented
ERROR: virtual HRESULT Direct3DRMDevice2Impl::SetDither(int): Not implemented
ERROR: virtual HRESULT Direct3DRMViewportImpl::SetFront(D3DVALUE): Not implemented
ERROR: virtual HRESULT Direct3DRMViewportImpl::SetBack(D3DVALUE): Not implemented
ERROR: virtual HRESULT Direct3DRMViewportImpl::SetField(D3DVALUE): Not implemented
ERROR: virtual HRESULT Direct3DRMFrameImpl::AddTransform(D3DRMCOMBINETYPE, D3DRMMATRIX4D): Not implemented
ERROR: virtual HRESULT Direct3DRMDevice2Impl::SetTextureQuality(D3DRMTEXTUREQUALITY): Not implemented
ERROR: virtual HRESULT Direct3DRMDevice2Impl::SetRenderMode(D3DRMRENDERMODE): Not implemented
ERROR: virtual HRESULT Direct3DRMFrameImpl::GetPosition(int, D3DVECTOR*): Not implemented
ERROR: virtual HRESULT Direct3DRMViewportImpl::Pick(float, float, IDirect3DRMPickedArray**): Not implemented
Resolved file path to /home/maarten/bigdata/legoisland/LEGO/Scripts/Isle/JUKEBOX.SI
Resolved file path to /home/maarten/bigdata/legoisland/LEGO/Scripts/Isle/ISLE.SI
Resolved file path to /home/maarten/bigdata/legoisland/LEGO/data/WORLD.WDB
ERROR: virtual HRESULT Direct3DRMMeshImpl::AddGroup(int, int, int, void*, D3DRMGROUPINDEX*): Not implemented
ERROR: virtual HRESULT Direct3DRMMeshImpl::SetVertices(int, int, int, D3DRMVERTEX*): Not implemented
ERROR: virtual HRESULT Direct3DRMMeshImpl::SetGroupMapping(D3DRMGROUPINDEX, D3DRMMAPPING): Not implemented
ERROR: virtual HRESULT Direct3DRMMeshImpl::SetGroupQuality(int, D3DRMRENDERQUALITY): Not implemented
ERROR: virtual HRESULT Direct3DRMMeshImpl::SetGroupColorRGB(int, float, float, float): Not implemented
ERROR: virtual HRESULT Direct3DRMMeshImpl::SetGroupMaterial(int, IDirect3DRMMaterial*): Not implemented
ERROR: virtual HRESULT Direct3DRMMeshImpl::SetGroupTexture(int, IDirect3DRMTexture*): Not implemented
ERROR: virtual HRESULT Direct3DRMMeshImpl::SetGroupColor(int, D3DCOLOR): Not implemented
Resolved file path to /home/maarten/bigdata/legoisland/LEGO/Scripts/SNDANIM.SI
ERROR: virtual HRESULT Direct3DRMMeshImpl::GetBox(D3DRMBOX*): Not implemented
Resolved file path to /home/maarten/bigdata/legoisland/LEGO/Scripts/Infocntr/INFOMAIN.SI
Resolved file path to /home/maarten/bigdata/legoisland/LEGO/data/WORLD.WDB
Resolved file path to /home/maarten/bigdata/legoisland/LEGO/Scripts/INTRO.SI
ERROR: virtual HRESULT Direct3DRMViewportImpl::Clear(): Not implemented
ERROR: virtual HRESULT Direct3DRMMeshImpl::GetGroupTexture(int, IDirect3DRMTexture**): Not implemented
ERROR: virtual HRESULT Direct3DRMFrameImpl::AddVisual(IDirect3DRMFrame*): Not implemented
ERROR: virtual HRESULT Direct3DRMFrameImpl::AddVisual(IDirect3DRMMesh*): Not implemented
ERROR: virtual HRESULT Direct3DRMFrameImpl::DeleteVisual(IDirect3DRMMesh*): Not implemented
ERROR: virtual HRESULT Direct3DRMFrameImpl::DeleteVisual(IDirect3DRMFrame*): Not implemented
```

/cc @AJenbo 