### PR TITLE
Align cache destruction callback in software renderer

### DIFF
--- a/miniwin/src/d3drm/backends/software/renderer.cpp
+++ b/miniwin/src/d3drm/backends/software/renderer.cpp
@@ -436,18 +436,18 @@ void Direct3DRMSoftwareRenderer::DrawTriangleProjected(
 	}
 }
 
-struct TextureDestroyContext {
+struct CacheDestroyContext {
 	Direct3DRMSoftwareRenderer* renderer;
-	Uint32 textureId;
+	Uint32 id;
 };
 
 void Direct3DRMSoftwareRenderer::AddTextureDestroyCallback(Uint32 id, IDirect3DRMTexture* texture)
 {
-	auto* ctx = new TextureDestroyContext{this, id};
+	auto* ctx = new CacheDestroyContext{this, id};
 	texture->AddDestroyCallback(
 		[](IDirect3DRMObject* obj, void* arg) {
-			auto* ctx = static_cast<TextureDestroyContext*>(arg);
-			auto& cacheEntry = ctx->renderer->m_textures[ctx->textureId];
+			auto* ctx = static_cast<CacheDestroyContext*>(arg);
+			auto& cacheEntry = ctx->renderer->m_textures[ctx->id];
 			if (cacheEntry.cached) {
 				SDL_UnlockSurface(cacheEntry.cached);
 				SDL_DestroySurface(cacheEntry.cached);
@@ -525,18 +525,18 @@ MeshCache UploadMesh(const MeshGroup& meshGroup)
 	return cache;
 }
 
-struct MeshDestroyContext {
-	Direct3DRMSoftwareRenderer* renderer;
-	Uint32 id;
-};
-
 void Direct3DRMSoftwareRenderer::AddMeshDestroyCallback(Uint32 id, IDirect3DRMMesh* mesh)
 {
-	auto* ctx = new MeshDestroyContext{this, id};
+	auto* ctx = new CacheDestroyContext{this, id};
 	mesh->AddDestroyCallback(
-		[](IDirect3DRMObject*, void* arg) {
-			auto* ctx = static_cast<MeshDestroyContext*>(arg);
-			ctx->renderer->m_meshs[ctx->id].meshGroup = nullptr;
+		[](IDirect3DRMObject* obj, void* arg) {
+			auto* ctx = static_cast<CacheDestroyContext*>(arg);
+			auto& cacheEntry = ctx->renderer->m_meshs[ctx->id];
+			if (cacheEntry.meshGroup) {
+				cacheEntry.meshGroup = nullptr;
+				cacheEntry.vertices.clear();
+				cacheEntry.indices.clear();
+			}
 			delete ctx;
 		},
 		ctx


### PR DESCRIPTION
This tries to address https://github.com/isledecomp/isle-portable/issues/279 and if not then at least help narrow the possible issues down. It makes sure to make the same validation checks as was done for textures