### PR TITLE
Replace GeometryVertex with D3DRMVERTEX

### DIFF
--- a/miniwin/include/miniwin/d3drm.h
+++ b/miniwin/include/miniwin/d3drm.h
@@ -136,10 +136,19 @@ struct D3DRMBOX {
 	D3DVECTOR max;
 };
 
+struct TexCoord {
+	float u, v;
+};
+
 struct D3DRMVERTEX {
 	D3DVECTOR position;
 	D3DVECTOR normal;
-	D3DVALUE tu, tv;
+	union {
+		struct {
+			D3DVALUE tu, tv;
+		};
+		TexCoord texCoord;
+	};
 };
 
 struct IDirect3DRMObject : public IUnknown {

--- a/miniwin/src/d3drm/backends/opengl15/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengl15/renderer.cpp
@@ -304,7 +304,7 @@ HRESULT OpenGL15Renderer::BeginFrame(const D3DRMMATRIX4D& viewMatrix)
 }
 
 void OpenGL15Renderer::SubmitDraw(
-	const GeometryVertex* vertices,
+	const D3DRMVERTEX* vertices,
 	const size_t count,
 	const D3DRMMATRIX4D& worldMatrix,
 	const Matrix3x3& normalMatrix,
@@ -350,8 +350,8 @@ void OpenGL15Renderer::SubmitDraw(
 
 	glBegin(GL_TRIANGLES);
 	for (size_t i = 0; i < count; i++) {
-		const GeometryVertex& v = vertices[i];
-		glNormal3f(v.normals.x, v.normals.y, v.normals.z);
+		const D3DRMVERTEX& v = vertices[i];
+		glNormal3f(v.normal.x, v.normal.y, v.normal.z);
 		glTexCoord2f(v.texCoord.u, v.texCoord.v);
 		glVertex3f(v.position.x, v.position.y, v.position.z);
 	}

--- a/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
+++ b/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
@@ -32,7 +32,7 @@ static SDL_GPUGraphicsPipeline* InitializeGraphicsPipeline(SDL_GPUDevice* device
 
 	SDL_GPUVertexBufferDescription vertexBufferDescs[1] = {};
 	vertexBufferDescs[0].slot = 0;
-	vertexBufferDescs[0].pitch = sizeof(GeometryVertex);
+	vertexBufferDescs[0].pitch = sizeof(D3DRMVERTEX);
 	vertexBufferDescs[0].input_rate = SDL_GPU_VERTEXINPUTRATE_VERTEX;
 	vertexBufferDescs[0].instance_step_rate = 0;
 
@@ -40,17 +40,17 @@ static SDL_GPUGraphicsPipeline* InitializeGraphicsPipeline(SDL_GPUDevice* device
 	vertexAttrs[0].location = 0;
 	vertexAttrs[0].buffer_slot = 0;
 	vertexAttrs[0].format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3;
-	vertexAttrs[0].offset = offsetof(GeometryVertex, position);
+	vertexAttrs[0].offset = offsetof(D3DRMVERTEX, position);
 
 	vertexAttrs[1].location = 1;
 	vertexAttrs[1].buffer_slot = 0;
 	vertexAttrs[1].format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3;
-	vertexAttrs[1].offset = offsetof(GeometryVertex, normals);
+	vertexAttrs[1].offset = offsetof(D3DRMVERTEX, normal);
 
 	vertexAttrs[2].location = 2;
 	vertexAttrs[2].buffer_slot = 0;
 	vertexAttrs[2].format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
-	vertexAttrs[2].offset = offsetof(GeometryVertex, texCoord);
+	vertexAttrs[2].offset = offsetof(D3DRMVERTEX, tv);
 
 	SDL_GPUVertexInputState vertexInputState = {};
 	vertexInputState.vertex_buffer_descriptions = vertexBufferDescs;
@@ -298,7 +298,7 @@ HRESULT Direct3DRMSDL3GPURenderer::BeginFrame(const D3DRMMATRIX4D& viewMatrix)
 }
 
 void Direct3DRMSDL3GPURenderer::SubmitDraw(
-	const GeometryVertex* vertices,
+	const D3DRMVERTEX* vertices,
 	const size_t count,
 	const D3DRMMATRIX4D& worldMatrix,
 	const Matrix3x3& normalMatrix,
@@ -317,7 +317,7 @@ void Direct3DRMSDL3GPURenderer::SubmitDraw(
 		}
 		SDL_GPUBufferCreateInfo bufferCreateInfo = {};
 		bufferCreateInfo.usage = SDL_GPU_BUFFERUSAGE_VERTEX;
-		bufferCreateInfo.size = static_cast<Uint32>(sizeof(GeometryVertex) * count);
+		bufferCreateInfo.size = static_cast<Uint32>(sizeof(D3DRMVERTEX) * count);
 		m_vertexBuffer = SDL_CreateGPUBuffer(m_device, &bufferCreateInfo);
 		if (!m_vertexBuffer) {
 			SDL_LogError(LOG_CATEGORY_MINIWIN, "SDL_CreateGPUBuffer returned NULL buffer (%s)", SDL_GetError());
@@ -332,7 +332,7 @@ void Direct3DRMSDL3GPURenderer::SubmitDraw(
 
 	SDL_GPUTransferBufferCreateInfo transferCreateInfo = {};
 	transferCreateInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
-	transferCreateInfo.size = static_cast<Uint32>(sizeof(GeometryVertex) * m_vertexCount);
+	transferCreateInfo.size = static_cast<Uint32>(sizeof(D3DRMVERTEX) * m_vertexCount);
 	SDL_GPUTransferBuffer* transferBuffer = SDL_CreateGPUTransferBuffer(m_device, &transferCreateInfo);
 	if (!transferBuffer) {
 		SDL_LogError(
@@ -342,12 +342,12 @@ void Direct3DRMSDL3GPURenderer::SubmitDraw(
 		);
 	}
 
-	GeometryVertex* transferData = (GeometryVertex*) SDL_MapGPUTransferBuffer(m_device, transferBuffer, false);
+	D3DRMVERTEX* transferData = (D3DRMVERTEX*) SDL_MapGPUTransferBuffer(m_device, transferBuffer, false);
 	if (!transferData) {
 		SDL_LogError(LOG_CATEGORY_MINIWIN, "SDL_MapGPUTransferBuffer returned NULL buffer (%s)", SDL_GetError());
 	}
 
-	memcpy(transferData, vertices, m_vertexCount * sizeof(GeometryVertex));
+	memcpy(transferData, vertices, m_vertexCount * sizeof(D3DRMVERTEX));
 
 	SDL_UnmapGPUTransferBuffer(m_device, transferBuffer);
 
@@ -366,7 +366,7 @@ void Direct3DRMSDL3GPURenderer::SubmitDraw(
 	SDL_GPUBufferRegion bufferRegion = {};
 	bufferRegion.buffer = m_vertexBuffer;
 	bufferRegion.offset = 0;
-	bufferRegion.size = static_cast<Uint32>(sizeof(GeometryVertex) * m_vertexCount);
+	bufferRegion.size = static_cast<Uint32>(sizeof(D3DRMVERTEX) * m_vertexCount);
 
 	SDL_UploadToGPUBuffer(copyPass, &transferLocation, &bufferRegion, false);
 

--- a/miniwin/src/d3drm/d3drmviewport.cpp
+++ b/miniwin/src/d3drm/d3drmviewport.cpp
@@ -215,7 +215,7 @@ bool IsBoxInFrustum(const D3DVECTOR corners[8], const Plane planes[6])
 void Direct3DRMViewportImpl::CollectMeshesFromFrame(
 	IDirect3DRMFrame* frame,
 	D3DRMMATRIX4D parentMatrix,
-	std::vector<GeometryVertex>& verts,
+	std::vector<D3DRMVERTEX>& verts,
 	std::vector<D3DRMVERTEX>& d3dVerts,
 	std::vector<DWORD>& faces
 )
@@ -365,7 +365,7 @@ HRESULT Direct3DRMViewportImpl::RenderScene()
 		return status;
 	}
 
-	std::vector<GeometryVertex> verts;
+	std::vector<D3DRMVERTEX> verts;
 	std::vector<D3DRMVERTEX> d3dVerts;
 	std::vector<DWORD> faces;
 	ExtractFrustumPlanes(viewProj);

--- a/miniwin/src/internal/d3drmrenderer.h
+++ b/miniwin/src/internal/d3drmrenderer.h
@@ -7,16 +7,7 @@
 
 #define NO_TEXTURE_ID 0xffffffff
 
-struct TexCoord {
-	float u, v;
-};
-
-struct GeometryVertex {
-	D3DVECTOR position;
-	D3DVECTOR normals;
-	TexCoord texCoord;
-};
-static_assert(sizeof(GeometryVertex) == 32);
+static_assert(sizeof(D3DRMVERTEX) == 32);
 
 struct Appearance {
 	SDL_Color color;
@@ -49,7 +40,7 @@ public:
 	virtual const char* GetName() = 0;
 	virtual HRESULT BeginFrame(const D3DRMMATRIX4D& viewMatrix) = 0;
 	virtual void SubmitDraw(
-		const GeometryVertex* vertices,
+		const D3DRMVERTEX* vertices,
 		const size_t count,
 		const D3DRMMATRIX4D& worldMatrix,
 		const Matrix3x3& normalMatrix,

--- a/miniwin/src/internal/d3drmrenderer_opengl15.h
+++ b/miniwin/src/internal/d3drmrenderer_opengl15.h
@@ -30,7 +30,7 @@ public:
 	const char* GetName() override;
 	HRESULT BeginFrame(const D3DRMMATRIX4D& viewMatrix) override;
 	void SubmitDraw(
-		const GeometryVertex* vertices,
+		const D3DRMVERTEX* vertices,
 		const size_t count,
 		const D3DRMMATRIX4D& worldMatrix,
 		const Matrix3x3& normalMatrix,

--- a/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
+++ b/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
@@ -37,7 +37,7 @@ public:
 	const char* GetName() override;
 	HRESULT BeginFrame(const D3DRMMATRIX4D& viewMatrix) override;
 	void SubmitDraw(
-		const GeometryVertex* vertices,
+		const D3DRMVERTEX* vertices,
 		const size_t count,
 		const D3DRMMATRIX4D& worldMatrix,
 		const Matrix3x3& normalMatrix,

--- a/miniwin/src/internal/d3drmrenderer_software.h
+++ b/miniwin/src/internal/d3drmrenderer_software.h
@@ -28,7 +28,7 @@ public:
 	const char* GetName() override;
 	HRESULT BeginFrame(const D3DRMMATRIX4D& viewMatrix) override;
 	void SubmitDraw(
-		const GeometryVertex* vertices,
+		const D3DRMVERTEX* vertices,
 		const size_t count,
 		const D3DRMMATRIX4D& worldMatrix,
 		const Matrix3x3& normalMatrix,
@@ -39,15 +39,15 @@ public:
 private:
 	void ClearZBuffer();
 	void DrawTriangleProjected(
-		const GeometryVertex& v0,
-		const GeometryVertex& v1,
-		const GeometryVertex& v2,
+		const D3DRMVERTEX& v0,
+		const D3DRMVERTEX& v1,
+		const D3DRMVERTEX& v2,
 		const Appearance& appearance
 	);
-	void DrawTriangleClipped(const GeometryVertex (&v)[3], const Appearance& appearance);
-	void ProjectVertex(const GeometryVertex& v, D3DRMVECTOR4D& p) const;
+	void DrawTriangleClipped(const D3DRMVERTEX (&v)[3], const Appearance& appearance);
+	void ProjectVertex(const D3DRMVERTEX& v, D3DRMVECTOR4D& p) const;
 	void BlendPixel(Uint8* pixelAddr, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
-	SDL_Color ApplyLighting(const GeometryVertex& vertex, const Appearance& appearance);
+	SDL_Color ApplyLighting(const D3DRMVERTEX& vertex, const Appearance& appearance);
 	void AddTextureDestroyCallback(Uint32 id, IDirect3DRMTexture* texture);
 
 	DWORD m_width;

--- a/miniwin/src/internal/d3drmviewport_impl.h
+++ b/miniwin/src/internal/d3drmviewport_impl.h
@@ -40,7 +40,7 @@ private:
 	void CollectMeshesFromFrame(
 		IDirect3DRMFrame* frame,
 		D3DRMMATRIX4D parentMatrix,
-		std::vector<GeometryVertex>& verts,
+		std::vector<D3DRMVERTEX>& verts,
 		std::vector<D3DRMVERTEX>& d3dVerts,
 		std::vector<DWORD>& faces
 	);


### PR DESCRIPTION
They have ended up having identical memory layout and this saves us some reprocessing (at least in follow ups). If one of the backends needs the data to be reprocessed it can do so to a format that suits it rather then affecting all backends.