### PR TITLE
Upload mesh data to GPU using VBOs when available

### DIFF
--- a/miniwin/CMakeLists.txt
+++ b/miniwin/CMakeLists.txt
@@ -29,8 +29,8 @@ add_library(miniwin STATIC EXCLUDE_FROM_ALL
 find_package(OpenGL)
 find_package(GLEW)
 if(OpenGL_FOUND AND GLEW_FOUND)
-  target_sources(miniwin PRIVATE src/d3drm/backends/opengl15/renderer.cpp)
-  target_compile_definitions(miniwin PRIVATE USE_OPENGL15)
+  target_sources(miniwin PRIVATE src/d3drm/backends/opengl1/renderer.cpp)
+  target_compile_definitions(miniwin PRIVATE USE_OPENGL1)
   # Find and link OpenGL (1.5)
   target_link_libraries(miniwin PRIVATE OpenGL::GL)
   # Glew is used for getting a FBO for off screen rendering

--- a/miniwin/src/d3drm/d3drm.cpp
+++ b/miniwin/src/d3drm/d3drm.cpp
@@ -7,8 +7,8 @@
 #include "d3drmmesh_impl.h"
 #include "d3drmobject_impl.h"
 #include "d3drmrenderer.h"
-#ifdef USE_OPENGL15
-#include "d3drmrenderer_opengl15.h"
+#ifdef USE_OPENGL1
+#include "d3drmrenderer_opengl1.h"
 #endif
 #include "d3drmrenderer_sdl3gpu.h"
 #include "d3drmrenderer_software.h"
@@ -144,9 +144,9 @@ HRESULT Direct3DRMImpl::CreateDeviceFromSurface(
 	else if (SDL_memcmp(&guid, &SOFTWARE_GUID, sizeof(GUID)) == 0) {
 		renderer = new Direct3DRMSoftwareRenderer(DDSDesc.dwWidth, DDSDesc.dwHeight);
 	}
-#ifdef USE_OPENGL15
-	else if (SDL_memcmp(&guid, &OPENGL15_GUID, sizeof(GUID)) == 0) {
-		renderer = OpenGL15Renderer::Create(DDSDesc.dwWidth, DDSDesc.dwHeight);
+#ifdef USE_OPENGL1
+	else if (SDL_memcmp(&guid, &OpenGL1_GUID, sizeof(GUID)) == 0) {
+		renderer = OpenGL1Renderer::Create(DDSDesc.dwWidth, DDSDesc.dwHeight);
 	}
 #endif
 	else {

--- a/miniwin/src/ddraw/ddraw.cpp
+++ b/miniwin/src/ddraw/ddraw.cpp
@@ -1,5 +1,5 @@
-#ifdef USE_OPENGL15
-#include "d3drmrenderer_opengl15.h"
+#ifdef USE_OPENGL1
+#include "d3drmrenderer_opengl1.h"
 #endif
 #include "d3drmrenderer_sdl3gpu.h"
 #include "d3drmrenderer_software.h"
@@ -227,8 +227,8 @@ void EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx, Direct3DRMRenderer* devi
 HRESULT DirectDrawImpl::EnumDevices(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
 	Direct3DRMSDL3GPU_EnumDevice(cb, ctx);
-#ifdef USE_OPENGL15
-	OpenGL15Renderer_EnumDevice(cb, ctx);
+#ifdef USE_OPENGL1
+	OpenGL1Renderer_EnumDevice(cb, ctx);
 #endif
 	Direct3DRMSoftware_EnumDevice(cb, ctx);
 
@@ -321,9 +321,9 @@ HRESULT DirectDrawImpl::CreateDevice(
 	if (SDL_memcmp(&guid, &SDL3_GPU_GUID, sizeof(GUID)) == 0) {
 		renderer = Direct3DRMSDL3GPURenderer::Create(DDSDesc.dwWidth, DDSDesc.dwHeight);
 	}
-#ifdef USE_OPENGL15
-	else if (SDL_memcmp(&guid, &OPENGL15_GUID, sizeof(GUID)) == 0) {
-		renderer = OpenGL15Renderer::Create(DDSDesc.dwWidth, DDSDesc.dwHeight);
+#ifdef USE_OPENGL1
+	else if (SDL_memcmp(&guid, &OpenGL1_GUID, sizeof(GUID)) == 0) {
+		renderer = OpenGL1Renderer::Create(DDSDesc.dwWidth, DDSDesc.dwHeight);
 	}
 #endif
 	else if (SDL_memcmp(&guid, &SOFTWARE_GUID, sizeof(GUID)) == 0) {

--- a/miniwin/src/internal/d3drmrenderer_opengl1.h
+++ b/miniwin/src/internal/d3drmrenderer_opengl1.h
@@ -8,7 +8,7 @@
 #include <SDL3/SDL.h>
 #include <vector>
 
-DEFINE_GUID(OPENGL15_GUID, 0x682656F3, 0x0000, 0x0000, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03);
+DEFINE_GUID(OpenGL1_GUID, 0x682656F3, 0x0000, 0x0000, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03);
 
 struct GLTextureCacheEntry {
 	IDirect3DRMTexture* texture;
@@ -20,17 +20,25 @@ struct GLMeshCacheEntry {
 	const MeshGroup* meshGroup;
 	int version;
 	bool flat;
+
+	// non-VBO cache
 	std::vector<D3DVECTOR> positions;
 	std::vector<D3DVECTOR> normals;
 	std::vector<TexCoord> texcoords;
 	std::vector<DWORD> indices;
+
+	// VBO cache
+	GLuint vboPositions;
+	GLuint vboNormals;
+	GLuint vboTexcoords;
+	GLuint ibo;
 };
 
-class OpenGL15Renderer : public Direct3DRMRenderer {
+class OpenGL1Renderer : public Direct3DRMRenderer {
 public:
 	static Direct3DRMRenderer* Create(DWORD width, DWORD height);
-	OpenGL15Renderer(int width, int height, SDL_GLContext context, GLuint fbo, GLuint colorTex, GLuint depthRb);
-	~OpenGL15Renderer() override;
+	OpenGL1Renderer(int width, int height, SDL_GLContext context, GLuint fbo, GLuint colorTex, GLuint depthRb);
+	~OpenGL1Renderer() override;
 	void PushLights(const SceneLight* lightsArray, size_t count) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
 	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
@@ -57,6 +65,7 @@ private:
 	D3DRMMATRIX4D m_projection;
 	SDL_Surface* m_renderedImage;
 	int m_width, m_height;
+	bool m_useVBOs;
 	std::vector<SceneLight> m_lights;
 	SDL_GLContext m_context;
 	GLuint m_fbo = 0;
@@ -64,11 +73,11 @@ private:
 	GLuint m_depthRb = 0;
 };
 
-inline static void OpenGL15Renderer_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
+inline static void OpenGL1Renderer_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
-	Direct3DRMRenderer* device = OpenGL15Renderer::Create(640, 480);
+	Direct3DRMRenderer* device = OpenGL1Renderer::Create(640, 480);
 	if (device) {
-		EnumDevice(cb, ctx, device, OPENGL15_GUID);
+		EnumDevice(cb, ctx, device, OpenGL1_GUID);
 		delete device;
 	}
 }


### PR DESCRIPTION
CPU load is now down to 24% so very close to SDL_GPU:Vulkan.

This should be the last of the OpenGL 1.x related optimizations. VBO is a 1.5 feature, there are some later features.

Display lists could be used to further improve performance on systems that lack VBO, but lets wait till someone finds one to test current performance one, it seems using display lists is a bit less compatible and more messy to implement.

The class is renamed from OpenGL15 to OpenGL1 since it should work just fine on OpenGL 1.2, the only blocker for OpenGL 1.1 is setting the texture format to GL_RGBA8 instead of GL_RGBA which ensures that it interacts correctly with CPU access to the pixels. 1.0 might work with how things where in f3a4d8fcb5d26c505d9eab9181b72c496896433f which should be doable as an option, but without a way to verify things I don't think it's work keeping it around.

This also does a check for the FBO extension before trying to use it.

No mip-mapping is implemented but this is general for all backends, texture compression hasn't been explored either.