### PR TITLE
Fix crash in `LegoAnimationManager::FUN_100609f0`

### DIFF
--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -1081,7 +1081,9 @@ MxResult LegoAnimationManager::FUN_100609f0(MxU32 p_objectId, MxMatrix* p_matrix
 	char buf[256];
 	sprintf(buf, "%s:%d", g_strANIMMAN_ID, info->m_index);
 
-	action.SetAtomId(*Lego()->GetWorldAtom(m_worldId));
+	if (m_worldId != LegoOmni::e_undefined) {
+	    action.SetAtomId(*Lego()->GetWorldAtom(m_worldId));
+	}
 	action.SetObjectId(p_objectId);
 	action.SetUnknown24(-1);
 	action.AppendExtra(strlen(buf) + 1, buf);


### PR DESCRIPTION
I've come across an issue where the game will crash when you ~~try to play two animations at once~~ click on an actor/object from too far away. Without this "fix", the game crashes. Making a PR here since I don't think this happens on win32, however I can't test because I'm on Linux and Wine doesn't really like Lego Island.

Hopefully this is the "correct" fix, I haven't had crashing after applying the fix.