### PR TITLE
Fix UB in software renderer

### DIFF
--- a/miniwin/src/d3drm/backends/software/renderer.cpp
+++ b/miniwin/src/d3drm/backends/software/renderer.cpp
@@ -711,9 +711,8 @@ void Direct3DRMSoftwareRenderer::SubmitDraw(
 	// Pre-transform all vertex positions and normals
 	m_transformedVerts.clear();
 	m_transformedVerts.resize(mesh.vertices.size());
-	for (size_t i = 0; i < mesh.vertices.size(); ++i) {
-		const D3DRMVERTEX& src = mesh.vertices[i];
-		D3DRMVERTEX& dst = m_transformedVerts[i];
+	for (const auto& src : mesh.vertices) {
+		D3DRMVERTEX& dst = m_transformedVerts.emplace_back();
 		dst.position = TransformPoint(src.position, modelViewMatrix);
 		dst.normal = src.normal;
 		dst.texCoord = src.texCoord;

--- a/miniwin/src/d3drm/backends/software/renderer.cpp
+++ b/miniwin/src/d3drm/backends/software/renderer.cpp
@@ -710,7 +710,7 @@ void Direct3DRMSoftwareRenderer::SubmitDraw(
 
 	// Pre-transform all vertex positions and normals
 	m_transformedVerts.clear();
-	m_transformedVerts.reserve(mesh.vertices.size());
+	m_transformedVerts.resize(mesh.vertices.size());
 	for (size_t i = 0; i < mesh.vertices.size(); ++i) {
 		const D3DRMVERTEX& src = mesh.vertices[i];
 		D3DRMVERTEX& dst = m_transformedVerts[i];


### PR DESCRIPTION
One cannot access elements of a vector that don't exist. `reserve` allocates memory, but doesn't add elements.

`D3DRMVERTEX& dst = m_transformedVerts[i];` is UB and crashes on Windows debug build