### PR TITLE
Split framebuffer from general surfaces

### DIFF
--- a/miniwin/CMakeLists.txt
+++ b/miniwin/CMakeLists.txt
@@ -6,9 +6,10 @@ add_library(miniwin STATIC EXCLUDE_FROM_ALL
   src/windows/windows.cpp
 
   # DDraw
-  src/ddraw/ddraw.cpp
   src/ddraw/ddpalette.cpp
+  src/ddraw/ddraw.cpp
   src/ddraw/ddsurface.cpp
+  src/ddraw/framebuffer.cpp
 
   # D3DRM
   src/d3drm/d3drm.cpp
@@ -21,9 +22,9 @@ add_library(miniwin STATIC EXCLUDE_FROM_ALL
   src/internal/meshutils.cpp
 
   # D3DRM backends
-  src/d3drm/backends/software/renderer.cpp
   src/d3drm/backends/sdl3gpu/renderer.cpp
   src/d3drm/backends/sdl3gpu/shaders/generated/ShaderIndex.cpp
+  src/d3drm/backends/software/renderer.cpp
 )
 
 find_package(OpenGL)

--- a/miniwin/src/ddraw/framebuffer.cpp
+++ b/miniwin/src/ddraw/framebuffer.cpp
@@ -1,0 +1,232 @@
+#include "ddpalette_impl.h"
+#include "ddraw_impl.h"
+#include "dummysurface_impl.h"
+#include "framebuffer_impl.h"
+#include "miniwin.h"
+
+#include <assert.h>
+
+FrameBufferImpl::FrameBufferImpl()
+{
+	int width, height;
+	SDL_GetRenderOutputSize(DDRenderer, &width, &height);
+	DDBackBuffer = SDL_CreateSurface(width, height, SDL_PIXELFORMAT_RGBA8888);
+	if (!DDBackBuffer) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create surface: %s", SDL_GetError());
+	}
+	m_uploadBuffer =
+		SDL_CreateTexture(DDRenderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, width, height);
+}
+
+FrameBufferImpl::~FrameBufferImpl()
+{
+	SDL_DestroySurface(DDBackBuffer);
+	if (m_palette) {
+		m_palette->Release();
+	}
+}
+
+// IUnknown interface
+HRESULT FrameBufferImpl::QueryInterface(const GUID& riid, void** ppvObject)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return E_NOINTERFACE;
+}
+
+// IDirectDrawSurface interface
+HRESULT FrameBufferImpl::AddAttachedSurface(LPDIRECTDRAWSURFACE lpDDSAttachedSurface)
+{
+	if (dynamic_cast<DummySurfaceImpl*>(lpDDSAttachedSurface)) {
+		return DD_OK;
+	}
+	MINIWIN_NOT_IMPLEMENTED();
+	return DDERR_GENERIC;
+}
+
+HRESULT FrameBufferImpl::Blt(
+	LPRECT lpDestRect,
+	LPDIRECTDRAWSURFACE lpDDSrcSurface,
+	LPRECT lpSrcRect,
+	DDBltFlags dwFlags,
+	LPDDBLTFX lpDDBltFx
+)
+{
+	if (dynamic_cast<FrameBufferImpl*>(lpDDSrcSurface) == this) {
+		return Flip(nullptr, DDFLIP_WAIT);
+	}
+	if ((dwFlags & DDBLT_COLORFILL) == DDBLT_COLORFILL) {
+		SDL_Rect rect = {0, 0, DDBackBuffer->w, DDBackBuffer->h};
+		const SDL_PixelFormatDetails* details = SDL_GetPixelFormatDetails(DDBackBuffer->format);
+		Uint8 r = (lpDDBltFx->dwFillColor >> 16) & 0xFF;
+		Uint8 g = (lpDDBltFx->dwFillColor >> 8) & 0xFF;
+		Uint8 b = lpDDBltFx->dwFillColor & 0xFF;
+		DirectDrawPaletteImpl* ddPal = static_cast<DirectDrawPaletteImpl*>(m_palette);
+		SDL_Palette* sdlPalette = ddPal ? ddPal->m_palette : nullptr;
+		Uint32 color = SDL_MapRGB(details, sdlPalette, r, g, b);
+		SDL_FillSurfaceRect(DDBackBuffer, &rect, color);
+		return DD_OK;
+	}
+	auto other = static_cast<DirectDrawSurfaceImpl*>(lpDDSrcSurface);
+	if (!other) {
+		return DDERR_GENERIC;
+	}
+	SDL_Rect srcRect = lpSrcRect ? ConvertRect(lpSrcRect) : SDL_Rect{0, 0, other->m_surface->w, other->m_surface->h};
+	SDL_Rect dstRect = lpDestRect ? ConvertRect(lpDestRect) : SDL_Rect{0, 0, DDBackBuffer->w, DDBackBuffer->h};
+
+	SDL_Surface* blitSource = other->m_surface;
+
+	if (other->m_surface->format != DDBackBuffer->format) {
+		blitSource = SDL_ConvertSurface(other->m_surface, DDBackBuffer->format);
+		if (!blitSource) {
+			return DDERR_GENERIC;
+		}
+	}
+
+	if (!SDL_BlitSurfaceScaled(blitSource, &srcRect, DDBackBuffer, &dstRect, SDL_SCALEMODE_NEAREST)) {
+		return DDERR_GENERIC;
+	}
+
+	if (blitSource != other->m_surface) {
+		SDL_DestroySurface(blitSource);
+	}
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::BltFast(
+	DWORD dwX,
+	DWORD dwY,
+	LPDIRECTDRAWSURFACE lpDDSrcSurface,
+	LPRECT lpSrcRect,
+	DDBltFastFlags dwTrans
+)
+{
+	RECT destRect = {
+		(int) dwX,
+		(int) dwY,
+		(int) (lpSrcRect->right - lpSrcRect->left + dwX),
+		(int) (lpSrcRect->bottom - lpSrcRect->top + dwY)
+	};
+	return Blt(&destRect, lpDDSrcSurface, lpSrcRect, DDBLT_NONE, nullptr);
+}
+
+HRESULT FrameBufferImpl::Flip(LPDIRECTDRAWSURFACE lpDDSurfaceTargetOverride, DDFlipFlags dwFlags)
+{
+	SDL_UpdateTexture(m_uploadBuffer, nullptr, DDBackBuffer->pixels, DDBackBuffer->pitch);
+	SDL_RenderTexture(DDRenderer, m_uploadBuffer, nullptr, nullptr);
+	SDL_RenderPresent(DDRenderer);
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::GetAttachedSurface(LPDDSCAPS lpDDSCaps, LPDIRECTDRAWSURFACE* lplpDDAttachedSurface)
+{
+	if ((lpDDSCaps->dwCaps & DDSCAPS_BACKBUFFER) != DDSCAPS_BACKBUFFER) {
+		return DDERR_INVALIDPARAMS;
+	}
+	*lplpDDAttachedSurface = static_cast<IDirectDrawSurface*>(this);
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::GetDC(HDC* lphDC)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::GetPalette(LPDIRECTDRAWPALETTE* lplpDDPalette)
+{
+	if (!m_palette) {
+		return DDERR_GENERIC;
+	}
+	m_palette->AddRef();
+	*lplpDDPalette = m_palette;
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat)
+{
+	memset(lpDDPixelFormat, 0, sizeof(*lpDDPixelFormat));
+	lpDDPixelFormat->dwFlags = DDPF_RGB;
+	const SDL_PixelFormatDetails* details = SDL_GetPixelFormatDetails(DDBackBuffer->format);
+	if (details->bits_per_pixel == 8) {
+		lpDDPixelFormat->dwFlags |= DDPF_PALETTEINDEXED8;
+	}
+	lpDDPixelFormat->dwRGBBitCount = details->bits_per_pixel;
+	lpDDPixelFormat->dwRBitMask = details->Rmask;
+	lpDDPixelFormat->dwGBitMask = details->Gmask;
+	lpDDPixelFormat->dwBBitMask = details->Bmask;
+	lpDDPixelFormat->dwRGBAlphaBitMask = details->Amask;
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::GetSurfaceDesc(LPDDSURFACEDESC lpDDSurfaceDesc)
+{
+	lpDDSurfaceDesc->dwFlags = DDSD_PIXELFORMAT;
+	GetPixelFormat(&lpDDSurfaceDesc->ddpfPixelFormat);
+	lpDDSurfaceDesc->dwFlags |= DDSD_WIDTH | DDSD_HEIGHT;
+	lpDDSurfaceDesc->dwWidth = DDBackBuffer->w;
+	lpDDSurfaceDesc->dwHeight = DDBackBuffer->h;
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::IsLost()
+{
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::Lock(LPRECT lpDestRect, DDSURFACEDESC* lpDDSurfaceDesc, DDLockFlags dwFlags, HANDLE hEvent)
+{
+	if (!SDL_LockSurface(DDBackBuffer)) {
+		return DDERR_GENERIC;
+	}
+
+	GetSurfaceDesc(lpDDSurfaceDesc);
+	lpDDSurfaceDesc->lpSurface = DDBackBuffer->pixels;
+	lpDDSurfaceDesc->lPitch = DDBackBuffer->pitch;
+
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::ReleaseDC(HDC hDC)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::Restore()
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::SetClipper(LPDIRECTDRAWCLIPPER lpDDClipper)
+{
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::SetColorKey(DDColorKeyFlags dwFlags, LPDDCOLORKEY lpDDColorKey)
+{
+	MINIWIN_NOT_IMPLEMENTED();
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::SetPalette(LPDIRECTDRAWPALETTE lpDDPalette)
+{
+	if (DDBackBuffer->format != SDL_PIXELFORMAT_INDEX8) {
+		MINIWIN_NOT_IMPLEMENTED();
+	}
+
+	if (m_palette) {
+		m_palette->Release();
+	}
+
+	m_palette = lpDDPalette;
+	SDL_SetSurfacePalette(DDBackBuffer, ((DirectDrawPaletteImpl*) m_palette)->m_palette);
+	m_palette->AddRef();
+	return DD_OK;
+}
+
+HRESULT FrameBufferImpl::Unlock(LPVOID lpSurfaceData)
+{
+	SDL_UnlockSurface(DDBackBuffer);
+	return DD_OK;
+}

--- a/miniwin/src/internal/ddraw_impl.h
+++ b/miniwin/src/internal/ddraw_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "d3drmrenderer.h"
+#include "framebuffer_impl.h"
 #include "miniwin/d3d.h"
 #include "miniwin/ddraw.h"
 
@@ -8,9 +9,13 @@
 
 extern SDL_Window* DDWindow;
 extern SDL_Surface* DDBackBuffer;
-extern SDL_Texture* HWBackBuffer;
-extern SDL_PixelFormat HWBackBufferFormat;
+extern FrameBufferImpl* DDFrameBuffer;
 extern SDL_Renderer* DDRenderer;
+
+inline static SDL_Rect ConvertRect(const RECT* r)
+{
+	return {r->left, r->top, r->right - r->left, r->bottom - r->top};
+}
 
 struct DirectDrawImpl : public IDirectDraw2, public IDirect3D2 {
 	// IUnknown interface

--- a/miniwin/src/internal/ddsurface_impl.h
+++ b/miniwin/src/internal/ddsurface_impl.h
@@ -4,7 +4,6 @@
 #include <miniwin/ddraw.h>
 
 struct DirectDrawSurfaceImpl : public IDirectDrawSurface3 {
-	DirectDrawSurfaceImpl();
 	DirectDrawSurfaceImpl(int width, int height, SDL_PixelFormat format);
 	~DirectDrawSurfaceImpl() override;
 
@@ -34,12 +33,10 @@ struct DirectDrawSurfaceImpl : public IDirectDrawSurface3 {
 	HRESULT SetClipper(LPDIRECTDRAWCLIPPER lpDDClipper) override;
 	HRESULT SetColorKey(DDColorKeyFlags dwFlags, LPDDCOLORKEY lpDDColorKey) override;
 	HRESULT SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) override;
-	void SetAutoFlip(bool enabled);
 	HRESULT Unlock(LPVOID lpSurfaceData) override;
 
 	SDL_Surface* m_surface = nullptr;
 
 private:
-	bool m_autoFlip = false;
 	IDirectDrawPalette* m_palette = nullptr;
 };

--- a/miniwin/src/internal/dummysurface_impl.h
+++ b/miniwin/src/internal/dummysurface_impl.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <miniwin.h>
+#include <miniwin/ddraw.h>
+
+struct DummySurfaceImpl : public IDirectDrawSurface3 {
+	// IUnknown interface
+	HRESULT QueryInterface(const GUID& riid, void** ppvObject) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+
+	// IDirectDrawSurface interface
+	HRESULT AddAttachedSurface(IDirectDrawSurface* lpDDSAttachedSurface) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT Blt(
+		LPRECT lpDestRect,
+		IDirectDrawSurface* lpDDSrcSurface,
+		LPRECT lpSrcRect,
+		DDBltFlags dwFlags,
+		LPDDBLTFX lpDDBltFx
+	) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT BltFast(DWORD dwX, DWORD dwY, IDirectDrawSurface* lpDDSrcSurface, LPRECT lpSrcRect, DDBltFastFlags dwTrans)
+		override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT Flip(IDirectDrawSurface* lpDDSurfaceTargetOverride, DDFlipFlags dwFlags) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT GetAttachedSurface(LPDDSCAPS lpDDSCaps, IDirectDrawSurface** lplpDDAttachedSurface) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT GetDC(HDC* lphDC) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT GetPalette(LPDIRECTDRAWPALETTE* lplpDDPalette) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT GetSurfaceDesc(DDSURFACEDESC* lpDDSurfaceDesc) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT IsLost() override { return DD_OK; }
+	HRESULT Lock(LPRECT lpDestRect, DDSURFACEDESC* lpDDSurfaceDesc, DDLockFlags dwFlags, HANDLE hEvent) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT ReleaseDC(HDC hDC) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT Restore() override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT SetClipper(IDirectDrawClipper* lpDDClipper) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT SetColorKey(DDColorKeyFlags dwFlags, LPDDCOLORKEY lpDDColorKey) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+	HRESULT Unlock(LPVOID lpSurfaceData) override
+	{
+		MINIWIN_NOT_IMPLEMENTED();
+		return DDERR_GENERIC;
+	}
+};

--- a/miniwin/src/internal/framebuffer_impl.h
+++ b/miniwin/src/internal/framebuffer_impl.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+#include <ddsurface_impl.h>
+#include <miniwin/ddraw.h>
+
+struct FrameBufferImpl : public IDirectDrawSurface3 {
+	FrameBufferImpl();
+	~FrameBufferImpl() override;
+
+	// IUnknown interface
+	HRESULT QueryInterface(const GUID& riid, void** ppvObject) override;
+	// IDirectDrawSurface interface
+	HRESULT AddAttachedSurface(IDirectDrawSurface* lpDDSAttachedSurface) override;
+	HRESULT Blt(
+		LPRECT lpDestRect,
+		IDirectDrawSurface* lpDDSrcSurface,
+		LPRECT lpSrcRect,
+		DDBltFlags dwFlags,
+		LPDDBLTFX lpDDBltFx
+	) override;
+	HRESULT BltFast(DWORD dwX, DWORD dwY, IDirectDrawSurface* lpDDSrcSurface, LPRECT lpSrcRect, DDBltFastFlags dwTrans)
+		override;
+	HRESULT Flip(IDirectDrawSurface* lpDDSurfaceTargetOverride, DDFlipFlags dwFlags) override;
+	HRESULT GetAttachedSurface(LPDDSCAPS lpDDSCaps, IDirectDrawSurface** lplpDDAttachedSurface) override;
+	HRESULT GetDC(HDC* lphDC) override;
+	HRESULT GetPalette(LPDIRECTDRAWPALETTE* lplpDDPalette) override;
+	HRESULT GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat) override;
+	HRESULT GetSurfaceDesc(DDSURFACEDESC* lpDDSurfaceDesc) override;
+	HRESULT IsLost() override;
+	HRESULT Lock(LPRECT lpDestRect, DDSURFACEDESC* lpDDSurfaceDesc, DDLockFlags dwFlags, HANDLE hEvent) override;
+	HRESULT ReleaseDC(HDC hDC) override;
+	HRESULT Restore() override;
+	HRESULT SetClipper(IDirectDrawClipper* lpDDClipper) override;
+	HRESULT SetColorKey(DDColorKeyFlags dwFlags, LPDDCOLORKEY lpDDColorKey) override;
+	HRESULT SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) override;
+	HRESULT Unlock(LPVOID lpSurfaceData) override;
+
+private:
+	SDL_Texture* m_uploadBuffer;
+	IDirectDrawPalette* m_palette = nullptr;
+};


### PR DESCRIPTION
Fixes: https://github.com/isledecomp/isle-portable/issues/142

Splitting the framebuffer and zbuffer from the general surfaces makes it a lot less complicated to reason about what's happening, we can now simple Flip the screen when a framebuffer is blitted on to itself and don't have set a state 