### PR TITLE
Add lighting for software renderer

### DIFF
--- a/miniwin/src/internal/d3drmrenderer_software.h
+++ b/miniwin/src/internal/d3drmrenderer_software.h
@@ -30,7 +30,8 @@ private:
 		const PositionColorVertex& v2
 	);
 	void ProjectVertex(const PositionColorVertex&, float&, float&, float&) const;
-	void BlendPixel(Uint8* pixelAddr, const PositionColorVertex& srcColor);
+	void BlendPixel(Uint8* pixelAddr, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+	SDL_Color ApplyLighting(const PositionColorVertex& vertex);
 
 	DWORD m_width;
 	DWORD m_height;
@@ -38,9 +39,10 @@ private:
 	SDL_Palette* m_palette;
 	const SDL_PixelFormatDetails* m_format;
 	int m_bytesPerPixel;
+	std::vector<SceneLight> m_lights;
 	D3DVALUE m_front;
 	D3DVALUE m_back;
 	std::vector<PositionColorVertex> m_vertexBuffer;
 	float proj[4][4] = {0};
-	std::vector<float> m_zBuffer;
+	std::vector<double> m_zBuffer;
 };


### PR DESCRIPTION
Simple Gouraud shading like the original D3DRM

![image](https://github.com/user-attachments/assets/3f945956-43db-45ce-b180-231e5f3e6afa)

I also bumped the z-buffer to use double which solved the z-fighting.

This does bring CPU load to 60-70% but still it's running at 90 fps in 32bit color.