### PR TITLE
Config clean ups

### DIFF
--- a/CONFIG/MainDlg.cpp
+++ b/CONFIG/MainDlg.cpp
@@ -91,9 +91,8 @@ bool CMainDialog::OnInitDialog()
 			device_i += 1;
 			sprintf(
 				device_name,
-				"%s [%s] ( %s )",
+				"%s ( %s )",
 				device.m_deviceDesc,
-				device.m_deviceName,
 				driver_i == 0 ? "Primary Device" : "Secondary Device"
 			);
 			m_ui->devicesList->addItem(device_name);

--- a/LEGO1/mxdirectx/legodxinfo.cpp
+++ b/LEGO1/mxdirectx/legodxinfo.cpp
@@ -342,7 +342,8 @@ unsigned char LegoDeviceEnumerate::FUN_1009d3d0(Direct3DDeviceInfo& p_device)
 	}
 
 	if (p_device.m_HWDesc.dcmColorModel != D3DCOLOR_NONE) {
-		if ((p_device.m_HWDesc.dwDeviceZBufferBitDepth & DDBD_16) == DDBD_16 &&
+		DDBitDepths zDepth = p_device.m_HWDesc.dwDeviceZBufferBitDepth;
+		if ((zDepth & (DDBD_16 | DDBD_24 | DDBD_32)) != static_cast<DDBitDepths>(0) &&
 			(p_device.m_HWDesc.dpcTriCaps.dwTextureCaps & D3DPTEXTURECAPS_PERSPECTIVE) == D3DPTEXTURECAPS_PERSPECTIVE) {
 			return TRUE;
 		}

--- a/miniwin/src/d3drm/backends/opengl15/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengl15/renderer.cpp
@@ -143,7 +143,7 @@ void OpenGL15Renderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc)
 
 const char* OpenGL15Renderer::GetName()
 {
-	return "OpenGL 1.5 Renderer";
+	return "OpenGL 1.5 HAL";
 }
 
 HRESULT OpenGL15Renderer::Render()

--- a/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
+++ b/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
@@ -316,7 +316,7 @@ void Direct3DRMSDL3GPURenderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* h
 
 const char* Direct3DRMSDL3GPURenderer::GetName()
 {
-	return "SDL3 GPU Rendere";
+	return "SDL3 GPU HAL";
 }
 
 HRESULT Direct3DRMSDL3GPURenderer::Render()

--- a/miniwin/src/d3drm/backends/software/renderer.cpp
+++ b/miniwin/src/d3drm/backends/software/renderer.cpp
@@ -463,7 +463,7 @@ void Direct3DRMSoftwareRenderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* 
 
 const char* Direct3DRMSoftwareRenderer::GetName()
 {
-	return "Software Renderer";
+	return "Miniwin Emulation";
 }
 
 HRESULT Direct3DRMSoftwareRenderer::Render()


### PR DESCRIPTION
This correct config to allow for decices that doesn't support 16bit z-buffer, but does support higher bit depths ... like the game does.

Also it tweaks the name of the backends to match the style of the original a bit more.

![image](https://github.com/user-attachments/assets/287ff8e4-d724-49f9-936f-36ea48440b5b)
