### PR TITLE
Update size to match vector content

### DIFF
--- a/miniwin/src/d3drm/d3drmviewport.cpp
+++ b/miniwin/src/d3drm/d3drmviewport.cpp
@@ -282,9 +282,7 @@ void Direct3DRMViewportImpl::CollectMeshesFromFrame(
 			verts.reserve(dataSize);
 			verts.clear();
 			d3dVerts.resize(vtxCount);
-			d3dVerts.clear();
 			faces.resize(dataSize);
-			faces.clear();
 			mesh->GetVertices(gi, 0, vtxCount, d3dVerts.data());
 			mesh->GetGroup(gi, nullptr, nullptr, nullptr, nullptr, faces.data());
 


### PR DESCRIPTION
clear() left size() at 0 since content is being written via memcpy. Technically there wasn't an issue since the buffer size was always ensured and reads happened directly (which is why there was no noticeable side effects) but MSVC is correct that this is the proper way to do it.

Fixes #244