### PR TITLE
Push textures to the rendere

### DIFF
--- a/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
+++ b/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
@@ -269,6 +269,11 @@ void Direct3DRMSDL3GPURenderer::SetProjection(D3DRMMATRIX4D perspective, D3DVALU
 	memcpy(&m_uniforms.perspective, perspective, sizeof(D3DRMMATRIX4D));
 }
 
+Uint32 Direct3DRMSDL3GPURenderer::GetTextureId(IDirect3DRMTexture* texture)
+{
+	return NO_TEXTURE_ID;
+}
+
 DWORD Direct3DRMSDL3GPURenderer::GetWidth()
 {
 	return m_width;

--- a/miniwin/src/d3drm/d3drmmesh.cpp
+++ b/miniwin/src/d3drm/d3drmmesh.cpp
@@ -153,8 +153,13 @@ HRESULT Direct3DRMMeshImpl::SetGroupTexture(DWORD groupIndex, IDirect3DRMTexture
 		return DDERR_INVALIDPARAMS;
 	}
 
+	auto& group = m_groups[groupIndex];
+	if (group.texture) {
+		group.texture->Release();
+	}
+
 	texture->AddRef();
-	m_groups[groupIndex].texture = texture;
+	group.texture = texture;
 	return DD_OK;
 }
 

--- a/miniwin/src/d3drm/d3drmtexture.cpp
+++ b/miniwin/src/d3drm/d3drmtexture.cpp
@@ -27,6 +27,6 @@ HRESULT Direct3DRMTextureImpl::Changed(BOOL pixels, BOOL palette)
 	if (!m_surface) {
 		return DDERR_GENERIC;
 	}
-	MINIWIN_NOT_IMPLEMENTED();
+	m_version++;
 	return DD_OK;
 }

--- a/miniwin/src/d3drm/d3drmviewport.cpp
+++ b/miniwin/src/d3drm/d3drmviewport.cpp
@@ -221,6 +221,13 @@ HRESULT Direct3DRMViewportImpl::CollectSceneData()
 
 						D3DCOLOR color = mesh->GetGroupColor(gi);
 						D3DRMRENDERQUALITY quality = mesh->GetGroupQuality(gi);
+						IDirect3DRMTexture* texture = nullptr;
+						mesh->GetGroupTexture(gi, &texture);
+						Uint32 texId = NO_TEXTURE_ID;
+						if (texture) {
+							texId = m_renderer->GetTextureId(texture);
+							texture->Release();
+						}
 
 						for (DWORD fi = 0; fi < faceCount; ++fi) {
 							D3DVECTOR norm;
@@ -277,6 +284,7 @@ HRESULT Direct3DRMViewportImpl::CollectSceneData()
 								vtx.g = (color >> 8) & 0xFF;
 								vtx.b = (color >> 0) & 0xFF;
 								vtx.a = (color >> 24) & 0xFF;
+								vtx.texId = texId;
 								verts.push_back(vtx);
 							}
 						}

--- a/miniwin/src/ddraw/ddsurface.cpp
+++ b/miniwin/src/ddraw/ddsurface.cpp
@@ -216,7 +216,7 @@ HRESULT DirectDrawSurfaceImpl::Lock(
 		return DDERR_GENERIC;
 	}
 
-	if (SDL_LockSurface(m_surface) < 0) {
+	if (!SDL_LockSurface(m_surface)) {
 		return DDERR_GENERIC;
 	}
 

--- a/miniwin/src/internal/d3drmrenderer.h
+++ b/miniwin/src/internal/d3drmrenderer.h
@@ -4,10 +4,13 @@
 
 #include <SDL3/SDL.h>
 
+#define NO_TEXTURE_ID 0xffffffff
+
 typedef struct PositionColorVertex {
 	float x, y, z;
 	float nx, ny, nz;
 	Uint8 r, g, b, a;
+	Uint32 texId = NO_TEXTURE_ID;
 } PositionColorVertex;
 
 struct FColor {
@@ -28,6 +31,7 @@ public:
 	virtual void PushVertices(const PositionColorVertex* vertices, size_t count) = 0;
 	virtual void PushLights(const SceneLight* vertices, size_t count) = 0;
 	virtual void SetProjection(D3DRMMATRIX4D perspective, D3DVALUE front, D3DVALUE back) = 0;
+	virtual Uint32 GetTextureId(IDirect3DRMTexture* texture) = 0;
 	virtual DWORD GetWidth() = 0;
 	virtual DWORD GetHeight() = 0;
 	virtual void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) = 0;

--- a/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
+++ b/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
@@ -22,6 +22,7 @@ public:
 	void SetBackbuffer(SDL_Surface* backbuffer) override;
 	void PushVertices(const PositionColorVertex* vertices, size_t count) override;
 	void PushLights(const SceneLight* vertices, size_t count) override;
+	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
 	void SetProjection(D3DRMMATRIX4D perspective, D3DVALUE front, D3DVALUE back) override;
 	DWORD GetWidth() override;
 	DWORD GetHeight() override;

--- a/miniwin/src/internal/d3drmrenderer_software.h
+++ b/miniwin/src/internal/d3drmrenderer_software.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "d3drmrenderer.h"
+#include "d3drmtexture_impl.h"
 
 #include <SDL3/SDL.h>
 #include <cstddef>
@@ -14,6 +15,7 @@ public:
 	void SetBackbuffer(SDL_Surface* backbuffer) override;
 	void PushVertices(const PositionColorVertex* vertices, size_t count) override;
 	void PushLights(const SceneLight* vertices, size_t count) override;
+	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
 	void SetProjection(D3DRMMATRIX4D perspective, D3DVALUE front, D3DVALUE back) override;
 	DWORD GetWidth() override;
 	DWORD GetHeight() override;
@@ -32,6 +34,7 @@ private:
 	void ProjectVertex(const PositionColorVertex&, float&, float&, float&) const;
 	void BlendPixel(Uint8* pixelAddr, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 	SDL_Color ApplyLighting(const PositionColorVertex& vertex);
+	void AddTextureDestroyCallback(Uint32 id, IDirect3DRMTexture* texture);
 
 	DWORD m_width;
 	DWORD m_height;
@@ -40,6 +43,7 @@ private:
 	const SDL_PixelFormatDetails* m_format;
 	int m_bytesPerPixel;
 	std::vector<SceneLight> m_lights;
+	std::vector<SDL_Surface*> m_textures;
 	D3DVALUE m_front;
 	D3DVALUE m_back;
 	std::vector<PositionColorVertex> m_vertexBuffer;

--- a/miniwin/src/internal/d3drmtexture_impl.h
+++ b/miniwin/src/internal/d3drmtexture_impl.h
@@ -8,6 +8,8 @@ struct Direct3DRMTextureImpl : public Direct3DRMObjectBaseImpl<IDirect3DRMTextur
 	HRESULT QueryInterface(const GUID& riid, void** ppvObject) override;
 	HRESULT Changed(BOOL pixels, BOOL palette) override;
 
-private:
 	IDirectDrawSurface* m_surface = nullptr;
+
+private:
+	Uint8 m_version = 0;
 };

--- a/miniwin/src/internal/ddsurface_impl.h
+++ b/miniwin/src/internal/ddsurface_impl.h
@@ -37,8 +37,9 @@ struct DirectDrawSurfaceImpl : public IDirectDrawSurface3 {
 	void SetAutoFlip(bool enabled);
 	HRESULT Unlock(LPVOID lpSurfaceData) override;
 
+	SDL_Surface* m_surface = nullptr;
+
 private:
 	bool m_autoFlip = false;
-	SDL_Surface* m_surface = nullptr;
 	IDirectDrawPalette* m_palette = nullptr;
 };


### PR DESCRIPTION
Textures are now pushed to the renderer and assigned to the mesh vertexes. It also tracks animated texture states but nothing consumes that info yet.

Just enough of the software renderer has been implemented to use the first pixel as the color for any surface that uses that texture. It's fully unlit, but still better then all the milk shaded from before:


![Screenshot from 2025-05-31 18-47-26](https://github.com/user-attachments/assets/b1391be1-7c64-423a-bc6b-324c6294d757)

![Screenshot from 2025-05-31 18-44-09](https://github.com/user-attachments/assets/1863abfa-5908-4009-81d7-63fb3644af0a)

![Screenshot from 2025-05-31 18-32-06](https://github.com/user-attachments/assets/84ca5d4f-d9e2-41c4-b325-508f047a2e0b)
