### PR TITLE
Verbose logging and static multiply

### DIFF
--- a/miniwin/sdl3gpu/src/miniwin_d3drm.cpp
+++ b/miniwin/sdl3gpu/src/miniwin_d3drm.cpp
@@ -166,12 +166,14 @@ HRESULT Direct3DRM_SDL3GPUImpl::CreateDevice(IDirect3DRMDevice2** outDevice, DWO
 		NULL
 	);
 	if (device == NULL) {
+		SDL_LogError(LOG_CATEGORY_MINIWIN, "SDL_CreateGPUDevice failed (%s)", SDL_GetError());
 		return DDERR_GENERIC;
 	}
 	if (DDWindow == NULL) {
 		return DDERR_GENERIC;
 	}
 	if (!SDL_ClaimWindowForGPUDevice(device, DDWindow)) {
+		SDL_LogError(LOG_CATEGORY_MINIWIN, "SDL_ClaimWindowForGPUDevice failed (%s)", SDL_GetError());
 		return DDERR_GENERIC;
 	}
 

--- a/miniwin/sdl3gpu/src/miniwin_d3drmviewport.cpp
+++ b/miniwin/sdl3gpu/src/miniwin_d3drmviewport.cpp
@@ -30,7 +30,7 @@ Direct3DRMViewport_SDL3GPUImpl::~Direct3DRMViewport_SDL3GPUImpl()
 	FreeDeviceResources();
 }
 
-void D3DRMMatrixMultiply(D3DRMMATRIX4D out, const D3DRMMATRIX4D a, const D3DRMMATRIX4D b)
+static void D3DRMMatrixMultiply(D3DRMMATRIX4D out, const D3DRMMATRIX4D a, const D3DRMMATRIX4D b)
 {
 	for (int i = 0; i < 4; ++i) {
 		for (int j = 0; j < 4; ++j) {


### PR DESCRIPTION
The extra logging allowed us to diagnose why SDL3GPU does not work on the iphone simulator.
It fails with the error:
```
ERROR: SDL_CreateGPUDevice failed (Device does not meet the hardware requirements for SDL_GPU Metal)
```
This is because the simulator is equivalent to an A8 device which is one generation below the min spec for SDL3_gpu.

The other patch gives `D3DRMMatrixMultiply` static visiblity. I was getting duplicate symbols after copying the sdl3gpu backend.