### PR TITLE
Implement some minor functions in miniwin

### DIFF
--- a/miniwin/include/miniwin/d3drm.h
+++ b/miniwin/include/miniwin/d3drm.h
@@ -318,7 +318,7 @@ struct IDirect3DRMDevice : virtual public IDirect3DRMObject {
 	virtual HRESULT SetBufferCount(int count) = 0;
 	virtual DWORD GetBufferCount() = 0;
 	virtual HRESULT SetShades(DWORD shadeCount) = 0;
-	virtual HRESULT GetShades() = 0;
+	virtual DWORD GetShades() = 0;
 	virtual HRESULT SetQuality(D3DRMRENDERQUALITY quality) = 0;
 	virtual D3DRMRENDERQUALITY GetQuality() = 0;
 	virtual HRESULT SetDither(BOOL dither) = 0;

--- a/miniwin/include/miniwin/ddraw.h
+++ b/miniwin/include/miniwin/ddraw.h
@@ -252,6 +252,7 @@ struct DDPIXELFORMAT {
 	DWORD dwRBitMask;    // Red bit mask (0xF800)
 	DWORD dwGBitMask;    // Green bit mask (0x07E0)
 	DWORD dwBBitMask;    // Blue bit mask (0x001F)
+	DWORD dwRGBAlphaBitMask;
 };
 typedef struct DDPIXELFORMAT* LPDDPIXELFORMAT;
 

--- a/miniwin/src/d3drm/d3drmdevice.cpp
+++ b/miniwin/src/d3drm/d3drmdevice.cpp
@@ -67,31 +67,35 @@ DWORD Direct3DRMDevice2Impl::GetBufferCount()
 
 HRESULT Direct3DRMDevice2Impl::SetShades(DWORD shadeCount)
 {
-	MINIWIN_NOT_IMPLEMENTED();
+	if (shadeCount != 256) {
+		MINIWIN_NOT_IMPLEMENTED();
+	}
 	return DD_OK;
 }
 
-HRESULT Direct3DRMDevice2Impl::GetShades()
+DWORD Direct3DRMDevice2Impl::GetShades()
 {
-	MINIWIN_NOT_IMPLEMENTED();
-	return DD_OK;
+	return 256;
 }
 
 HRESULT Direct3DRMDevice2Impl::SetQuality(D3DRMRENDERQUALITY quality)
 {
-	MINIWIN_NOT_IMPLEMENTED();
+	if (quality != D3DRMRENDER_GOURAUD && quality != D3DRMRENDER_PHONG) {
+		MINIWIN_NOT_IMPLEMENTED();
+	}
 	return DD_OK;
 }
 
 D3DRMRENDERQUALITY Direct3DRMDevice2Impl::GetQuality()
 {
-	MINIWIN_NOT_IMPLEMENTED();
 	return D3DRMRENDERQUALITY::GOURAUD;
 }
 
 HRESULT Direct3DRMDevice2Impl::SetDither(BOOL dither)
 {
-	MINIWIN_NOT_IMPLEMENTED();
+	if (dither) {
+		MINIWIN_NOT_IMPLEMENTED();
+	}
 	return DD_OK;
 }
 

--- a/miniwin/src/ddraw/ddraw.cpp
+++ b/miniwin/src/ddraw/ddraw.cpp
@@ -182,6 +182,7 @@ HRESULT DirectDrawImpl::EnumDisplayModes(
 		ddsd.ddpfPixelFormat.dwRBitMask = details->Rmask;
 		ddsd.ddpfPixelFormat.dwGBitMask = details->Gmask;
 		ddsd.ddpfPixelFormat.dwBBitMask = details->Bmask;
+		ddsd.ddpfPixelFormat.dwRGBAlphaBitMask = details->Amask;
 
 		if (!lpEnumModesCallback(&ddsd, lpContext)) {
 			status = DDERR_GENERIC;
@@ -270,6 +271,7 @@ HRESULT DirectDrawImpl::GetDisplayMode(LPDDSURFACEDESC lpDDSurfaceDesc)
 	lpDDSurfaceDesc->ddpfPixelFormat.dwRBitMask = details->Rmask;
 	lpDDSurfaceDesc->ddpfPixelFormat.dwGBitMask = details->Gmask;
 	lpDDSurfaceDesc->ddpfPixelFormat.dwBBitMask = details->Bmask;
+	lpDDSurfaceDesc->ddpfPixelFormat.dwRGBAlphaBitMask = details->Amask;
 
 	return DD_OK;
 }

--- a/miniwin/src/ddraw/ddsurface.cpp
+++ b/miniwin/src/ddraw/ddsurface.cpp
@@ -210,6 +210,7 @@ HRESULT DirectDrawSurfaceImpl::GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat)
 	lpDDPixelFormat->dwRBitMask = details->Rmask;
 	lpDDPixelFormat->dwGBitMask = details->Gmask;
 	lpDDPixelFormat->dwBBitMask = details->Bmask;
+	lpDDPixelFormat->dwRGBAlphaBitMask = details->Amask;
 	return DD_OK;
 }
 

--- a/miniwin/src/internal/d3drmdevice_impl.h
+++ b/miniwin/src/internal/d3drmdevice_impl.h
@@ -16,7 +16,7 @@ struct Direct3DRMDevice2Impl : public Direct3DRMObjectBaseImpl<IDirect3DRMDevice
 	HRESULT SetBufferCount(int count) override;
 	DWORD GetBufferCount() override;
 	HRESULT SetShades(DWORD shadeCount) override;
-	HRESULT GetShades() override;
+	DWORD GetShades() override;
 	HRESULT SetQuality(D3DRMRENDERQUALITY quality) override;
 	D3DRMRENDERQUALITY GetQuality() override;
 	HRESULT SetDither(BOOL dither) override;


### PR DESCRIPTION
This implements a few loose bits in miniwin, at least to Isle's satisfaction.

D3DRM never fully supported Phong so we treat it and Gouraud the same.

Alpha is needed for proper 32bit support and was easy to add to miniwin.

This makes the console a little less noisy.