### PR TITLE
miniwin: Use the GLEW::GLEW target to find glew.

### DIFF
--- a/miniwin/CMakeLists.txt
+++ b/miniwin/CMakeLists.txt
@@ -30,8 +30,7 @@ if(OpenGL_FOUND AND GLEW_FOUND)
   # Find and link OpenGL (1.5)
   target_link_libraries(miniwin PRIVATE OpenGL::GL)
   # Glew is used for getting a FBO for off screen rendering
-  target_include_directories(miniwin PRIVATE ${GLEW_INCLUDE_DIRS})
-  target_link_libraries(miniwin PRIVATE ${GLEW_LIBRARIES})
+  target_link_libraries(miniwin PRIVATE GLEW::GLEW)
 endif()
 
 # Force reported render mods from MiniWin


### PR DESCRIPTION
On some systems, the old-style GLEW_TARGET_LIBRARIES variable is not set by find_package(GLEW), and instead we must use the newer GLEW::GLEW target, as we do for OpenGL.

This fixes a build error on openSUSE Tumbleweed, which has a glew CMake config in /usr/lib64/cmake/glew/glew-config.cmake.

**Please check that this doesn't break your existing config. I suspect there are two different ways GLEW can be found — ``glew-config.cmake`` and ``FindGLEW.cmake`` — and I've only tried and tested one of them.**