### PR TITLE
Early culling

### DIFF
--- a/miniwin/include/miniwin/d3drm.h
+++ b/miniwin/include/miniwin/d3drm.h
@@ -145,10 +145,10 @@ struct D3DRMVERTEX {
 	D3DVECTOR position;
 	D3DVECTOR normal;
 	union {
+		TexCoord texCoord;
 		struct {
 			D3DVALUE tu, tv;
 		};
-		TexCoord texCoord;
 	};
 };
 

--- a/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
+++ b/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
@@ -355,6 +355,10 @@ void Direct3DRMSDL3GPURenderer::PushLights(const SceneLight* vertices, size_t co
 	m_fragmentShadingData.lightCount = count;
 }
 
+void Direct3DRMSDL3GPURenderer::SetFrustumPlanes(const Plane* frustumPlanes)
+{
+}
+
 void Direct3DRMSDL3GPURenderer::SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back)
 {
 	m_front = front;
@@ -507,7 +511,7 @@ SDL3MeshCache Direct3DRMSDL3GPURenderer::UploadMesh(const MeshGroup& meshGroup)
 	std::vector<Uint16> finalIndices;
 
 	if (meshGroup.quality == D3DRMRENDER_FLAT || meshGroup.quality == D3DRMRENDER_UNLITFLAT) {
-		std::vector<DWORD> newIndices;
+		std::vector<uint16_t> newIndices;
 		FlattenSurfaces(
 			meshGroup.vertices.data(),
 			meshGroup.vertices.size(),
@@ -703,13 +707,11 @@ SDL_GPUTransferBuffer* Direct3DRMSDL3GPURenderer::GetUploadBuffer(size_t size)
 	return m_uploadBuffer;
 }
 
-HRESULT Direct3DRMSDL3GPURenderer::BeginFrame(const D3DRMMATRIX4D& viewMatrix)
+HRESULT Direct3DRMSDL3GPURenderer::BeginFrame()
 {
 	if (!DDBackBuffer) {
 		return DDERR_GENERIC;
 	}
-
-	memcpy(&m_viewMatrix, viewMatrix, sizeof(D3DRMMATRIX4D));
 
 	// Clear color and depth targets
 	SDL_GPUColorTargetInfo colorTargetInfo = {};
@@ -742,14 +744,12 @@ void Direct3DRMSDL3GPURenderer::EnableTransparency()
 
 void Direct3DRMSDL3GPURenderer::SubmitDraw(
 	DWORD meshId,
-	const D3DRMMATRIX4D& worldMatrix,
+	const D3DRMMATRIX4D& modelViewMatrix,
 	const Matrix3x3& normalMatrix,
 	const Appearance& appearance
 )
 {
-	D3DRMMATRIX4D worldViewMatrix;
-	MultiplyMatrix(worldViewMatrix, worldMatrix, m_viewMatrix);
-	memcpy(&m_uniforms.worldViewMatrix, worldViewMatrix, sizeof(D3DRMMATRIX4D));
+	memcpy(&m_uniforms.worldViewMatrix, modelViewMatrix, sizeof(D3DRMMATRIX4D));
 	PackNormalMatrix(normalMatrix, m_uniforms.normalMatrix);
 	m_fragmentShadingData.color = appearance.color;
 	m_fragmentShadingData.shininess = appearance.shininess;

--- a/miniwin/src/ddraw/ddsurface.cpp
+++ b/miniwin/src/ddraw/ddsurface.cpp
@@ -173,9 +173,20 @@ HRESULT DirectDrawSurfaceImpl::Flip(LPDIRECTDRAWSURFACE lpDDSurfaceTargetOverrid
 		return DDERR_GENERIC;
 	}
 
-	SDL_Surface* copy = SDL_ConvertSurface(DDBackBuffer, HWBackBufferFormat);
-	SDL_UpdateTexture(HWBackBuffer, nullptr, copy->pixels, copy->pitch);
-	SDL_DestroySurface(copy);
+	SDL_Surface* blitSource;
+	if (HWBackBufferFormat != DDBackBuffer->format) {
+		blitSource = SDL_ConvertSurface(DDBackBuffer, HWBackBufferFormat);
+		if (!blitSource) {
+			return DDERR_GENERIC;
+		}
+	}
+	else {
+		blitSource = DDBackBuffer;
+	}
+	SDL_UpdateTexture(HWBackBuffer, nullptr, blitSource->pixels, blitSource->pitch);
+	if (HWBackBufferFormat != DDBackBuffer->format) {
+		SDL_DestroySurface(blitSource);
+	}
 	SDL_RenderTexture(DDRenderer, HWBackBuffer, nullptr, nullptr);
 	SDL_RenderPresent(DDRenderer);
 	return DD_OK;

--- a/miniwin/src/internal/d3drmmesh_impl.h
+++ b/miniwin/src/internal/d3drmmesh_impl.h
@@ -13,7 +13,7 @@ struct MeshGroup {
 	int vertexPerFace = 0;
 	int version = 0;
 	std::vector<D3DRMVERTEX> vertices;
-	std::vector<unsigned int> indices;
+	std::vector<DWORD> indices;
 
 	MeshGroup() = default;
 

--- a/miniwin/src/internal/d3drmrenderer.h
+++ b/miniwin/src/internal/d3drmrenderer.h
@@ -31,23 +31,29 @@ struct SceneLight {
 };
 static_assert(sizeof(SceneLight) == 48);
 
+struct Plane {
+	D3DVECTOR normal;
+	float d;
+};
+
 extern SDL_Renderer* DDRenderer;
 
 class Direct3DRMRenderer : public IDirect3DDevice2 {
 public:
 	virtual void PushLights(const SceneLight* vertices, size_t count) = 0;
 	virtual void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) = 0;
+	virtual void SetFrustumPlanes(const Plane* frustumPlanes) = 0;
 	virtual Uint32 GetTextureId(IDirect3DRMTexture* texture) = 0;
 	virtual Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) = 0;
 	virtual DWORD GetWidth() = 0;
 	virtual DWORD GetHeight() = 0;
 	virtual void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) = 0;
 	virtual const char* GetName() = 0;
-	virtual HRESULT BeginFrame(const D3DRMMATRIX4D& viewMatrix) = 0;
+	virtual HRESULT BeginFrame() = 0;
 	virtual void EnableTransparency() = 0;
 	virtual void SubmitDraw(
 		DWORD meshId,
-		const D3DRMMATRIX4D& worldMatrix,
+		const D3DRMMATRIX4D& modelViewMatrix,
 		const Matrix3x3& normalMatrix,
 		const Appearance& appearance
 	) = 0;

--- a/miniwin/src/internal/d3drmrenderer_opengl1.h
+++ b/miniwin/src/internal/d3drmrenderer_opengl1.h
@@ -25,7 +25,7 @@ struct GLMeshCacheEntry {
 	std::vector<D3DVECTOR> positions;
 	std::vector<D3DVECTOR> normals;
 	std::vector<TexCoord> texcoords;
-	std::vector<DWORD> indices;
+	std::vector<uint16_t> indices;
 
 	// VBO cache
 	GLuint vboPositions;
@@ -41,17 +41,18 @@ public:
 	~OpenGL1Renderer() override;
 	void PushLights(const SceneLight* lightsArray, size_t count) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
+	void SetFrustumPlanes(const Plane* frustumPlanes) override;
 	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	DWORD GetWidth() override;
 	DWORD GetHeight() override;
 	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
 	const char* GetName() override;
-	HRESULT BeginFrame(const D3DRMMATRIX4D& viewMatrix) override;
+	HRESULT BeginFrame() override;
 	void EnableTransparency() override;
 	void SubmitDraw(
 		DWORD meshId,
-		const D3DRMMATRIX4D& worldMatrix,
+		const D3DRMMATRIX4D& modelViewMatrix,
 		const Matrix3x3& normalMatrix,
 		const Appearance& appearance
 	) override;
@@ -62,7 +63,6 @@ private:
 	void AddMeshDestroyCallback(Uint32 id, IDirect3DRMMesh* mesh);
 	std::vector<GLTextureCacheEntry> m_textures;
 	std::vector<GLMeshCacheEntry> m_meshs;
-	D3DRMMATRIX4D m_viewMatrix;
 	D3DRMMATRIX4D m_projection;
 	SDL_Surface* m_renderedImage;
 	int m_width, m_height;

--- a/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
+++ b/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
@@ -50,15 +50,16 @@ public:
 	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
+	void SetFrustumPlanes(const Plane* frustumPlanes) override;
 	DWORD GetWidth() override;
 	DWORD GetHeight() override;
 	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
 	const char* GetName() override;
-	HRESULT BeginFrame(const D3DRMMATRIX4D& viewMatrix) override;
+	HRESULT BeginFrame() override;
 	void EnableTransparency() override;
 	void SubmitDraw(
 		DWORD meshId,
-		const D3DRMMATRIX4D& worldMatrix,
+		const D3DRMMATRIX4D& modelViewMatrix,
 		const Matrix3x3& normalMatrix,
 		const Appearance& appearance
 	) override;
@@ -91,7 +92,6 @@ private:
 	ViewportUniforms m_uniforms;
 	FragmentShadingData m_fragmentShadingData;
 	D3DDEVICEDESC m_desc;
-	D3DRMMATRIX4D m_viewMatrix;
 	std::vector<SDL3TextureCache> m_textures;
 	std::vector<SDL3MeshCache> m_meshs;
 	SDL_GPUDevice* m_device;

--- a/miniwin/src/internal/d3drmrenderer_software.h
+++ b/miniwin/src/internal/d3drmrenderer_software.h
@@ -21,7 +21,7 @@ struct MeshCache {
 	int version;
 	bool flat;
 	std::vector<D3DRMVERTEX> vertices;
-	std::vector<DWORD> indices;
+	std::vector<uint16_t> indices;
 };
 
 class Direct3DRMSoftwareRenderer : public Direct3DRMRenderer {
@@ -31,15 +31,16 @@ public:
 	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
+	void SetFrustumPlanes(const Plane* frustumPlanes) override;
 	DWORD GetWidth() override;
 	DWORD GetHeight() override;
 	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
 	const char* GetName() override;
-	HRESULT BeginFrame(const D3DRMMATRIX4D& viewMatrix) override;
+	HRESULT BeginFrame() override;
 	void EnableTransparency() override;
 	void SubmitDraw(
 		DWORD meshId,
-		const D3DRMMATRIX4D& worldMatrix,
+		const D3DRMMATRIX4D& modelViewMatrix,
 		const Matrix3x3& normalMatrix,
 		const Appearance& appearance
 	) override;
@@ -54,7 +55,7 @@ private:
 		const Appearance& appearance
 	);
 	void DrawTriangleClipped(const D3DRMVERTEX (&v)[3], const Appearance& appearance);
-	void ProjectVertex(const D3DRMVERTEX& v, D3DRMVECTOR4D& p) const;
+	void ProjectVertex(const D3DVECTOR& v, D3DRMVECTOR4D& p) const;
 	Uint32 BlendPixel(Uint8* pixelAddr, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 	SDL_Color ApplyLighting(const D3DVECTOR& position, const D3DVECTOR& normal, const Appearance& appearance);
 	void AddTextureDestroyCallback(Uint32 id, IDirect3DRMTexture* texture);
@@ -70,9 +71,11 @@ private:
 	std::vector<MeshCache> m_meshs;
 	D3DVALUE m_front;
 	D3DVALUE m_back;
-	D3DRMMATRIX4D m_viewMatrix;
+	Matrix3x3 m_normalMatrix;
 	D3DRMMATRIX4D m_projection;
 	std::vector<float> m_zBuffer;
+	std::vector<D3DRMVERTEX> m_transformedVerts;
+	Plane m_frustumPlanes[6];
 };
 
 inline static void Direct3DRMSoftware_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)

--- a/miniwin/src/internal/d3drmviewport_impl.h
+++ b/miniwin/src/internal/d3drmviewport_impl.h
@@ -9,7 +9,7 @@
 
 struct DeferredDrawCommand {
 	DWORD meshId;
-	D3DRMMATRIX4D worldMatrix;
+	D3DRMMATRIX4D modelViewMatrix;
 	Matrix3x3 normalMatrix;
 	Appearance appearance;
 	float depth;
@@ -47,6 +47,7 @@ private:
 	HRESULT RenderScene();
 	void CollectLightsFromFrame(IDirect3DRMFrame* frame, D3DRMMATRIX4D parentMatrix, std::vector<SceneLight>& lights);
 	void CollectMeshesFromFrame(IDirect3DRMFrame* frame, D3DRMMATRIX4D parentMatrix);
+	void BuildViewFrustumPlanes();
 	void UpdateProjectionMatrix();
 	Direct3DRMRenderer* m_renderer;
 	std::vector<DeferredDrawCommand> m_deferredDraws;
@@ -62,6 +63,7 @@ private:
 	D3DVALUE m_front = 1.f;
 	D3DVALUE m_back = 10.f;
 	D3DVALUE m_field = 0.5f;
+	Plane m_frustumPlanes[6];
 };
 
 struct Direct3DRMViewportArrayImpl

--- a/miniwin/src/internal/meshutils.cpp
+++ b/miniwin/src/internal/meshutils.cpp
@@ -43,7 +43,7 @@ void FlattenSurfaces(
 	const size_t indexCount,
 	bool hasTexture,
 	std::vector<D3DRMVERTEX>& dedupedVertices,
-	std::vector<DWORD>& newIndices
+	std::vector<uint16_t>& newIndices
 )
 {
 	std::unordered_map<D3DRMVERTEX, DWORD> uniqueVertexMap;

--- a/miniwin/src/internal/meshutils.h
+++ b/miniwin/src/internal/meshutils.h
@@ -11,5 +11,5 @@ void FlattenSurfaces(
 	const size_t indexCount,
 	bool hasTexture,
 	std::vector<D3DRMVERTEX>& dedupedVertices,
-	std::vector<DWORD>& newIndices
+	std::vector<uint16_t>& newIndices
 );


### PR DESCRIPTION
The idea here is to cull all vertices early in view space so that can avoid having to reprocess all vertices for every triangle and instead take advantage of them being indexed so vertices are only processed once and only when visible.

This improves performance by maybe 2% so honestly not a lot, but it does make it more feasible to do multi threaded rasterization.

Originally I also intended to only calculate lighting per plane for flat shading, but it doesn't seem it will be a meaningful performance increase so I left it at once per triangle like before.

Indecies are now also uint16_t like they are on SDL_GPU so things takes up a bit less memory.

Update: I tested out multi threading on top of this, I was able to get good, but not stable performance with 2-6 threads. So I won't be pushing further in that direction. Please only merge this after testing performance on your system and if you think the changes make sens. I do think there are over all improvements to this PR both for software and the other renderers.