### PR TITLE
Add status badges for platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please note: this project is dedicated to achieving platform independence withou
 
 ### Supported platforms
 
-| Platform | status |
+| Platform | Status |
 | - | - | 
 | Windows | [![CI](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml/badge.svg)](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml) | 
 | Linux | [![CI](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml/badge.svg)](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml) |

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Please note: this project is dedicated to achieving platform independence withou
 
 | Platform | Implementation status |
 | - | - | 
-| Windows | ✅ | 
-| Linux | 🚧 |
-| macOS | 🚧 |
+| Windows | [![CI](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml/badge.svg)](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml) | 
+| Linux | [![CI](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml/badge.svg)](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml) |
+| macOS | [![CI](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml/badge.svg)](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml) |
 
 ### Library substitutions
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To achieve our goal of platform independence, we need to replace any Windows-onl
 | WinMM, DirectSound (Audio) | [SDL3](https://www.libsdl.org/), [miniaudio](https://miniaud.io/) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Aaudio%5D%22&type=code) |
 | DirectDraw (2D video) | [SDL3](https://www.libsdl.org/) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3A2d%5D%22&type=code) |
 | [Smacker](https://github.com/isledecomp/isle/tree/master/3rdparty/smacker) | [libsmacker](https://github.com/foxtacles/libsmacker) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable%20%22%2F%2F%20%5Blibrary%3Alibsmacker%5D%22&type=code) |
-| Direct3D (3D video) | [SDL3](https://www.libsdl.org/) | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3A3d%5D%22&type=code) |
+| Direct3D (3D video) | [SDL3](https://www.libsdl.org/), OpenGL, Software | ✅ | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3A3d%5D%22&type=code) |
 | Direct3D Retained Mode | Custom re-implementation | 🚧 | [Remarks](https://github.com/search?q=repo%3Aisledecomp%2Fisle-portable+%22%2F%2F+%5Blibrary%3Aretained%5D%22&type=code) |
 | [SmartHeap](https://github.com/isledecomp/isle/tree/master/3rdparty/smartheap) | Default memory allocator | - | - |
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please note: this project is dedicated to achieving platform independence withou
 
 ### Supported platforms
 
-| Platform | Implementation status |
+| Platform | status |
 | - | - | 
 | Windows | [![CI](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml/badge.svg)](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml) | 
 | Linux | [![CI](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml/badge.svg)](https://github.com/isledecomp/isle-portable/actions/workflows/ci.yml) |


### PR DESCRIPTION
Things now work well under miniwin, there are still some improvement like faster rendering and full screen that can be done but this is true for most Windows builds and the other emojis does a better job of showing where specific short comings are present.