### PR TITLE
d3drm: Minor cleanup and improvments

### DIFF
--- a/miniwin/miniwin/include/miniwin_d3drm.h
+++ b/miniwin/miniwin/include/miniwin_d3drm.h
@@ -195,7 +195,7 @@ struct IDirect3DRMMesh : public IDirect3DRMVisual {
 	virtual HRESULT GetGroupTexture(int groupIndex, LPDIRECT3DRMTEXTURE* texture) = 0;
 	virtual D3DRMMAPPING GetGroupMapping(int groupIndex) = 0;
 	virtual D3DRMRENDERQUALITY GetGroupQuality(int groupIndex) = 0;
-	virtual HRESULT GetGroupColor(D3DRMGROUPINDEX index) = 0;
+	virtual D3DCOLOR GetGroupColor(D3DRMGROUPINDEX index) = 0;
 	virtual HRESULT GetVertices(int groupIndex, int startIndex, int count, D3DRMVERTEX* vertices) = 0;
 };
 
@@ -308,13 +308,13 @@ struct IDirect3DRMDevice : virtual public IDirect3DRMObject {
 	virtual DWORD GetWidth() = 0;
 	virtual DWORD GetHeight() = 0;
 	virtual HRESULT SetBufferCount(int count) = 0;
-	virtual HRESULT GetBufferCount() = 0;
+	virtual DWORD GetBufferCount() = 0;
 	virtual HRESULT SetShades(DWORD shadeCount) = 0;
 	virtual HRESULT GetShades() = 0;
 	virtual HRESULT SetQuality(D3DRMRENDERQUALITY quality) = 0;
 	virtual D3DRMRENDERQUALITY GetQuality() = 0;
 	virtual HRESULT SetDither(int dither) = 0;
-	virtual HRESULT GetDither() = 0;
+	virtual BOOL GetDither() = 0;
 	virtual HRESULT SetTextureQuality(D3DRMTEXTUREQUALITY quality) = 0;
 	virtual D3DRMTEXTUREQUALITY GetTextureQuality() = 0;
 	virtual HRESULT SetRenderMode(D3DRMRENDERMODE mode) = 0;

--- a/miniwin/miniwin/src/include/miniwin_d3drmdevice_p.h
+++ b/miniwin/miniwin/src/include/miniwin_d3drmdevice_p.h
@@ -11,13 +11,13 @@ struct Direct3DRMDevice2Impl : public Direct3DRMObjectBase<IDirect3DRMDevice2> {
 	DWORD GetWidth() override;
 	DWORD GetHeight() override;
 	HRESULT SetBufferCount(int count) override;
-	HRESULT GetBufferCount() override;
+	DWORD GetBufferCount() override;
 	HRESULT SetShades(DWORD shadeCount) override;
 	HRESULT GetShades() override;
 	HRESULT SetQuality(D3DRMRENDERQUALITY quality) override;
 	D3DRMRENDERQUALITY GetQuality() override;
 	HRESULT SetDither(int dither) override;
-	HRESULT GetDither() override;
+	BOOL GetDither() override;
 	HRESULT SetTextureQuality(D3DRMTEXTUREQUALITY quality) override;
 	D3DRMTEXTUREQUALITY GetTextureQuality() override;
 	HRESULT SetRenderMode(D3DRMRENDERMODE mode) override;

--- a/miniwin/miniwin/src/include/miniwin_d3drmviewport_p.h
+++ b/miniwin/miniwin/src/include/miniwin_d3drmviewport_p.h
@@ -42,6 +42,7 @@ struct Direct3DRMViewportImpl : public Direct3DRMObjectBase<IDirect3DRMViewport>
 
 private:
 	void FreeDeviceResources();
+	int m_vertexBufferCount = 0;
 	int m_vertexCount;
 	bool m_updated = false;
 	DWORD m_width;
@@ -51,6 +52,6 @@ private:
 	SDL_GPUGraphicsPipeline* m_pipeline;
 	SDL_GPUTexture* m_transferTexture;
 	SDL_GPUTransferBuffer* m_downloadTransferBuffer;
-	SDL_GPUBuffer* m_vertexBuffer;
+	SDL_GPUBuffer* m_vertexBuffer = nullptr;
 	SDL_Surface* m_renderedImage = nullptr;
 };

--- a/miniwin/miniwin/src/include/miniwin_p.h
+++ b/miniwin/miniwin/src/include/miniwin_p.h
@@ -28,7 +28,3 @@
 	do {                                                                                                               \
 		SDL_LogTrace(LOG_CATEGORY_MINIWIN, __VA_ARGS__);                                                               \
 	} while (0)
-static SDL_Rect ConvertRect(const RECT* r)
-{
-	return {r->left, r->top, r->right - r->left, r->bottom - r->top};
-}

--- a/miniwin/miniwin/src/miniwin_d3drm.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drm.cpp
@@ -8,6 +8,7 @@
 #include "miniwin_d3drmobject_p.h"
 #include "miniwin_d3drmviewport_p.h"
 #include "miniwin_ddsurface_p.h"
+#include "miniwin_p.h"
 
 #include <SDL3/SDL.h>
 
@@ -251,7 +252,7 @@ struct Direct3DRMImpl : virtual public IDirect3DRM2 {
 		textureInfo.num_levels = 1;
 		textureInfo.usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
 		SDL_GPUTexture* transferTexture = SDL_CreateGPUTexture(device->m_device, &textureInfo);
-		if (transferTexture == NULL) {
+		if (!transferTexture) {
 			return DDERR_GENERIC;
 		}
 

--- a/miniwin/miniwin/src/miniwin_d3drmdevice.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drmdevice.cpp
@@ -41,10 +41,10 @@ HRESULT Direct3DRMDevice2Impl::SetBufferCount(int count)
 	return DD_OK;
 }
 
-HRESULT Direct3DRMDevice2Impl::GetBufferCount()
+DWORD Direct3DRMDevice2Impl::GetBufferCount()
 {
 	MINIWIN_NOT_IMPLEMENTED();
-	return DD_OK;
+	return 2;
 }
 
 HRESULT Direct3DRMDevice2Impl::SetShades(DWORD shadeCount)
@@ -77,10 +77,10 @@ HRESULT Direct3DRMDevice2Impl::SetDither(int dither)
 	return DD_OK;
 }
 
-HRESULT Direct3DRMDevice2Impl::GetDither()
+BOOL Direct3DRMDevice2Impl::GetDither()
 {
 	MINIWIN_NOT_IMPLEMENTED();
-	return DD_OK;
+	return false;
 }
 
 HRESULT Direct3DRMDevice2Impl::SetTextureQuality(D3DRMTEXTUREQUALITY quality)

--- a/miniwin/miniwin/src/miniwin_d3drmviewport.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drmviewport.cpp
@@ -30,18 +30,24 @@ Direct3DRMViewportImpl::~Direct3DRMViewportImpl()
 
 void Direct3DRMViewportImpl::Update()
 {
-	m_vertexCount = 3;
+	int newVertexCount = 3;
 
-	SDL_GPUBufferCreateInfo bufferCreateInfo = {};
-	bufferCreateInfo.usage = SDL_GPU_BUFFERUSAGE_VERTEX;
-	bufferCreateInfo.size = static_cast<Uint32>(sizeof(PositionColorVertex) * m_vertexCount);
+	if (newVertexCount > m_vertexBufferCount) {
+		if (m_vertexBuffer) {
+			SDL_ReleaseGPUBuffer(m_device, m_vertexBuffer);
+		}
+		SDL_GPUBufferCreateInfo bufferCreateInfo = {};
+		bufferCreateInfo.usage = SDL_GPU_BUFFERUSAGE_VERTEX;
+		bufferCreateInfo.size = static_cast<Uint32>(sizeof(PositionColorVertex) * newVertexCount);
+		m_vertexBuffer = SDL_CreateGPUBuffer(m_device, &bufferCreateInfo);
+		m_vertexBufferCount = newVertexCount;
+	}
 
-	m_vertexBuffer = SDL_CreateGPUBuffer(m_device, &bufferCreateInfo);
+	m_vertexCount = newVertexCount;
 
 	SDL_GPUTransferBufferCreateInfo transferCreateInfo = {};
 	transferCreateInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
 	transferCreateInfo.size = static_cast<Uint32>(sizeof(PositionColorVertex) * m_vertexCount);
-
 	SDL_GPUTransferBuffer* transferBuffer = SDL_CreateGPUTransferBuffer(m_device, &transferCreateInfo);
 
 	PositionColorVertex* transferData =
@@ -117,7 +123,7 @@ HRESULT Direct3DRMViewportImpl::Render(IDirect3DRMFrame* group)
 	SDL_DownloadFromGPUTexture(copyPass, &region, &transferInfo);
 	SDL_EndGPUCopyPass(copyPass);
 	SDL_GPUFence* fence = SDL_SubmitGPUCommandBufferAndAcquireFence(cmdbuf);
-	if (!cmdbuf || !SDL_WaitForGPUFences(m_device, true, &fence, 1)) {
+	if (!SDL_WaitForGPUFences(m_device, true, &fence, 1)) {
 		return DDERR_GENERIC;
 	}
 	SDL_ReleaseGPUFence(m_device, fence);

--- a/miniwin/miniwin/src/miniwin_ddsurface.cpp
+++ b/miniwin/miniwin/src/miniwin_ddsurface.cpp
@@ -51,6 +51,11 @@ void DirectDrawSurfaceImpl::SetAutoFlip(bool enabled)
 	m_autoFlip = enabled;
 }
 
+static SDL_Rect ConvertRect(const RECT* r)
+{
+	return {r->left, r->top, r->right - r->left, r->bottom - r->top};
+}
+
 HRESULT DirectDrawSurfaceImpl::Blt(
 	LPRECT lpDestRect,
 	LPDIRECTDRAWSURFACE lpDDSrcSurface,
@@ -242,9 +247,6 @@ HRESULT DirectDrawSurfaceImpl::SetClipper(LPDIRECTDRAWCLIPPER lpDDClipper)
 
 HRESULT DirectDrawSurfaceImpl::SetColorKey(DDColorKeyFlags dwFlags, LPDDCOLORKEY lpDDColorKey)
 {
-	if (!lpDDColorKey) {
-		return DDERR_INVALIDPARAMS;
-	}
 	if (lpDDColorKey->dwColorSpaceLowValue != lpDDColorKey->dwColorSpaceHighValue) {
 		return DDERR_GENERIC; // Not supported
 	}


### PR DESCRIPTION
Some wrong types, also it fees the vertex buffer, reuses the vertex buffer, and grows the vertex buffer depending on need.