### PR TITLE
25% less CPU load

### DIFF
--- a/miniwin/src/d3drm/d3drmmesh.cpp
+++ b/miniwin/src/d3drm/d3drmmesh.cpp
@@ -64,8 +64,6 @@ HRESULT Direct3DRMMeshImpl::AddGroup(
 
 	m_groups.push_back(std::move(group));
 
-	UpdateBox(newIndex);
-
 	return DD_OK;
 }
 
@@ -281,19 +279,14 @@ void Direct3DRMMeshImpl::UpdateBox()
 	m_box.max = {-INF, -INF, -INF};
 
 	for (size_t i = 0; i < m_groups.size(); ++i) {
-		UpdateBox(i);
-	}
-}
-
-void Direct3DRMMeshImpl::UpdateBox(DWORD groupIndex)
-{
-	for (const D3DRMVERTEX& v : m_groups[groupIndex].vertices) {
-		m_box.min.x = std::min(m_box.min.x, v.position.x);
-		m_box.min.y = std::min(m_box.min.y, v.position.y);
-		m_box.min.z = std::min(m_box.min.z, v.position.z);
-		m_box.max.x = std::max(m_box.max.x, v.position.x);
-		m_box.max.y = std::max(m_box.max.y, v.position.y);
-		m_box.max.z = std::max(m_box.max.z, v.position.z);
+		for (const D3DRMVERTEX& v : m_groups[i].vertices) {
+			m_box.min.x = std::min(m_box.min.x, v.position.x);
+			m_box.min.y = std::min(m_box.min.y, v.position.y);
+			m_box.min.z = std::min(m_box.min.z, v.position.z);
+			m_box.max.x = std::max(m_box.max.x, v.position.x);
+			m_box.max.y = std::max(m_box.max.y, v.position.y);
+			m_box.max.z = std::max(m_box.max.z, v.position.z);
+		}
 	}
 }
 

--- a/miniwin/src/internal/d3drmmesh_impl.h
+++ b/miniwin/src/internal/d3drmmesh_impl.h
@@ -94,7 +94,6 @@ struct Direct3DRMMeshImpl : public Direct3DRMObjectBaseImpl<IDirect3DRMMesh> {
 
 private:
 	void UpdateBox();
-	void UpdateBox(DWORD groupIndex);
 
 	std::vector<MeshGroup> m_groups;
 	D3DRMBOX m_box;

--- a/miniwin/src/internal/d3drmviewport_impl.h
+++ b/miniwin/src/internal/d3drmviewport_impl.h
@@ -37,7 +37,13 @@ struct Direct3DRMViewportImpl : public Direct3DRMObjectBaseImpl<IDirect3DRMViewp
 private:
 	HRESULT RenderScene();
 	void CollectLightsFromFrame(IDirect3DRMFrame* frame, D3DRMMATRIX4D parentMatrix, std::vector<SceneLight>& lights);
-	void CollectMeshesFromFrame(IDirect3DRMFrame* frame, D3DRMMATRIX4D parentMatrix);
+	void CollectMeshesFromFrame(
+		IDirect3DRMFrame* frame,
+		D3DRMMATRIX4D parentMatrix,
+		std::vector<GeometryVertex>& verts,
+		std::vector<D3DRMVERTEX>& d3dVerts,
+		std::vector<DWORD>& faces
+	);
 	void UpdateProjectionMatrix();
 	Direct3DRMRenderer* m_renderer;
 	D3DCOLOR m_backgroundColor = 0xFF000000;


### PR DESCRIPTION
Herp derp - vertex count = vertex count * 3.
Also I was creating a new buffer for every mesh instead of reusing the same ones for all meshes.

Lastly calling `UpdateBox()` in add group makes no sens as we have no vertexes arrive there, but that's mostly about loading performance.