### PR TITLE
Remove screen mode restrictions and related code

### DIFF
--- a/LEGO1/mxdirectx/legodxinfo.cpp
+++ b/LEGO1/mxdirectx/legodxinfo.cpp
@@ -284,11 +284,6 @@ int LegoDeviceEnumerate::FUN_1009d210()
 	}
 
 	for (list<MxDriver>::iterator it = m_list.begin(); it != m_list.end();) {
-		if (!DriverSupportsRequiredDisplayMode(*it)) {
-			m_list.erase(it++);
-			continue;
-		}
-
 		MxDriver& driver = *it;
 
 		for (list<Direct3DDeviceInfo>::iterator it2 = driver.m_devices.begin(); it2 != driver.m_devices.end();) {
@@ -313,23 +308,6 @@ int LegoDeviceEnumerate::FUN_1009d210()
 	}
 
 	return 0;
-}
-
-// FUNCTION: CONFIG 0x00402b00
-// FUNCTION: LEGO1 0x1009d370
-// FUNCTION: BETA10 0x1011d176
-unsigned char LegoDeviceEnumerate::DriverSupportsRequiredDisplayMode(MxDriver& p_driver)
-{
-	for (list<MxDisplayMode>::iterator it = p_driver.m_displayModes.begin(); it != p_driver.m_displayModes.end();
-		 it++) {
-		if ((*it).m_width == 640 && (*it).m_height == 480) {
-			if ((*it).m_bitsPerPixel == 8 || (*it).m_bitsPerPixel == 16) {
-				return TRUE;
-			}
-		}
-	}
-
-	return FALSE;
 }
 
 // FUNCTION: CONFIG 0x00402b60

--- a/LEGO1/mxdirectx/legodxinfo.h
+++ b/LEGO1/mxdirectx/legodxinfo.h
@@ -18,7 +18,6 @@ public:
 	static bool SupportsSIMD();
 	static bool SupportsCPUID();
 	int FUN_1009d210();
-	unsigned char DriverSupportsRequiredDisplayMode(MxDriver& p_driver);
 	unsigned char FUN_1009d3d0(Direct3DDeviceInfo& p_device);
 
 	// SYNTHETIC: BETA10 0x100d8d10

--- a/LEGO1/mxdirectx/mxdirect3d.cpp
+++ b/LEGO1/mxdirectx/mxdirect3d.cpp
@@ -167,14 +167,6 @@ BOOL MxDirect3D::D3DSetMode()
 	}
 
 	DeviceModesInfo::Mode mode = *CurrentMode();
-
-	if (IsFullScreen()) {
-		if (!IsSupportedMode(mode.width, mode.height, mode.bitsPerPixel)) {
-			Error("This device cannot support the current display mode", DDERR_GENERIC);
-			return FALSE;
-		}
-	}
-
 	LPDIRECTDRAWSURFACE frontBuffer = FrontBuffer();
 	LPDIRECTDRAWSURFACE backBuffer = BackBuffer();
 
@@ -275,21 +267,6 @@ BOOL MxDirect3D::SetDevice(MxDeviceEnumerate& p_deviceEnumerate, MxDriver* p_dri
 			if (driver.m_guid) {
 				d->m_deviceInfo->m_guid = new GUID;
 				*d->m_deviceInfo->m_guid = *driver.m_guid;
-			}
-
-			d->m_deviceInfo->m_count = driver.m_displayModes.size();
-
-			if (d->m_deviceInfo->m_count > 0) {
-				int j = 0;
-				d->m_deviceInfo->m_modeArray = new DeviceModesInfo::Mode[d->m_deviceInfo->m_count];
-
-				for (list<MxDisplayMode>::iterator it2 = driver.m_displayModes.begin();
-					 it2 != driver.m_displayModes.end();
-					 it2++, j++) {
-					d->m_deviceInfo->m_modeArray[j].width = (*it2).m_width;
-					d->m_deviceInfo->m_modeArray[j].height = (*it2).m_height;
-					d->m_deviceInfo->m_modeArray[j].bitsPerPixel = (*it2).m_bitsPerPixel;
-				}
 			}
 
 			d->m_deviceInfo->m_ddcaps = driver.m_ddCaps;

--- a/LEGO1/mxdirectx/mxdirectdraw.cpp
+++ b/LEGO1/mxdirectx/mxdirectdraw.cpp
@@ -283,23 +283,6 @@ BOOL MxDirectDraw::DDInit(BOOL fullscreen)
 	return TRUE;
 }
 
-// FUNCTION: LEGO1 0x1009d9d0
-// FUNCTION: BETA10 0x10120e45
-BOOL MxDirectDraw::IsSupportedMode(int width, int height, int bpp)
-{
-	DeviceModesInfo::Mode mode = {width, height, bpp};
-
-	assert(m_currentDevInfo);
-
-	for (int i = 0; i < m_currentDevInfo->m_count; i++) {
-		if (m_currentDevInfo->m_modeArray[i] == mode) {
-			return TRUE;
-		}
-	}
-
-	return FALSE;
-}
-
 // FUNCTION: LEGO1 0x1009da20
 // FUNCTION: BETA10 0x10120efb
 void EnableResizing(HWND p_hwnd, BOOL p_flag)
@@ -338,12 +321,6 @@ BOOL MxDirectDraw::DDSetMode(int width, int height, int bpp)
 			}
 		}
 #endif
-
-		if (!IsSupportedMode(width, height, bpp)) {
-			width = m_currentDevInfo->m_modeArray[0].width;
-			height = m_currentDevInfo->m_modeArray[0].height;
-			bpp = m_currentDevInfo->m_modeArray[0].bitsPerPixel;
-		}
 
 		m_bIgnoreWMSIZE = TRUE;
 		result = m_pDirectDraw->SetDisplayMode(width, height, bpp);

--- a/LEGO1/mxdirectx/mxdirectdraw.h
+++ b/LEGO1/mxdirectx/mxdirectdraw.h
@@ -55,8 +55,6 @@ public:
 	// FUNCTION: BETA10 0x1011c170
 	BOOL IsFullScreen() { return m_bFullScreen; }
 
-	BOOL IsSupportedMode(int width, int height, int bpp);
-
 	int Pause(BOOL);
 	BOOL RestoreSurfaces();
 

--- a/LEGO1/mxdirectx/mxdirectxinfo.cpp
+++ b/LEGO1/mxdirectx/mxdirectxinfo.cpp
@@ -216,7 +216,6 @@ BOOL MxDeviceEnumerate::EnumDirectDrawCallback(LPGUID p_guid, LPSTR p_driverDesc
 		BuildErrorString("DirectDraw Create failed: %s\n", EnumerateErrorToString(result));
 	}
 	else {
-		lpDD->EnumDisplayModes(0, NULL, this, DisplayModesEnumerateCallback);
 		newDevice.m_ddCaps.dwSize = sizeof(newDevice.m_ddCaps);
 		result = lpDD->GetCaps(&newDevice.m_ddCaps, NULL);
 
@@ -267,18 +266,6 @@ void MxDeviceEnumerate::BuildErrorString(const char* p_format, ...)
 	va_end(args);
 }
 
-// FUNCTION: CONFIG 0x00401bf0
-// FUNCTION: LEGO1 0x1009c4f0
-// FUNCTION: BETA10 0x1011e1dd
-HRESULT CALLBACK MxDeviceEnumerate::DisplayModesEnumerateCallback(LPDDSURFACEDESC p_ddsd, LPVOID p_context)
-{
-	if (p_context == NULL) {
-		assert(0);
-	}
-
-	return ((MxDeviceEnumerate*) p_context)->EnumDisplayModesCallback(p_ddsd);
-}
-
 // FUNCTION: CONFIG 0x00401c10
 // FUNCTION: LEGO1 0x1009c510
 // FUNCTION: BETA10 0x1011e226
@@ -297,20 +284,6 @@ HRESULT CALLBACK MxDeviceEnumerate::DevicesEnumerateCallback(
 
 	return ((MxDeviceEnumerate*) p_context)
 		->EnumDevicesCallback(p_guid, p_deviceDesc, p_deviceName, p_HWDesc, p_HELDesc);
-}
-
-// FUNCTION: CONFIG 0x00401c40
-// FUNCTION: LEGO1 0x1009c540
-// FUNCTION: BETA10 0x1011e27f
-HRESULT MxDeviceEnumerate::EnumDisplayModesCallback(LPDDSURFACEDESC p_ddsd)
-{
-	assert(m_list.size() > 0);
-	assert(p_ddsd);
-
-	// TODO: compat_mode?
-	MxDisplayMode displayMode(p_ddsd->dwWidth, p_ddsd->dwHeight, p_ddsd->ddpfPixelFormat.dwRGBBitCount);
-	m_list.back().m_displayModes.push_back(displayMode);
-	return DDENUMRET_OK;
 }
 
 // FUNCTION: CONFIG 0x00401cd0
@@ -581,9 +554,5 @@ DeviceModesInfo::~DeviceModesInfo()
 {
 	if (m_guid != NULL) {
 		delete m_guid;
-	}
-
-	if (m_modeArray != NULL) {
-		delete[] m_modeArray;
 	}
 }

--- a/LEGO1/mxdirectx/mxdirectxinfo.h
+++ b/LEGO1/mxdirectx/mxdirectxinfo.h
@@ -28,11 +28,10 @@ struct DeviceModesInfo {
 	DeviceModesInfo();
 	~DeviceModesInfo();
 
-	GUID* m_guid;      // 0x00
-	Mode* m_modeArray; // 0x04
-	int m_count;       // 0x08
-	DDCAPS m_ddcaps;   // 0x0c
-	void* m_unk0x178;  // 0x178
+	GUID* m_guid;     // 0x00
+	int m_count;      // 0x08
+	DDCAPS m_ddcaps;  // 0x0c
+	void* m_unk0x178; // 0x178
 
 	// SYNTHETIC: BETA10 0x1011c650
 	// DeviceModesInfo::`scalar deleting destructor'
@@ -128,7 +127,6 @@ struct MxDriver {
 	char* m_driverName;                 // 0x08
 	DDCAPS m_ddCaps;                    // 0x0c
 	list<Direct3DDeviceInfo> m_devices; // 0x178
-	list<MxDisplayMode> m_displayModes; // 0x184
 
 	int operator==(MxDriver) const { return 0; }
 	int operator<(MxDriver) const { return 0; }
@@ -199,7 +197,6 @@ public:
 	virtual int DoEnumerate(); // vtable+0x00
 
 	BOOL EnumDirectDrawCallback(LPGUID p_guid, LPSTR p_driverDesc, LPSTR p_driverName);
-	HRESULT EnumDisplayModesCallback(LPDDSURFACEDESC p_ddsd);
 	HRESULT EnumDevicesCallback(
 		LPGUID p_guid,
 		LPCSTR p_deviceDesc,
@@ -211,7 +208,6 @@ public:
 	static void BuildErrorString(const char*, ...);
 	static BOOL CALLBACK
 	DirectDrawEnumerateCallback(LPGUID p_guid, LPSTR p_driverDesc, LPSTR p_driverName, LPVOID p_context);
-	static HRESULT CALLBACK DisplayModesEnumerateCallback(LPDDSURFACEDESC p_ddsd, LPVOID p_context);
 	static HRESULT CALLBACK DevicesEnumerateCallback(
 		LPGUID p_guid,
 		LPSTR p_deviceDesc,


### PR DESCRIPTION
With https://github.com/isledecomp/isle-portable/pull/290 there is no real point to the resolution restrictions as it uses the desktop mode and simply upscales the image to what ever your system is currently running.

Even for low spec systems where up-scaling isn't viable the code probably isn't needed and instead the window should just be created in full screen exclusive mode. The existing code is problematic on many modern systems that do not support running in 640x480 so not much point in keeping it in any case.