### PR TITLE
Move 2D rendering to GPU: part 1

### DIFF
--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -61,11 +61,6 @@ void MxDisplaySurface::ClearScreen()
 		backBuffers = m_videoParam.GetBackBuffers() + 1;
 	}
 
-	MxS32 width = m_videoParam.GetRect().GetWidth();
-	MxS32 height = m_videoParam.GetRect().GetHeight();
-
-	RECT rc = {0, 0, width, height};
-
 	memset(&desc, 0, sizeof(desc));
 	desc.dwSize = sizeof(desc);
 	if (m_ddSurface2->GetSurfaceDesc(&desc) != DD_OK) {
@@ -77,9 +72,9 @@ void MxDisplaySurface::ClearScreen()
 	ddBltFx.dwFillColor = 0;
 
 	for (MxS32 i = 0; i < backBuffers; i++) {
-		if (m_ddSurface2->Blt(&rc, NULL, NULL, DDBLT_COLORFILL | DDBLT_WAIT, &ddBltFx) == DDERR_SURFACELOST) {
+		if (m_ddSurface2->Blt(NULL, NULL, NULL, DDBLT_COLORFILL | DDBLT_WAIT, &ddBltFx) == DDERR_SURFACELOST) {
 			m_ddSurface2->Restore();
-			m_ddSurface2->Blt(&rc, NULL, NULL, DDBLT_COLORFILL | DDBLT_WAIT, &ddBltFx);
+			m_ddSurface2->Blt(NULL, NULL, NULL, DDBLT_COLORFILL | DDBLT_WAIT, &ddBltFx);
 		}
 
 		if (m_videoParam.Flags().GetFlipSurfaces()) {

--- a/miniwin/CMakeLists.txt
+++ b/miniwin/CMakeLists.txt
@@ -6,9 +6,10 @@ add_library(miniwin STATIC EXCLUDE_FROM_ALL
   src/windows/windows.cpp
 
   # DDraw
-  src/ddraw/ddraw.cpp
   src/ddraw/ddpalette.cpp
+  src/ddraw/ddraw.cpp
   src/ddraw/ddsurface.cpp
+  src/ddraw/framebuffer.cpp
 
   # D3DRM
   src/d3drm/d3drm.cpp
@@ -21,9 +22,9 @@ add_library(miniwin STATIC EXCLUDE_FROM_ALL
   src/internal/meshutils.cpp
 
   # D3DRM backends
-  src/d3drm/backends/software/renderer.cpp
   src/d3drm/backends/sdl3gpu/renderer.cpp
   src/d3drm/backends/sdl3gpu/shaders/generated/ShaderIndex.cpp
+  src/d3drm/backends/software/renderer.cpp
 )
 
 find_package(OpenGL)

--- a/miniwin/include/miniwin/d3drm.h
+++ b/miniwin/include/miniwin/d3drm.h
@@ -347,7 +347,7 @@ struct IDirect3DRM : virtual public IUnknown {
 		IDirect3DRMDevice2** outDevice
 	) = 0;
 	virtual HRESULT CreateTexture(D3DRMIMAGE* image, IDirect3DRMTexture2** outTexture) = 0;
-	virtual HRESULT CreateTextureFromSurface(LPDIRECTDRAWSURFACE surface, IDirect3DRMTexture2** outTexture) = 0;
+	virtual HRESULT CreateTextureFromSurface(IDirectDrawSurface* surface, IDirect3DRMTexture2** outTexture) = 0;
 	virtual HRESULT CreateMesh(IDirect3DRMMesh** outMesh) = 0;
 	virtual HRESULT CreateMaterial(D3DVAL power, IDirect3DRMMaterial** outMaterial) = 0;
 	virtual HRESULT CreateLightRGB(D3DRMLIGHTTYPE type, D3DVAL r, D3DVAL g, D3DVAL b, IDirect3DRMLight** outLight) = 0;

--- a/miniwin/include/miniwin/ddraw.h
+++ b/miniwin/include/miniwin/ddraw.h
@@ -311,10 +311,10 @@ typedef IDirectDrawClipper* LPDIRECTDRAWCLIPPER;
 
 typedef struct IDirectDrawSurface* LPDIRECTDRAWSURFACE;
 struct IDirectDrawSurface : virtual public IUnknown {
-	virtual HRESULT AddAttachedSurface(LPDIRECTDRAWSURFACE lpDDSAttachedSurface) = 0;
+	virtual HRESULT AddAttachedSurface(IDirectDrawSurface* lpDDSAttachedSurface) = 0;
 	virtual HRESULT Blt(
 		LPRECT lpDestRect,
-		LPDIRECTDRAWSURFACE lpDDSrcSurface,
+		IDirectDrawSurface* lpDDSrcSurface,
 		LPRECT lpSrcRect,
 		DDBltFlags dwFlags,
 		LPDDBLTFX lpDDBltFx
@@ -322,21 +322,21 @@ struct IDirectDrawSurface : virtual public IUnknown {
 	virtual HRESULT BltFast(
 		DWORD dwX,
 		DWORD dwY,
-		LPDIRECTDRAWSURFACE lpDDSrcSurface,
+		IDirectDrawSurface* lpDDSrcSurface,
 		LPRECT lpSrcRect,
 		DDBltFastFlags dwTrans
 	) = 0;
-	virtual HRESULT Flip(LPDIRECTDRAWSURFACE lpDDSurfaceTargetOverride, DDFlipFlags dwFlags) = 0;
-	virtual HRESULT GetAttachedSurface(LPDDSCAPS lpDDSCaps, LPDIRECTDRAWSURFACE* lplpDDAttachedSurface) = 0;
+	virtual HRESULT Flip(IDirectDrawSurface* lpDDSurfaceTargetOverride, DDFlipFlags dwFlags) = 0;
+	virtual HRESULT GetAttachedSurface(LPDDSCAPS lpDDSCaps, IDirectDrawSurface** lplpDDAttachedSurface) = 0;
 	virtual HRESULT GetDC(HDC* lphDC) = 0;
 	virtual HRESULT GetPalette(LPDIRECTDRAWPALETTE* lplpDDPalette) = 0;
 	virtual HRESULT GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat) = 0;
-	virtual HRESULT GetSurfaceDesc(LPDDSURFACEDESC lpDDSurfaceDesc) = 0;
+	virtual HRESULT GetSurfaceDesc(DDSURFACEDESC* lpDDSurfaceDesc) = 0;
 	virtual HRESULT IsLost() = 0;
-	virtual HRESULT Lock(LPRECT lpDestRect, LPDDSURFACEDESC lpDDSurfaceDesc, DDLockFlags dwFlags, HANDLE hEvent) = 0;
+	virtual HRESULT Lock(LPRECT lpDestRect, DDSURFACEDESC* lpDDSurfaceDesc, DDLockFlags dwFlags, HANDLE hEvent) = 0;
 	virtual HRESULT ReleaseDC(HDC hDC) = 0;
 	virtual HRESULT Restore() = 0;
-	virtual HRESULT SetClipper(LPDIRECTDRAWCLIPPER lpDDClipper) = 0;
+	virtual HRESULT SetClipper(IDirectDrawClipper* lpDDClipper) = 0;
 	virtual HRESULT SetColorKey(DDColorKeyFlags dwFlags, LPDDCOLORKEY lpDDColorKey) = 0;
 	virtual HRESULT SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) = 0;
 	virtual HRESULT Unlock(LPVOID lpSurfaceData) = 0;
@@ -345,9 +345,9 @@ struct IDirectDrawSurface : virtual public IUnknown {
 struct IDirectDrawSurface3 : public IDirectDrawSurface {};
 typedef IDirectDrawSurface3* LPDIRECTDRAWSURFACE3;
 
-typedef HRESULT (*LPDDENUMMODESCALLBACK)(LPDDSURFACEDESC, LPVOID);
+typedef HRESULT (*LPDDENUMMODESCALLBACK)(DDSURFACEDESC*, LPVOID);
 struct IDirectDraw : virtual public IUnknown {
-	virtual HRESULT CreateClipper(DWORD dwFlags, LPDIRECTDRAWCLIPPER* lplpDDClipper, IUnknown* pUnkOuter) = 0;
+	virtual HRESULT CreateClipper(DWORD dwFlags, IDirectDrawClipper** lplpDDClipper, IUnknown* pUnkOuter) = 0;
 	virtual HRESULT CreatePalette(
 		DDPixelCaps dwFlags,
 		LPPALETTEENTRY lpColorTable,
@@ -355,19 +355,19 @@ struct IDirectDraw : virtual public IUnknown {
 		IUnknown* pUnkOuter
 	) = 0;
 	virtual HRESULT CreateSurface(
-		LPDDSURFACEDESC lpDDSurfaceDesc,
-		LPDIRECTDRAWSURFACE* lplpDDSurface,
+		DDSURFACEDESC* lpDDSurfaceDesc,
+		IDirectDrawSurface** lplpDDSurface,
 		IUnknown* pUnkOuter
 	) = 0;
 	virtual HRESULT EnumDisplayModes(
 		DWORD dwFlags,
-		LPDDSURFACEDESC lpDDSurfaceDesc,
+		DDSURFACEDESC* lpDDSurfaceDesc,
 		LPVOID lpContext,
 		LPDDENUMMODESCALLBACK lpEnumModesCallback
 	) = 0;
 	virtual HRESULT FlipToGDISurface() = 0;
 	virtual HRESULT GetCaps(LPDDCAPS lpDDDriverCaps, LPDDCAPS lpDDHELCaps) = 0;
-	virtual HRESULT GetDisplayMode(LPDDSURFACEDESC lpDDSurfaceDesc) = 0;
+	virtual HRESULT GetDisplayMode(DDSURFACEDESC* lpDDSurfaceDesc) = 0;
 	virtual HRESULT RestoreDisplayMode() = 0;
 	virtual HRESULT SetCooperativeLevel(HWND hWnd, DDSCLFlags dwFlags) = 0;
 	virtual HRESULT SetDisplayMode(DWORD dwWidth, DWORD dwHeight, DWORD dwBPP) = 0;

--- a/miniwin/src/d3drm/d3drm.cpp
+++ b/miniwin/src/d3drm/d3drm.cpp
@@ -160,14 +160,18 @@ HRESULT Direct3DRMImpl::CreateDeviceFromSurface(
 
 HRESULT Direct3DRMImpl::CreateTexture(D3DRMIMAGE* image, IDirect3DRMTexture2** outTexture)
 {
-	*outTexture = static_cast<IDirect3DRMTexture2*>(new Direct3DRMTextureImpl(image));
+	MINIWIN_NOT_IMPLEMENTED();
 	return DD_OK;
 }
 
-HRESULT Direct3DRMImpl::CreateTextureFromSurface(LPDIRECTDRAWSURFACE surface, IDirect3DRMTexture2** outTexture)
+HRESULT Direct3DRMImpl::CreateTextureFromSurface(IDirectDrawSurface* surface, IDirect3DRMTexture2** outTexture)
 
 {
-	*outTexture = static_cast<IDirect3DRMTexture2*>(new Direct3DRMTextureImpl(surface));
+	*outTexture = dynamic_cast<IDirect3DRMTexture2*>(surface);
+	if (!*outTexture) {
+		return DDERR_GENERIC;
+	}
+	surface->AddRef();
 	return DD_OK;
 }
 

--- a/miniwin/src/d3drm/d3drmtexture.cpp
+++ b/miniwin/src/d3drm/d3drmtexture.cpp
@@ -1,13 +1,18 @@
 #include "d3drmtexture_impl.h"
+#include "ddpalette_impl.h"
 #include "miniwin.h"
 
-Direct3DRMTextureImpl::Direct3DRMTextureImpl(D3DRMIMAGE* image)
+Direct3DRMTextureImpl::Direct3DRMTextureImpl(int width, int height, SDL_PixelFormat format)
 {
-	MINIWIN_NOT_IMPLEMENTED();
+	m_surface = SDL_CreateSurface(width, height, format);
+	if (!m_surface) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create surface: %s", SDL_GetError());
+	}
 }
 
-Direct3DRMTextureImpl::Direct3DRMTextureImpl(IDirectDrawSurface* surface) : m_surface(surface)
+Direct3DRMTextureImpl::~Direct3DRMTextureImpl()
 {
+	SDL_DestroySurface(m_surface);
 }
 
 HRESULT Direct3DRMTextureImpl::QueryInterface(const GUID& riid, void** ppvObject)
@@ -23,9 +28,169 @@ HRESULT Direct3DRMTextureImpl::QueryInterface(const GUID& riid, void** ppvObject
 
 HRESULT Direct3DRMTextureImpl::Changed(BOOL pixels, BOOL palette)
 {
-	if (!m_surface) {
+	m_version++;
+	return DD_OK;
+}
+
+// IDirectDrawSurface interface
+HRESULT Direct3DRMTextureImpl::AddAttachedSurface(IDirectDrawSurface* lpDDSAttachedSurface)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMTextureImpl::Blt(
+	LPRECT lpDestRect,
+	IDirectDrawSurface* lpDDSrcSurface,
+	LPRECT lpSrcRect,
+	DDBltFlags dwFlags,
+	LPDDBLTFX lpDDBltFx
+)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMTextureImpl::BltFast(
+	DWORD dwX,
+	DWORD dwY,
+	IDirectDrawSurface* lpDDSrcSurface,
+	LPRECT lpSrcRect,
+	DDBltFastFlags dwTrans
+)
+{
+	if (dwX != 0 || dwY != 0) {
+		MINIWIN_NOT_IMPLEMENTED();
 		return DDERR_GENERIC;
 	}
-	m_version++;
+	auto* other = dynamic_cast<Direct3DRMTextureImpl*>(lpDDSrcSurface);
+	if (!other) {
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	if (other->m_surface->format != m_surface->format) {
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	SDL_BlitSurface(other->m_surface, nullptr, m_surface, nullptr);
+	return DD_OK;
+}
+
+HRESULT Direct3DRMTextureImpl::Flip(IDirectDrawSurface* lpDDSurfaceTarget, DDFlipFlags dwFlags)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMTextureImpl::GetAttachedSurface(LPDDSCAPS lpDDSCaps, IDirectDrawSurface** lplpDDAttachedSurface)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMTextureImpl::GetDC(HDC* lphDC)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMTextureImpl::GetPalette(LPDIRECTDRAWPALETTE* lplpDDPalette)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMTextureImpl::GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat)
+{
+	lpDDPixelFormat->dwFlags = DDPF_RGB;
+	const SDL_PixelFormatDetails* details = SDL_GetPixelFormatDetails(m_surface->format);
+	if (details->bits_per_pixel == 8) {
+		lpDDPixelFormat->dwFlags |= DDPF_PALETTEINDEXED8;
+	}
+	lpDDPixelFormat->dwRGBBitCount = details->bits_per_pixel;
+	lpDDPixelFormat->dwRBitMask = details->Rmask;
+	lpDDPixelFormat->dwGBitMask = details->Gmask;
+	lpDDPixelFormat->dwBBitMask = details->Bmask;
+	lpDDPixelFormat->dwRGBAlphaBitMask = details->Amask;
+	return DD_OK;
+}
+
+HRESULT Direct3DRMTextureImpl::GetSurfaceDesc(DDSURFACEDESC* lpDDSurfaceDesc)
+{
+	lpDDSurfaceDesc->dwFlags = DDSD_PIXELFORMAT;
+	GetPixelFormat(&lpDDSurfaceDesc->ddpfPixelFormat);
+	lpDDSurfaceDesc->dwFlags |= DDSD_WIDTH | DDSD_HEIGHT;
+	lpDDSurfaceDesc->dwWidth = m_surface->w;
+	lpDDSurfaceDesc->dwHeight = m_surface->h;
+	return DD_OK;
+}
+
+HRESULT Direct3DRMTextureImpl::IsLost()
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMTextureImpl::Lock(
+	LPRECT lpDestRect,
+	DDSURFACEDESC* lpDDSurfaceDesc,
+	DDLockFlags dwFlags,
+	HANDLE hEvent
+)
+{
+	if (!SDL_LockSurface(m_surface)) {
+		return DDERR_GENERIC;
+	}
+
+	GetSurfaceDesc(lpDDSurfaceDesc);
+	lpDDSurfaceDesc->lpSurface = m_surface->pixels;
+	lpDDSurfaceDesc->lPitch = m_surface->pitch;
+
+	return DD_OK;
+}
+
+HRESULT Direct3DRMTextureImpl::ReleaseDC(HDC hDC)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMTextureImpl::Restore()
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMTextureImpl::SetClipper(IDirectDrawClipper* lpDDClipper)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMTextureImpl::SetColorKey(DDColorKeyFlags dwFlags, LPDDCOLORKEY lpDDColorKey)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT Direct3DRMTextureImpl::SetPalette(LPDIRECTDRAWPALETTE lpDDPalette)
+{
+	if (m_surface->format != SDL_PIXELFORMAT_INDEX8) {
+		MINIWIN_NOT_IMPLEMENTED();
+	}
+
+	if (m_palette) {
+		m_palette->Release();
+	}
+
+	m_palette = lpDDPalette;
+	SDL_SetSurfacePalette(m_surface, ((DirectDrawPaletteImpl*) m_palette)->m_palette);
+	m_palette->AddRef();
+	return DD_OK;
+}
+
+HRESULT Direct3DRMTextureImpl::Unlock(LPVOID lpSurfaceData)
+{
+	SDL_UnlockSurface(m_surface);
 	return DD_OK;
 }

--- a/miniwin/src/d3drm/d3drmviewport.cpp
+++ b/miniwin/src/d3drm/d3drmviewport.cpp
@@ -358,16 +358,15 @@ HRESULT Direct3DRMViewportImpl::ForceUpdate(int x, int y, int w, int h)
 
 HRESULT Direct3DRMViewportImpl::Clear()
 {
-	if (!DDBackBuffer) {
+	if (!DDRenderer) {
 		return DDERR_GENERIC;
 	}
 
 	uint8_t r = (m_backgroundColor >> 16) & 0xFF;
 	uint8_t g = (m_backgroundColor >> 8) & 0xFF;
 	uint8_t b = m_backgroundColor & 0xFF;
-
-	Uint32 color = SDL_MapRGB(SDL_GetPixelFormatDetails(DDBackBuffer->format), nullptr, r, g, b);
-	SDL_FillSurfaceRect(DDBackBuffer, nullptr, color);
+	SDL_SetRenderDrawColor(DDRenderer, r, g, b, 255);
+	SDL_RenderClear(DDRenderer);
 
 	return DD_OK;
 }

--- a/miniwin/src/ddraw/framebuffer.cpp
+++ b/miniwin/src/ddraw/framebuffer.cpp
@@ -1,0 +1,226 @@
+#include "ddpalette_impl.h"
+#include "ddraw_impl.h"
+#include "dummysurface_impl.h"
+#include "framebuffer_impl.h"
+#include "miniwin.h"
+
+#include <assert.h>
+
+FrameBufferImpl::FrameBufferImpl()
+{
+	int width, height;
+	SDL_GetRenderOutputSize(DDRenderer, &width, &height);
+	m_backBuffer = SDL_CreateTexture(DDRenderer, HWBackBufferFormat, SDL_TEXTUREACCESS_TARGET, width, height);
+	m_uploadBuffer = SDL_CreateTexture(DDRenderer, HWBackBufferFormat, SDL_TEXTUREACCESS_STREAMING, width, height);
+	SDL_SetRenderTarget(DDRenderer, m_backBuffer);
+	if (!m_backBuffer) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create surface: %s", SDL_GetError());
+	}
+}
+
+FrameBufferImpl::~FrameBufferImpl()
+{
+	SDL_DestroyTexture(m_backBuffer);
+}
+
+// IUnknown interface
+HRESULT FrameBufferImpl::QueryInterface(const GUID& riid, void** ppvObject)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return E_NOINTERFACE;
+}
+
+// IDirectDrawSurface interface
+HRESULT FrameBufferImpl::AddAttachedSurface(IDirectDrawSurface* lpDDSAttachedSurface)
+{
+	if (dynamic_cast<DummySurfaceImpl*>(lpDDSAttachedSurface)) {
+		return DD_OK;
+	}
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+static SDL_FRect ConvertRect(const RECT* r)
+{
+	return {(float) r->left, (float) r->top, (float) (r->right - r->left), (float) (r->bottom - r->top)};
+}
+
+HRESULT FrameBufferImpl::Blt(
+	LPRECT lpDestRect,
+	IDirectDrawSurface* lpDDSrcSurface,
+	LPRECT lpSrcRect,
+	DDBltFlags dwFlags,
+	LPDDBLTFX lpDDBltFx
+)
+{
+	if (dynamic_cast<FrameBufferImpl*>(lpDDSrcSurface) == this) {
+		return Flip(nullptr, DDFLIP_WAIT);
+	}
+	if ((dwFlags & DDBLT_COLORFILL) == DDBLT_COLORFILL) {
+		if (lpDestRect != nullptr) {
+			MINIWIN_NOT_IMPLEMENTED();
+		}
+		Uint8 r = (lpDDBltFx->dwFillColor >> 16) & 0xFF;
+		Uint8 g = (lpDDBltFx->dwFillColor >> 8) & 0xFF;
+		Uint8 b = lpDDBltFx->dwFillColor & 0xFF;
+		SDL_SetRenderDrawColor(DDRenderer, r, g, b, 0xFF);
+		SDL_RenderClear(DDRenderer);
+	}
+	else {
+		auto srcSurface = dynamic_cast<DirectDrawSurfaceImpl*>(lpDDSrcSurface);
+		if (!srcSurface) {
+			return DDERR_GENERIC;
+		}
+		SDL_FRect srcRect, dstRect;
+		if (lpSrcRect) {
+			srcRect = ConvertRect(lpSrcRect);
+		}
+		if (lpDestRect) {
+			dstRect = ConvertRect(lpDestRect);
+		}
+		if (!SDL_RenderTexture(
+				DDRenderer,
+				srcSurface->m_texture,
+				lpSrcRect ? &srcRect : nullptr,
+				lpDestRect ? &dstRect : nullptr
+			)) {
+			return DDERR_GENERIC;
+		}
+	}
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::BltFast(
+	DWORD dwX,
+	DWORD dwY,
+	IDirectDrawSurface* lpDDSrcSurface,
+	LPRECT lpSrcRect,
+	DDBltFastFlags dwTrans
+)
+{
+	RECT destRect = {
+		(int) dwX,
+		(int) dwY,
+		(int) (lpSrcRect->right - lpSrcRect->left + dwX),
+		(int) (lpSrcRect->bottom - lpSrcRect->top + dwY)
+	};
+	return Blt(&destRect, lpDDSrcSurface, lpSrcRect, DDBLT_NONE, nullptr);
+}
+
+HRESULT FrameBufferImpl::Flip(IDirectDrawSurface* lpDDSurfaceTargetOverride, DDFlipFlags dwFlags)
+{
+	SDL_SetRenderTarget(DDRenderer, nullptr);
+	SDL_RenderTexture(DDRenderer, m_backBuffer, nullptr, nullptr);
+	SDL_RenderPresent(DDRenderer);
+	SDL_SetRenderTarget(DDRenderer, m_backBuffer);
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::GetAttachedSurface(LPDDSCAPS lpDDSCaps, IDirectDrawSurface** lplpDDAttachedSurface)
+{
+	if ((lpDDSCaps->dwCaps & DDSCAPS_BACKBUFFER) != DDSCAPS_BACKBUFFER) {
+		return DDERR_INVALIDPARAMS;
+	}
+	this->AddRef();
+	*lplpDDAttachedSurface = static_cast<IDirectDrawSurface*>(this);
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::GetDC(HDC* lphDC)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::GetPalette(LPDIRECTDRAWPALETTE* lplpDDPalette)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat)
+{
+	lpDDPixelFormat->dwFlags = DDPF_RGB;
+	const SDL_PixelFormatDetails* details = SDL_GetPixelFormatDetails(HWBackBufferFormat);
+	if (details->bits_per_pixel == 8) {
+		lpDDPixelFormat->dwFlags |= DDPF_PALETTEINDEXED8;
+	}
+	lpDDPixelFormat->dwRGBBitCount = details->bits_per_pixel;
+	lpDDPixelFormat->dwRBitMask = details->Rmask;
+	lpDDPixelFormat->dwGBitMask = details->Gmask;
+	lpDDPixelFormat->dwBBitMask = details->Bmask;
+	lpDDPixelFormat->dwRGBAlphaBitMask = details->Amask;
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::GetSurfaceDesc(DDSURFACEDESC* lpDDSurfaceDesc)
+{
+	lpDDSurfaceDesc->dwFlags = DDSD_PIXELFORMAT;
+	GetPixelFormat(&lpDDSurfaceDesc->ddpfPixelFormat);
+	lpDDSurfaceDesc->dwFlags |= DDSD_WIDTH | DDSD_HEIGHT;
+	lpDDSurfaceDesc->dwWidth = m_backBuffer->w;
+	lpDDSurfaceDesc->dwHeight = m_backBuffer->h;
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::IsLost()
+{
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::Lock(LPRECT lpDestRect, DDSURFACEDESC* lpDDSurfaceDesc, DDLockFlags dwFlags, HANDLE hEvent)
+{
+	m_readBackBuffer = SDL_RenderReadPixels(DDRenderer, nullptr);
+	if (!SDL_LockSurface(m_readBackBuffer)) {
+		return DDERR_GENERIC;
+	}
+
+	GetSurfaceDesc(lpDDSurfaceDesc);
+	lpDDSurfaceDesc->lpSurface = m_readBackBuffer->pixels;
+	lpDDSurfaceDesc->lPitch = m_readBackBuffer->pitch;
+
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::ReleaseDC(HDC hDC)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::Restore()
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::SetClipper(IDirectDrawClipper* lpDDClipper)
+{
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::SetColorKey(DDColorKeyFlags dwFlags, LPDDCOLORKEY lpDDColorKey)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::SetPalette(LPDIRECTDRAWPALETTE lpDDPalette)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::Unlock(LPVOID lpSurfaceData)
+{
+	SDL_UpdateTexture(m_uploadBuffer, nullptr, m_readBackBuffer->pixels, m_readBackBuffer->pitch);
+	SDL_DestroySurface(m_readBackBuffer);
+	SDL_RenderTexture(DDRenderer, m_uploadBuffer, nullptr, nullptr);
+	return DD_OK;
+}
+
+void FrameBufferImpl::Upload(void* pixels, int pitch)
+{
+	SDL_UpdateTexture(m_uploadBuffer, nullptr, pixels, pitch);
+	SDL_RenderTexture(DDRenderer, m_uploadBuffer, nullptr, nullptr);
+}

--- a/miniwin/src/internal/d3drm_impl.h
+++ b/miniwin/src/internal/d3drm_impl.h
@@ -24,7 +24,7 @@ struct Direct3DRMImpl : virtual public IDirect3DRM2 {
 		IDirect3DRMDevice2** outDevice
 	) override;
 	HRESULT CreateTexture(D3DRMIMAGE* image, IDirect3DRMTexture2** outTexture) override;
-	HRESULT CreateTextureFromSurface(LPDIRECTDRAWSURFACE surface, IDirect3DRMTexture2** outTexture) override;
+	HRESULT CreateTextureFromSurface(IDirectDrawSurface* surface, IDirect3DRMTexture2** outTexture) override;
 	HRESULT CreateMesh(IDirect3DRMMesh** outMesh) override;
 	HRESULT CreateMaterial(D3DVAL power, IDirect3DRMMaterial** outMaterial) override;
 	HRESULT CreateLightRGB(D3DRMLIGHTTYPE type, D3DVAL r, D3DVAL g, D3DVAL b, IDirect3DRMLight** outLight) override;

--- a/miniwin/src/internal/d3drmrenderer_software.h
+++ b/miniwin/src/internal/d3drmrenderer_software.h
@@ -62,6 +62,7 @@ private:
 
 	DWORD m_width;
 	DWORD m_height;
+	SDL_Surface* m_renderedImage;
 	SDL_Palette* m_palette;
 	const SDL_PixelFormatDetails* m_format;
 	int m_bytesPerPixel;

--- a/miniwin/src/internal/d3drmtexture_impl.h
+++ b/miniwin/src/internal/d3drmtexture_impl.h
@@ -1,13 +1,47 @@
 #pragma once
 
 #include "d3drmobject_impl.h"
+#include "miniwin/ddraw.h"
 
-struct Direct3DRMTextureImpl : public Direct3DRMObjectBaseImpl<IDirect3DRMTexture2> {
-	Direct3DRMTextureImpl(D3DRMIMAGE* image);
-	Direct3DRMTextureImpl(IDirectDrawSurface* surface);
+#include <SDL3/SDL.h>
+
+struct Direct3DRMTextureImpl : public Direct3DRMObjectBaseImpl<IDirect3DRMTexture2>, public IDirectDrawSurface3 {
+	Direct3DRMTextureImpl(int width, int height, SDL_PixelFormat format);
+	~Direct3DRMTextureImpl() override;
+
+	// IUnknown interface
 	HRESULT QueryInterface(const GUID& riid, void** ppvObject) override;
+	// IDirect3DRMTexture2 interface
 	HRESULT Changed(BOOL pixels, BOOL palette) override;
+	// IDirectDrawSurface interface
+	HRESULT AddAttachedSurface(IDirectDrawSurface* lpDDSAttachedSurface) override;
+	HRESULT Blt(
+		LPRECT lpDestRect,
+		IDirectDrawSurface* lpDDSrcSurface,
+		LPRECT lpSrcRect,
+		DDBltFlags dwFlags,
+		LPDDBLTFX lpDDBltFx
+	) override;
+	HRESULT BltFast(DWORD dwX, DWORD dwY, IDirectDrawSurface* lpDDSrcSurface, LPRECT lpSrcRect, DDBltFastFlags dwTrans)
+		override;
+	HRESULT Flip(IDirectDrawSurface* lpDDSurfaceTargetOverride, DDFlipFlags dwFlags) override;
+	HRESULT GetAttachedSurface(LPDDSCAPS lpDDSCaps, IDirectDrawSurface** lplpDDAttachedSurface) override;
+	HRESULT GetDC(HDC* lphDC) override;
+	HRESULT GetPalette(LPDIRECTDRAWPALETTE* lplpDDPalette) override;
+	HRESULT GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat) override;
+	HRESULT GetSurfaceDesc(DDSURFACEDESC* lpDDSurfaceDesc) override;
+	HRESULT IsLost() override;
+	HRESULT Lock(LPRECT lpDestRect, DDSURFACEDESC* lpDDSurfaceDesc, DDLockFlags dwFlags, HANDLE hEvent) override;
+	HRESULT ReleaseDC(HDC hDC) override;
+	HRESULT Restore() override;
+	HRESULT SetClipper(IDirectDrawClipper* lpDDClipper) override;
+	HRESULT SetColorKey(DDColorKeyFlags dwFlags, LPDDCOLORKEY lpDDColorKey) override;
+	HRESULT SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) override;
+	HRESULT Unlock(LPVOID lpSurfaceData) override;
 
-	IDirectDrawSurface* m_surface = nullptr;
+	SDL_Surface* m_surface = nullptr;
 	Uint8 m_version = 0;
+
+private:
+	IDirectDrawPalette* m_palette = nullptr;
 };

--- a/miniwin/src/internal/ddraw_impl.h
+++ b/miniwin/src/internal/ddraw_impl.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include "d3drmrenderer.h"
+#include "framebuffer_impl.h"
 #include "miniwin/d3d.h"
 #include "miniwin/ddraw.h"
 
 #include <SDL3/SDL.h>
 
 extern SDL_Window* DDWindow;
-extern SDL_Surface* DDBackBuffer;
-extern SDL_Texture* HWBackBuffer;
+extern FrameBufferImpl* DDFrameBuffer;
 extern SDL_PixelFormat HWBackBufferFormat;
 extern SDL_Renderer* DDRenderer;
 
@@ -16,7 +16,7 @@ struct DirectDrawImpl : public IDirectDraw2, public IDirect3D2 {
 	// IUnknown interface
 	HRESULT QueryInterface(const GUID& riid, void** ppvObject) override;
 	// IDirectDraw interface
-	HRESULT CreateClipper(DWORD dwFlags, LPDIRECTDRAWCLIPPER* lplpDDClipper, IUnknown* pUnkOuter) override;
+	HRESULT CreateClipper(DWORD dwFlags, IDirectDrawClipper** lplpDDClipper, IUnknown* pUnkOuter) override;
 	HRESULT
 	CreatePalette(
 		DDPixelCaps dwFlags,
@@ -24,17 +24,17 @@ struct DirectDrawImpl : public IDirectDraw2, public IDirect3D2 {
 		LPDIRECTDRAWPALETTE* lplpDDPalette,
 		IUnknown* pUnkOuter
 	) override;
-	HRESULT CreateSurface(LPDDSURFACEDESC lpDDSurfaceDesc, LPDIRECTDRAWSURFACE* lplpDDSurface, IUnknown* pUnkOuter)
+	HRESULT CreateSurface(DDSURFACEDESC* lpDDSurfaceDesc, IDirectDrawSurface** lplpDDSurface, IUnknown* pUnkOuter)
 		override;
 	HRESULT EnumDisplayModes(
 		DWORD dwFlags,
-		LPDDSURFACEDESC lpDDSurfaceDesc,
+		DDSURFACEDESC* lpDDSurfaceDesc,
 		LPVOID lpContext,
 		LPDDENUMMODESCALLBACK lpEnumModesCallback
 	) override;
 	HRESULT FlipToGDISurface() override;
 	HRESULT GetCaps(LPDDCAPS lpDDDriverCaps, LPDDCAPS lpDDHELCaps) override;
-	HRESULT GetDisplayMode(LPDDSURFACEDESC lpDDSurfaceDesc) override;
+	HRESULT GetDisplayMode(DDSURFACEDESC* lpDDSurfaceDesc) override;
 	HRESULT RestoreDisplayMode() override;
 	HRESULT SetCooperativeLevel(HWND hWnd, DDSCLFlags dwFlags) override;
 	HRESULT SetDisplayMode(DWORD dwWidth, DWORD dwHeight, DWORD dwBPP) override;

--- a/miniwin/src/internal/dummysurface_impl.h
+++ b/miniwin/src/internal/dummysurface_impl.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <miniwin.h>
+#include <miniwin/ddraw.h>
+
+struct DummySurfaceImpl : public IDirectDrawSurface3 {
+	// IUnknown interface
+	HRESULT QueryInterface(const GUID& riid, void** ppvObject) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+
+	// IDirectDrawSurface interface
+	HRESULT AddAttachedSurface(IDirectDrawSurface* lpDDSAttachedSurface) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT Blt(
+		LPRECT lpDestRect,
+		IDirectDrawSurface* lpDDSrcSurface,
+		LPRECT lpSrcRect,
+		DDBltFlags dwFlags,
+		LPDDBLTFX lpDDBltFx
+	) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT BltFast(DWORD dwX, DWORD dwY, IDirectDrawSurface* lpDDSrcSurface, LPRECT lpSrcRect, DDBltFastFlags dwTrans)
+		override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT Flip(IDirectDrawSurface* lpDDSurfaceTargetOverride, DDFlipFlags dwFlags) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT GetAttachedSurface(LPDDSCAPS lpDDSCaps, IDirectDrawSurface** lplpDDAttachedSurface) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT GetDC(HDC* lphDC) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT GetPalette(LPDIRECTDRAWPALETTE* lplpDDPalette) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT GetSurfaceDesc(DDSURFACEDESC* lpDDSurfaceDesc) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT IsLost() override { return DD_OK; }
+	HRESULT Lock(LPRECT lpDestRect, DDSURFACEDESC* lpDDSurfaceDesc, DDLockFlags dwFlags, HANDLE hEvent) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT ReleaseDC(HDC hDC) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT Restore() override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT SetClipper(IDirectDrawClipper* lpDDClipper) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT SetColorKey(DDColorKeyFlags dwFlags, LPDDCOLORKEY lpDDColorKey) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT Unlock(LPVOID lpSurfaceData) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+};

--- a/miniwin/src/internal/framebuffer_impl.h
+++ b/miniwin/src/internal/framebuffer_impl.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <SDL3/SDL.h>
+#include <ddsurface_impl.h>
 #include <miniwin/ddraw.h>
 
-struct DirectDrawSurfaceImpl : public IDirectDrawSurface3 {
-	DirectDrawSurfaceImpl(int width, int height, SDL_PixelFormat format);
-	~DirectDrawSurfaceImpl() override;
+struct FrameBufferImpl : public IDirectDrawSurface3 {
+	FrameBufferImpl();
+	~FrameBufferImpl() override;
 
 	// IUnknown interface
 	HRESULT QueryInterface(const GUID& riid, void** ppvObject) override;
@@ -35,5 +36,10 @@ struct DirectDrawSurfaceImpl : public IDirectDrawSurface3 {
 	HRESULT SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) override;
 	HRESULT Unlock(LPVOID lpSurfaceData) override;
 
-	SDL_Texture* m_texture;
+	void Upload(void* pixels, int pitch);
+
+private:
+	SDL_Surface* m_readBackBuffer;
+	SDL_Texture* m_backBuffer;
+	SDL_Texture* m_uploadBuffer;
 };


### PR DESCRIPTION
Fixes https://github.com/isledecomp/isle-portable/issues/142

Split surfaces up in frambuffer, 2d surfaces, and 3d textures. This makes it a lot easier to reason about there logic, which makes moving the rendering portion of it to the backends much more feasible.

All miniwin 2D rendering has now been moved to the GPU, but interaction with the 3D rendering still takes a round trip by the CPU until the pipelines get more direct access to each other. Some systems may benefit from this if they have a relatively weak CPU.

On my system SDL_GPU saw a drop from 15% to 9% on CPU load and the other backs seems to have dropped by maybe 1%, but that wasn't really the goal here.

It's notable that CPU load jumps from 5% to 10% on OpenGL when getting on a vehicle with a gas meter, I don't know what it was before but it tells us a little bit about how much performances is possibly still lost to GPU->CPU->GPU even when not on a vehicle.

Another point is that it was technically possible for me to use SDL_TEXTUREACCESS_TARGET instead of SDL_TEXTUREACCESS_STREAMING and do surface copying without looping though the CPU, but it's unclear to me what the downside of setting all textures to SDL_TEXTUREACCESS_TARGET would be. texture->texture transfer is also only required in a few niche cases where the game copies surfaces on to other ones to animate them instead of simply rendering two instances of the same surface (like the blinking green V in the registration book), if that was changed we could change to SDL_TEXTUREACCESS_STATIC which is the optimal type, even though this would lower miniwin's DirectDraw compliance... but if another project wants to use miniwin they can dig for a less optimized and more compatible version in git.