### PR TITLE
Add flat shading to Appearance

### DIFF
--- a/miniwin/src/d3drm/backends/opengl15/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengl15/renderer.cpp
@@ -333,6 +333,10 @@ void OpenGL15Renderer::SubmitDraw(
 		glDisable(GL_TEXTURE_2D);
 	}
 
+	if (appearance.flat) {
+		glShadeModel(GL_FLAT);
+	}
+
 	float shininess = appearance.shininess;
 	glMaterialf(GL_FRONT, GL_SHININESS, shininess);
 	if (shininess != 0.0f) {

--- a/miniwin/src/d3drm/d3drmviewport.cpp
+++ b/miniwin/src/d3drm/d3drmviewport.cpp
@@ -288,6 +288,7 @@ void Direct3DRMViewportImpl::CollectMeshesFromFrame(
 
 			D3DCOLOR color = mesh->GetGroupColor(gi);
 			D3DRMRENDERQUALITY quality = mesh->GetGroupQuality(gi);
+			bool flat = quality == D3DRMRENDER_FLAT || quality == D3DRMRENDER_UNLITFLAT;
 
 			IDirect3DRMTexture* texture = nullptr;
 			mesh->GetGroupTexture(gi, &texture);
@@ -307,7 +308,7 @@ void Direct3DRMViewportImpl::CollectMeshesFromFrame(
 
 			for (DWORD fi = 0; fi < faceCount; ++fi) {
 				D3DVECTOR norm;
-				if (quality == D3DRMRENDER_FLAT || quality == D3DRMRENDER_UNLITFLAT) {
+				if (flat) {
 					D3DRMVERTEX& v0 = d3dVerts[faces[fi * vpf + 0]];
 					D3DRMVERTEX& v1 = d3dVerts[faces[fi * vpf + 1]];
 					D3DRMVERTEX& v2 = d3dVerts[faces[fi * vpf + 2]];
@@ -334,7 +335,8 @@ void Direct3DRMViewportImpl::CollectMeshesFromFrame(
 				  static_cast<Uint8>((color >> 0) & 0xFF),
 				  static_cast<Uint8>((color >> 24) & 0xFF)},
 				 shininess,
-				 textureId}
+				 textureId,
+				 flat}
 			);
 		}
 		mesh->Release();

--- a/miniwin/src/internal/d3drmrenderer.h
+++ b/miniwin/src/internal/d3drmrenderer.h
@@ -22,6 +22,7 @@ struct Appearance {
 	SDL_Color color;
 	float shininess;
 	Uint32 textureId;
+	bool flat;
 };
 
 struct FColor {


### PR DESCRIPTION
A small pre-PR that lets the renderer know if the geometry is supposed to be flat shaded, it does improve rendering a little on OpenGL where it's pretty simple to take advantage of this, but not yet for Software or SDL_GPU, but they should be fully unaffected by this change.