### PR TITLE
Fix Infocenter -> Act2/Act3 switch

### DIFF
--- a/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/infocenter.cpp
@@ -273,7 +273,11 @@ MxLong Infocenter::Notify(MxParam& p_param)
 			else if (m_destLocation != 0) {
 				BackgroundAudioManager()->RaiseVolume();
 				GameState()->SwitchArea(m_destLocation);
-				m_destLocation = LegoGameState::e_undefined;
+
+				if (GameState()->m_currentArea != LegoGameState::e_act2main &&
+					GameState()->m_currentArea != LegoGameState::e_act3script) {
+					m_destLocation = LegoGameState::e_undefined;
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
Both Act2 and Act3 delete the Infocenter world when enabled. Infocenter cannot set `m_destLocation` to `undefined` anymore in these cases, since `this` has been deleted.

Close #281