### PR TITLE
Fix `MxStopWatch`

### DIFF
--- a/LEGO1/mxdirectx/mxstopwatch.h
+++ b/LEGO1/mxdirectx/mxstopwatch.h
@@ -49,7 +49,7 @@ private:
 inline MxStopWatch::MxStopWatch()
 {
 	Reset();
-	m_ticksPerSeconds = SDL_GetPerformanceCounter();
+	m_ticksPerSeconds = SDL_GetPerformanceFrequency();
 }
 
 // FUNCTION: BETA10 0x100d8be0


### PR DESCRIPTION
This actually broke the game in at least one way. Scaling up the ambient Lego pedestrians depends on the performance counter. Right now it is stuck at 5 maximum characters in the world because the counter always returns `0`, and never scales to expected values.