### PR TITLE
Fix bad normals

### DIFF
--- a/miniwin/src/d3drm/d3drmmesh.cpp
+++ b/miniwin/src/d3drm/d3drmmesh.cpp
@@ -206,6 +206,13 @@ HRESULT Direct3DRMMeshImpl::SetGroupQuality(DWORD groupIndex, D3DRMRENDERQUALITY
 		return DDERR_INVALIDPARAMS;
 	}
 
+	switch (quality) {
+	case D3DRMRENDER_WIREFRAME:
+	case D3DRMRENDER_UNLITFLAT:
+		MINIWIN_NOT_IMPLEMENTED();
+		break;
+	}
+
 	m_groups[groupIndex].quality = quality;
 	return DD_OK;
 }


### PR DESCRIPTION
Lots of models have bad normals and the game request that they be rendered with flat shading, which can be done by simply recalculating there normals to be the face normal.

No more broken legs:
![image](https://github.com/user-attachments/assets/c4420743-dc9b-4953-a548-88fc21530b6b)

![image](https://github.com/user-attachments/assets/a69c79b1-3b18-4586-adda-56117632c8fe)
