### PR TITLE
Enable backface culling

### DIFF
--- a/miniwin/src/d3drm/backends/opengl15/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengl15/renderer.cpp
@@ -37,6 +37,9 @@ Direct3DRMRenderer* OpenGL15Renderer::Create(DWORD width, DWORD height)
 		return nullptr;
 	}
 
+	glEnable(GL_CULL_FACE);
+	glCullFace(GL_BACK);
+	glFrontFace(GL_CCW);
 	glEnable(GL_DEPTH_TEST);
 	glEnable(GL_LIGHTING);
 	glEnable(GL_COLOR_MATERIAL);
@@ -316,6 +319,8 @@ void OpenGL15Renderer::SubmitDraw(
 	glLoadMatrixf(&mvMatrix[0][0]);
 	glEnable(GL_NORMALIZE);
 
+	glColor4ub(appearance.color.r, appearance.color.g, appearance.color.b, appearance.color.a);
+
 	// Bind texture if present
 	if (appearance.textureId != NO_TEXTURE_ID) {
 		auto& tex = m_textures[appearance.textureId];
@@ -342,7 +347,6 @@ void OpenGL15Renderer::SubmitDraw(
 	glBegin(GL_TRIANGLES);
 	for (size_t i = 0; i < count; i++) {
 		const GeometryVertex& v = vertices[i];
-		glColor4ub(appearance.color.r, appearance.color.g, appearance.color.b, appearance.color.a);
 		glNormal3f(v.normals.x, v.normals.y, v.normals.z);
 		glTexCoord2f(v.texCoord.u, v.texCoord.v);
 		glVertex3f(v.position.x, v.position.y, v.position.z);


### PR DESCRIPTION
Turns out the issue with the bridge is because they are infinity thin so when backface culling isn't enabled you see it z-fighting with the top of the bridge.

And of cause there is the added benefit of rendering way less triangles.

![image](https://github.com/user-attachments/assets/1ebb1670-42b7-46f7-a23c-b7acc75d74d2)

This also applies a small optimization of only transmitting the material color once per mesh group instead of once per vertex.

Performance is a solid 90fps and hovering around 40% load on the CPU core.