### PR TITLE
Upload mesh

### DIFF
--- a/miniwin/src/internal/d3drmmesh_impl.h
+++ b/miniwin/src/internal/d3drmmesh_impl.h
@@ -6,11 +6,12 @@
 #include <vector>
 
 struct MeshGroup {
-	D3DCOLOR color = 0xFFFFFFFF;
+	SDL_Color color = {0xFF, 0xFF, 0xFF, 0xFF};
 	IDirect3DRMTexture* texture = nullptr;
 	IDirect3DRMMaterial* material = nullptr;
 	D3DRMRENDERQUALITY quality = D3DRMRENDER_GOURAUD;
 	int vertexPerFace = 0;
+	int version = 0;
 	std::vector<D3DRMVERTEX> vertices;
 	std::vector<unsigned int> indices;
 

--- a/miniwin/src/internal/d3drmrenderer.h
+++ b/miniwin/src/internal/d3drmrenderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "d3drmmesh_impl.h"
 #include "mathutils.h"
 #include "miniwin/d3drm.h"
 #include "miniwin/miniwindevice.h"
@@ -35,16 +36,14 @@ public:
 	virtual void PushLights(const SceneLight* vertices, size_t count) = 0;
 	virtual void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) = 0;
 	virtual Uint32 GetTextureId(IDirect3DRMTexture* texture) = 0;
+	virtual Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) = 0;
 	virtual DWORD GetWidth() = 0;
 	virtual DWORD GetHeight() = 0;
 	virtual void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) = 0;
 	virtual const char* GetName() = 0;
 	virtual HRESULT BeginFrame(const D3DRMMATRIX4D& viewMatrix) = 0;
 	virtual void SubmitDraw(
-		const D3DRMVERTEX* vertices,
-		const size_t vertexCount,
-		const DWORD* indices,
-		const size_t indexCount,
+		DWORD meshId,
 		const D3DRMMATRIX4D& worldMatrix,
 		const Matrix3x3& normalMatrix,
 		const Appearance& appearance

--- a/miniwin/src/internal/d3drmrenderer_opengl15.h
+++ b/miniwin/src/internal/d3drmrenderer_opengl15.h
@@ -16,6 +16,16 @@ struct GLTextureCacheEntry {
 	GLuint glTextureId;
 };
 
+struct GLMeshCacheEntry {
+	const MeshGroup* meshGroup;
+	int version;
+	bool flat;
+	std::vector<D3DVECTOR> positions;
+	std::vector<D3DVECTOR> normals;
+	std::vector<TexCoord> texcoords;
+	std::vector<DWORD> indices;
+};
+
 class OpenGL15Renderer : public Direct3DRMRenderer {
 public:
 	static Direct3DRMRenderer* Create(DWORD width, DWORD height);
@@ -24,16 +34,14 @@ public:
 	void PushLights(const SceneLight* lightsArray, size_t count) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
 	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
+	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	DWORD GetWidth() override;
 	DWORD GetHeight() override;
 	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
 	const char* GetName() override;
 	HRESULT BeginFrame(const D3DRMMATRIX4D& viewMatrix) override;
 	void SubmitDraw(
-		const D3DRMVERTEX* vertices,
-		const size_t vertexCount,
-		const DWORD* indices,
-		const size_t indexCount,
+		DWORD meshId,
 		const D3DRMMATRIX4D& worldMatrix,
 		const Matrix3x3& normalMatrix,
 		const Appearance& appearance
@@ -42,7 +50,9 @@ public:
 
 private:
 	void AddTextureDestroyCallback(Uint32 id, IDirect3DRMTexture* texture);
+	void AddMeshDestroyCallback(Uint32 id, IDirect3DRMMesh* mesh);
 	std::vector<GLTextureCacheEntry> m_textures;
+	std::vector<GLMeshCacheEntry> m_meshs;
 	D3DRMMATRIX4D m_viewMatrix;
 	D3DRMMATRIX4D m_projection;
 	SDL_Surface* m_renderedImage;

--- a/miniwin/src/internal/d3drmrenderer_software.h
+++ b/miniwin/src/internal/d3drmrenderer_software.h
@@ -16,11 +16,20 @@ struct TextureCache {
 	SDL_Surface* cached;
 };
 
+struct MeshCache {
+	const MeshGroup* meshGroup;
+	int version;
+	bool flat;
+	std::vector<D3DRMVERTEX> vertices;
+	std::vector<DWORD> indices;
+};
+
 class Direct3DRMSoftwareRenderer : public Direct3DRMRenderer {
 public:
 	Direct3DRMSoftwareRenderer(DWORD width, DWORD height);
 	void PushLights(const SceneLight* vertices, size_t count) override;
 	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
+	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
 	DWORD GetWidth() override;
 	DWORD GetHeight() override;
@@ -28,10 +37,7 @@ public:
 	const char* GetName() override;
 	HRESULT BeginFrame(const D3DRMMATRIX4D& viewMatrix) override;
 	void SubmitDraw(
-		const D3DRMVERTEX* vertices,
-		const size_t vertexCount,
-		const DWORD* indices,
-		const size_t indexCount,
+		DWORD meshId,
 		const D3DRMMATRIX4D& worldMatrix,
 		const Matrix3x3& normalMatrix,
 		const Appearance& appearance
@@ -51,6 +57,7 @@ private:
 	void BlendPixel(Uint8* pixelAddr, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 	SDL_Color ApplyLighting(const D3DVECTOR& position, const D3DVECTOR& normal, const Appearance& appearance);
 	void AddTextureDestroyCallback(Uint32 id, IDirect3DRMTexture* texture);
+	void AddMeshDestroyCallback(Uint32 id, IDirect3DRMMesh* mesh);
 
 	DWORD m_width;
 	DWORD m_height;
@@ -59,6 +66,7 @@ private:
 	int m_bytesPerPixel;
 	std::vector<SceneLight> m_lights;
 	std::vector<TextureCache> m_textures;
+	std::vector<MeshCache> m_meshs;
 	D3DVALUE m_front;
 	D3DVALUE m_back;
 	D3DRMMATRIX4D m_viewMatrix;


### PR DESCRIPTION
Adds a mesh upload phase to the renderer. This allows use to pre-process the meshes once and for SDL_GPU critically upload the meshes to the GPU once.

There are still some wins that have not been implemented, notably:
- Only process lighting once in Software Renderer
- Use indicies for for triangle format in SDL_GPU

But these can come later.

Performance after this PR, all renderers now run at 90FPS:
SDL_GPU: 23% CPU load (up from ~40fps at 100% load)
OpenGL: 25% CPU load (27% previously)
Software: 82% CPU load (this seems a little higher then a few versions ago, but not by much)