### PR TITLE
Fix `DirectDrawPalette_SDL3GPUImpl::SetEntries`

### DIFF
--- a/miniwin/sdl3gpu/src/miniwin_ddpalette.cpp
+++ b/miniwin/sdl3gpu/src/miniwin_ddpalette.cpp
@@ -39,10 +39,10 @@ HRESULT DirectDrawPalette_SDL3GPUImpl::SetEntries(
 {
 	SDL_Color colors[256];
 	for (DWORD i = 0; i < dwCount; i++) {
-		colors[i].r = lpEntries[dwStartingEntry + i].peRed;
-		colors[i].g = lpEntries[dwStartingEntry + i].peGreen;
-		colors[i].b = lpEntries[dwStartingEntry + i].peBlue;
-		colors[i].a = SDL_ALPHA_OPAQUE;
+		colors[i + dwStartingEntry].r = lpEntries[i].peRed;
+		colors[i + dwStartingEntry].g = lpEntries[i].peGreen;
+		colors[i + dwStartingEntry].b = lpEntries[i].peBlue;
+		colors[i + dwStartingEntry].a = SDL_ALPHA_OPAQUE;
 	}
 
 	SDL_SetPaletteColors(m_palette, colors, dwStartingEntry, dwCount);


### PR DESCRIPTION
`dwStartingEntry` is the offset into the destination colors array, not the source array.

With the current implementation, we are crashing here: https://github.com/isledecomp/isle-portable/blob/master/LEGO1/omni/src/video/mxpalette.cpp#L247

Also compare the implementation in Wine: https://gitlab.winehq.org/mxkrsv/wine/-/blob/wine-1.7.25/dlls/wined3d/palette.c#L92