### PR TITLE
Mark IDirectDrawClipper::SetHWnd() as implemented

### DIFF
--- a/miniwin/miniwin/src/miniwin_ddraw.cpp
+++ b/miniwin/miniwin/src/miniwin_ddraw.cpp
@@ -16,7 +16,6 @@ SDL_Surface* DDBackBuffer;
 
 HRESULT IDirectDrawClipper::SetHWnd(DWORD unnamedParam1, HWND hWnd)
 {
-	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 


### PR DESCRIPTION
SDL does not allow rendering outside it's window and so there is no need to limit it to the window in the first place.