### PR TITLE
miniwin: Compartmentalize EnumDevices

### DIFF
--- a/miniwin/src/ddraw/ddraw.cpp
+++ b/miniwin/src/ddraw/ddraw.cpp
@@ -223,14 +223,8 @@ void EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx, Direct3DRMRenderer* devi
 
 HRESULT DirectDrawImpl::EnumDevices(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
-	Direct3DRMRenderer* device = Direct3DRMSDL3GPURenderer::Create(640, 480);
-	if (device) {
-		EnumDevice(cb, ctx, device, SDL3_GPU_GUID);
-		delete device;
-	}
-	device = new Direct3DRMSoftwareRenderer(640, 480);
-	EnumDevice(cb, ctx, device, SOFTWARE_GUID);
-	delete device;
+	Direct3DRMSDL3GPU_EnumDevice(cb, ctx);
+	Direct3DRMSoftware_EnumDevice(cb, ctx);
 
 	return S_OK;
 }

--- a/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
+++ b/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "d3drmrenderer.h"
+#include "ddraw_impl.h"
 
 #include <SDL3/SDL.h>
 
@@ -60,3 +61,12 @@ private:
 	SDL_GPUBuffer* m_vertexBuffer = nullptr;
 	SDL_Surface* m_renderedImage = nullptr;
 };
+
+inline static void Direct3DRMSDL3GPU_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
+{
+	Direct3DRMRenderer* device = Direct3DRMSDL3GPURenderer::Create(640, 480);
+	if (device) {
+		EnumDevice(cb, ctx, device, SDL3_GPU_GUID);
+		delete device;
+	}
+}

--- a/miniwin/src/internal/d3drmrenderer_software.h
+++ b/miniwin/src/internal/d3drmrenderer_software.h
@@ -2,6 +2,7 @@
 
 #include "d3drmrenderer.h"
 #include "d3drmtexture_impl.h"
+#include "ddraw_impl.h"
 
 #include <SDL3/SDL.h>
 #include <cstddef>
@@ -56,3 +57,11 @@ private:
 	float proj[4][4] = {0};
 	std::vector<float> m_zBuffer;
 };
+
+inline static void Direct3DRMSoftware_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
+{
+	Direct3DRMRenderer* device = nullptr;
+	device = new Direct3DRMSoftwareRenderer(640, 480);
+	EnumDevice(cb, ctx, device, SOFTWARE_GUID);
+	delete device;
+}

--- a/miniwin/src/internal/ddraw_impl.h
+++ b/miniwin/src/internal/ddraw_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "d3drmrenderer.h"
 #include "miniwin/d3d.h"
 #include "miniwin/ddraw.h"
 
@@ -43,3 +44,5 @@ struct DirectDrawImpl : public IDirectDraw2, public IDirect3D2 {
 HRESULT DirectDrawEnumerate(LPDDENUMCALLBACKA cb, void* context);
 
 HRESULT DirectDrawCreate(LPGUID lpGuid, LPDIRECTDRAW* lplpDD, IUnknown* pUnkOuter);
+
+void EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx, Direct3DRMRenderer* device, GUID deviceGuid);


### PR DESCRIPTION
This compartmentalizes everything into a corresponding EnumDevice function for each renderer backend.

This makes it easier to add new renderers. I think this could be done better, so I made a draft PR.