### PR TITLE
Fix `LegoUnknown::FUN_1009a1e0`

### DIFF
--- a/LEGO1/lego/sources/misc/legounknown.cpp
+++ b/LEGO1/lego/sources/misc/legounknown.cpp
@@ -2,6 +2,8 @@
 
 #include "mxgeometry/mxmatrix.h"
 
+#include <math.h>
+
 DECOMP_SIZE_ASSERT(LegoUnknown, 0x50)
 
 // FUNCTION: LEGO1 0x1009a0f0
@@ -44,7 +46,7 @@ LegoResult LegoUnknown::FUN_1009a1e0(float p_f1, Matrix4& p_mat, Vector3& p_v, L
 	Vector3 v3(p_mat[1]);
 	Vector3 v4(p_mat[2]);
 
-	if (p_f1 <= 0.001) {
+	if (isnan(p_f1) || p_f1 <= 0.001) {
 		v1 = m_unk0x00[0];
 		v4 = m_unk0x00[1];
 	}


### PR DESCRIPTION
In some instances, a divide-by-zero happens with floating point numbers: https://github.com/isledecomp/isle-portable/blob/master/LEGO1/lego/legoomni/src/paths/legopathactor.cpp#L361

This is actually well-defined behavior, and happens in retail too. In this case, `LegoUnknown::FUN_1009a1e0` receives NaN (or negative infinity on MSVC 4.20). Using MSVC 4.20, the compiler incorrectly evaluates [`p_f1 <= 0.001`](https://github.com/isledecomp/isle-portable/blob/master/LEGO1/lego/sources/misc/legounknown.cpp#L47) to being true. While this is technically incorrect, it does lead to the desired branch being executed. The game functions normally.

Modern compilers fixed this comparison, and correctly yield `false`, which causes the 3rd branch to be executed and subsequently `FUN_1009a1e0` cannot produce the expected result. Adding a check for `isnan` to the first branch solves the problem.

I've verified this definitely fixes #234, but I'm reasonably certain this will solve the issue for the `r == 0` assertion trigger in general and that #249 has the same cause so I'm closing all of these issues:

Close #234
Close #249 
Close #121 