### PR TITLE
Cache bounding box

### DIFF
--- a/miniwin/src/internal/d3drmmesh_impl.h
+++ b/miniwin/src/internal/d3drmmesh_impl.h
@@ -93,5 +93,9 @@ struct Direct3DRMMeshImpl : public Direct3DRMObjectBaseImpl<IDirect3DRMMesh> {
 	HRESULT GetBox(D3DRMBOX* box) override;
 
 private:
+	void UpdateBox();
+	void UpdateBox(DWORD groupIndex);
+
 	std::vector<MeshGroup> m_groups;
+	D3DRMBOX m_box;
 };


### PR DESCRIPTION
Only calculate the bounding box when the mesh changes, and only the parts the potentially changed.

Since we likely will want to use this for optimizing rendering it's best that it's fast.

This also correct a potential issue with the initial value being the smallest positive number and not the smallest negative number.