### PR TITLE
Sky color controls

### DIFF
--- a/miniwin/miniwin/src/include/miniwin_d3drmframe_p.h
+++ b/miniwin/miniwin/src/include/miniwin_d3drmframe_p.h
@@ -28,6 +28,8 @@ struct Direct3DRMFrameImpl : public Direct3DRMObjectBase<IDirect3DRMFrame2> {
 	HRESULT SetMaterialMode(D3DRMMATERIALMODE mode) override;
 	HRESULT GetChildren(IDirect3DRMFrameArray** children) override;
 
+	D3DCOLOR m_backgroundColor = 0xFFFFFFFF;
+
 private:
 	IDirect3DRMFrameArray* m_children;
 	IDirect3DRMLightArray* m_lights;

--- a/miniwin/miniwin/src/include/miniwin_d3drmframe_p.h
+++ b/miniwin/miniwin/src/include/miniwin_d3drmframe_p.h
@@ -28,7 +28,7 @@ struct Direct3DRMFrameImpl : public Direct3DRMObjectBase<IDirect3DRMFrame2> {
 	HRESULT SetMaterialMode(D3DRMMATERIALMODE mode) override;
 	HRESULT GetChildren(IDirect3DRMFrameArray** children) override;
 
-	D3DCOLOR m_backgroundColor = 0xFFFFFFFF;
+	D3DCOLOR m_backgroundColor = 0xFF000000;
 
 private:
 	IDirect3DRMFrameArray* m_children;

--- a/miniwin/miniwin/src/include/miniwin_d3drmlight_p.h
+++ b/miniwin/miniwin/src/include/miniwin_d3drmlight_p.h
@@ -4,4 +4,7 @@
 
 struct Direct3DRMLightImpl : public Direct3DRMObjectBase<IDirect3DRMLight> {
 	HRESULT SetColorRGB(float r, float g, float b) override;
+
+private:
+	D3DCOLOR m_color = 0xFFFFFFFF;
 };

--- a/miniwin/miniwin/src/include/miniwin_d3drmviewport_p.h
+++ b/miniwin/miniwin/src/include/miniwin_d3drmviewport_p.h
@@ -5,7 +5,6 @@
 #include "miniwin_d3drmobject_p.h"
 
 #include <SDL3/SDL.h>
-#include <span>
 
 struct Direct3DRMViewportImpl : public Direct3DRMObjectBase<IDirect3DRMViewport> {
 	Direct3DRMViewportImpl(

--- a/miniwin/miniwin/src/include/miniwin_d3drmviewport_p.h
+++ b/miniwin/miniwin/src/include/miniwin_d3drmviewport_p.h
@@ -5,6 +5,7 @@
 #include "miniwin_d3drmobject_p.h"
 
 #include <SDL3/SDL.h>
+#include <span>
 
 struct Direct3DRMViewportImpl : public Direct3DRMObjectBase<IDirect3DRMViewport> {
 	Direct3DRMViewportImpl(
@@ -38,13 +39,14 @@ struct Direct3DRMViewportImpl : public Direct3DRMObjectBase<IDirect3DRMViewport>
 	HRESULT InverseTransform(D3DVECTOR* world, D3DRMVECTOR4D* screen) override;
 	HRESULT Pick(float x, float y, LPDIRECT3DRMPICKEDARRAY* pickedArray) override;
 	void CloseDevice();
-	void Update();
+	void CollectSceneData(IDirect3DRMFrame* group);
+	void PushVertices(const PositionColorVertex* vertices, size_t count);
 
 private:
 	void FreeDeviceResources();
 	int m_vertexBufferCount = 0;
 	int m_vertexCount;
-	bool m_updated = false;
+	D3DCOLOR m_backgroundColor = 0xFF000000;
 	DWORD m_width;
 	DWORD m_height;
 	IDirect3DRMFrame* m_camera = nullptr;

--- a/miniwin/miniwin/src/miniwin_d3drmdevice.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drmdevice.cpp
@@ -105,12 +105,7 @@ D3DRMRENDERMODE Direct3DRMDevice2Impl::GetRenderMode()
 
 HRESULT Direct3DRMDevice2Impl::Update()
 {
-	for (int i = 0; i < m_viewports->GetSize(); i++) {
-		IDirect3DRMViewport* viewport;
-		m_viewports->GetElement(i, &viewport);
-		static_cast<Direct3DRMViewportImpl*>(viewport)->Update();
-	}
-
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 

--- a/miniwin/miniwin/src/miniwin_d3drmframe.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drmframe.cpp
@@ -33,7 +33,8 @@ HRESULT Direct3DRMFrameImpl::DeleteChild(IDirect3DRMFrame* child)
 
 HRESULT Direct3DRMFrameImpl::SetSceneBackgroundRGB(float r, float g, float b)
 {
-	MINIWIN_NOT_IMPLEMENTED();
+	m_backgroundColor = (0xFF << 24) | (static_cast<BYTE>(r * 255.0f) << 16) | (static_cast<BYTE>(g * 255.0f) << 8) |
+						(static_cast<BYTE>(b * 255.0f));
 	return DD_OK;
 }
 

--- a/miniwin/miniwin/src/miniwin_d3drmlight.cpp
+++ b/miniwin/miniwin/src/miniwin_d3drmlight.cpp
@@ -3,6 +3,7 @@
 
 HRESULT Direct3DRMLightImpl::SetColorRGB(float r, float g, float b)
 {
-	MINIWIN_NOT_IMPLEMENTED();
+	m_color = (0xFF << 24) | (static_cast<BYTE>(r * 255.0f) << 16) | (static_cast<BYTE>(g * 255.0f) << 8) |
+			  (static_cast<BYTE>(b * 255.0f));
 	return DD_OK;
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/7420b710-a9bb-4ba5-8a52-f5a6057cd287

This implements a few of the color functions, cleans up the vertex uploading a bit and corrects the flow for how the scene is gathered.

This is enough that we get rid of the HoM effect and the sky color can now be control from the panel in the center.