### PR TITLE
Implement GetGroupMaterial()

### DIFF
--- a/miniwin/include/miniwin_d3drm.h
+++ b/miniwin/include/miniwin_d3drm.h
@@ -195,6 +195,7 @@ struct IDirect3DRMMesh : public IDirect3DRMVisual {
 	virtual HRESULT SetVertices(DWORD groupIndex, int offset, int count, D3DRMVERTEX* vertices) = 0;
 	virtual HRESULT GetGroupTexture(DWORD groupIndex, LPDIRECT3DRMTEXTURE* texture) = 0;
 	virtual D3DRMMAPPING GetGroupMapping(DWORD groupIndex) = 0;
+	virtual HRESULT GetGroupMaterial(DWORD groupIndex, LPDIRECT3DRMMATERIAL* material) = 0;
 	virtual D3DRMRENDERQUALITY GetGroupQuality(DWORD groupIndex) = 0;
 	virtual D3DCOLOR GetGroupColor(D3DRMGROUPINDEX index) = 0;
 	virtual HRESULT GetVertices(DWORD groupIndex, int startIndex, int count, D3DRMVERTEX* vertices) = 0;

--- a/miniwin/sdl3gpu/include/miniwin_d3drmmesh_sdl3gpu.h
+++ b/miniwin/sdl3gpu/include/miniwin_d3drmmesh_sdl3gpu.h
@@ -83,6 +83,7 @@ struct Direct3DRMMesh_SDL3GPUImpl : public Direct3DRMObjectBase_SDL3GPUImpl<IDir
 	HRESULT SetGroupMaterial(DWORD groupIndex, IDirect3DRMMaterial* material) override;
 	HRESULT SetGroupTexture(DWORD groupIndex, IDirect3DRMTexture* texture) override;
 	HRESULT GetGroupTexture(DWORD groupIndex, LPDIRECT3DRMTEXTURE* texture) override;
+	HRESULT GetGroupMaterial(DWORD groupIndex, LPDIRECT3DRMMATERIAL* material) override;
 	HRESULT SetGroupMapping(D3DRMGROUPINDEX groupIndex, D3DRMMAPPING mapping) override;
 	D3DRMMAPPING GetGroupMapping(DWORD groupIndex) override;
 	HRESULT SetGroupQuality(DWORD groupIndex, D3DRMRENDERQUALITY quality) override;

--- a/miniwin/sdl3gpu/src/miniwin_d3drmmesh.cpp
+++ b/miniwin/sdl3gpu/src/miniwin_d3drmmesh.cpp
@@ -158,6 +158,22 @@ HRESULT Direct3DRMMesh_SDL3GPUImpl::SetGroupTexture(DWORD groupIndex, IDirect3DR
 	return DD_OK;
 }
 
+HRESULT Direct3DRMMesh_SDL3GPUImpl::GetGroupMaterial(DWORD groupIndex, LPDIRECT3DRMMATERIAL* material)
+{
+	if (groupIndex >= m_groups.size()) {
+		return DDERR_GENERIC;
+	}
+
+	auto& group = m_groups[groupIndex];
+	if (!group.material) {
+		return DDERR_GENERIC;
+	}
+
+	group.material->AddRef();
+	*material = group.material;
+	return DD_OK;
+}
+
 HRESULT Direct3DRMMesh_SDL3GPUImpl::GetGroupTexture(DWORD groupIndex, LPDIRECT3DRMTEXTURE* texture)
 {
 	if (groupIndex >= m_groups.size()) {


### PR DESCRIPTION
This isn't used anywhere in the game but it will be needed internally for rendering the specular effect on materials.