### PR TITLE
Make windowed the default 

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -83,7 +83,7 @@ IsleApp::IsleApp()
 	m_cdPath = NULL;
 	m_deviceId = NULL;
 	m_savePath = NULL;
-	m_fullScreen = TRUE;
+	m_fullScreen = FALSE;
 	m_flipSurfaces = FALSE;
 	m_backBuffersInVram = TRUE;
 	m_using8bit = FALSE;


### PR DESCRIPTION
Currently the game isn't robust enough to handle launching with full screens on many devices, leading to (unexplained) crashes. See #128

Until this is addressed I think it's better to have windowed as the default.