### PR TITLE
miniwin: Mark ClientToScreen() as implemented

### DIFF
--- a/miniwin/miniwin/src/miniwin.cpp
+++ b/miniwin/miniwin/src/miniwin.cpp
@@ -216,7 +216,6 @@ VOID WINAPI Sleep(DWORD dwMilliseconds)
 
 BOOL ClientToScreen(HWND hWnd, LPPOINT lpPoint)
 {
-	MINIWIN_NOT_IMPLEMENTED();
 	return TRUE;
 }
 


### PR DESCRIPTION
SDL rendering works relative to the window surface and do not need translation in to screen coordinates.