### PR TITLE
Unhook turn speed from the frame rate

### DIFF
--- a/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
@@ -352,7 +352,7 @@ MxBool LegoNavController::CalculateNewPosDir(
 		m_rotationalVel = CalculateNewVel(m_targetRotationalVel, m_rotationalVel, m_rotationalAccel * 40.0f, deltaTime);
 	}
 	else {
-		m_rotationalVel = m_targetRotationalVel;
+		m_rotationalVel = m_targetRotationalVel * m_maxRotationalVel * deltaTime;
 	}
 
 	m_linearVel = CalculateNewVel(m_targetLinearVel, m_linearVel, m_linearAccel, deltaTime);


### PR DESCRIPTION
This is a simple fix adapted from the patch I wrote for LEGO Island Rebuilder. Crucially it multiplies `m_rotationalVel` by `deltaTime` so the speed is unaffected by the frame rate.

Also multiplies by `m_maxRotationalVel` to achieve full "intended" turning speed. Not sure if this is actually the correct thing to do, but the results feel about right to me.