### PR TITLE
Make OpenGL compatible with config

### DIFF
--- a/miniwin/src/d3drm/backends/opengl15/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengl15/renderer.cpp
@@ -132,7 +132,7 @@ void OpenGL15Renderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc)
 {
 	halDesc->dcmColorModel = D3DCOLORMODEL::RGB;
 	halDesc->dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
-	halDesc->dwDeviceZBufferBitDepth = DDBD_24; // Todo add support for other depths
+	halDesc->dwDeviceZBufferBitDepth = DDBD_16 | DDBD_24; // Todo add support for other depths
 	helDesc->dwDeviceRenderBitDepth = DDBD_8 | DDBD_16 | DDBD_24 | DDBD_32;
 	halDesc->dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
 	halDesc->dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d2ccee8c-61e0-4a62-89fc-20578ff367dd)

Probably because this garbage REQUIRE 16bit, not 16bit or grater. The engine will actually use High so it's a bad check.
https://github.com/isledecomp/isle-portable/blob/e520a47e2f65b4d44305983b08db27bc557b7619/LEGO1/mxdirectx/legodxinfo.cpp#L345