### PR TITLE
Cull by Bounding Box

### DIFF
--- a/miniwin/src/internal/d3drmviewport_impl.h
+++ b/miniwin/src/internal/d3drmviewport_impl.h
@@ -35,7 +35,13 @@ struct Direct3DRMViewportImpl : public Direct3DRMObjectBaseImpl<IDirect3DRMViewp
 	void CloseDevice();
 
 private:
-	HRESULT CollectSceneData();
+	void CollectSceneData();
+	void CollectLightsFromFrame(IDirect3DRMFrame* frame, D3DRMMATRIX4D parentMatrix, std::vector<SceneLight>& lights);
+	void CollectMeshesFromFrame(
+		IDirect3DRMFrame* frame,
+		D3DRMMATRIX4D parentMatrix,
+		std::vector<PositionColorVertex>& verts
+	);
 	void UpdateProjectionMatrix();
 	Direct3DRMRenderer* m_renderer;
 	D3DCOLOR m_backgroundColor = 0xFF000000;


### PR DESCRIPTION
This calculates the frustum planes and uses them to cull meshes by bounding box. It also cleans up the structure of Direct3DRMViewportImpl a bit and removes a few unnecessary status checks. The restructuring helps prepare for further planned improvements to the render pipeline.

An optimized release build on my system now gives these performance numbers:
- Software: 70-90fps 80-100% CPU
- OpenGL: 90fps 40-45% CPU
- Vulkan: 90fps 30-40% CPU