### PR TITLE
Turn things right side in on SDL_GPU

### DIFF
--- a/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
+++ b/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
@@ -93,7 +93,7 @@ static SDL_GPUGraphicsPipeline* InitializeGraphicsPipeline(SDL_GPUDevice* device
 	pipelineCreateInfo.depth_stencil_state.enable_depth_test = true;
 	pipelineCreateInfo.depth_stencil_state.enable_depth_write = depthWrite;
 	pipelineCreateInfo.depth_stencil_state.enable_stencil_test = false;
-	pipelineCreateInfo.depth_stencil_state.compare_op = SDL_GPU_COMPAREOP_LESS;
+	pipelineCreateInfo.depth_stencil_state.compare_op = SDL_GPU_COMPAREOP_GREATER;
 	pipelineCreateInfo.depth_stencil_state.write_mask = 0xff;
 
 	SDL_GPUGraphicsPipeline* pipeline = SDL_CreateGPUGraphicsPipeline(device, &pipelineCreateInfo);
@@ -277,7 +277,7 @@ HRESULT Direct3DRMSDL3GPURenderer::BeginFrame(const D3DRMMATRIX4D& viewMatrix)
 
 	SDL_GPUDepthStencilTargetInfo depthStencilTargetInfo = {};
 	depthStencilTargetInfo.texture = m_depthTexture;
-	depthStencilTargetInfo.clear_depth = 1.f;
+	depthStencilTargetInfo.clear_depth = 0.f;
 	depthStencilTargetInfo.load_op = SDL_GPU_LOADOP_CLEAR;
 
 	SDL_GPUCommandBuffer* cmdbuf = SDL_AcquireGPUCommandBuffer(m_device);


### PR DESCRIPTION
Currently everything looks messed up on SDL_GPU because of a mistake i made here thinking it was the norm based on an example, but apparently we are special and want to backwards: https://github.com/AJenbo/isle-portable/commit/874cc526be3752747449417e5cd81a01a0ce4b6e#diff-fdc41fd9200ca80c13ebc44c37fa2e95b90b56e492bab4ce6d2dc3054aef388eL96