### PR TITLE
Use extensions to probe for 24 or 32bit depth buffer

### DIFF
--- a/miniwin/src/d3drm/backends/opengles2/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengles2/renderer.cpp
@@ -1,6 +1,7 @@
 #include "d3drmrenderer_opengles2.h"
 #include "meshutils.h"
 
+#include <GLES2/gl2ext.h>
 #include <GLES2/gl2.h>
 #include <SDL3/SDL.h>
 #include <algorithm>
@@ -76,7 +77,16 @@ Direct3DRMRenderer* OpenGLES2Renderer::Create(DWORD width, DWORD height)
 	GLuint depthRb;
 	glGenRenderbuffers(1, &depthRb);
 	glBindRenderbuffer(GL_RENDERBUFFER, depthRb);
-	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, width, height);
+	const char* extensions = (const char*)glGetString(GL_EXTENSIONS);
+	if (strstr(extensions, "GL_OES_depth24")) {
+		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24_OES, width, height);
+	}
+	else if (strstr(extensions, "GL_OES_depth32")) {
+		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT32_OES, width, height);
+	}
+	else {
+		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, width, height);
+	}
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthRb);
 
 	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
@@ -454,6 +464,13 @@ void OpenGLES2Renderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc)
 	halDesc->dcmColorModel = D3DCOLORMODEL::RGB;
 	halDesc->dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
 	halDesc->dwDeviceZBufferBitDepth = DDBD_16;
+	const char* extensions = (const char*)glGetString(GL_EXTENSIONS);
+	if (strstr(extensions, "GL_OES_depth24")) {
+		halDesc->dwDeviceZBufferBitDepth |= DDBD_24;
+	}
+	if (strstr(extensions, "GL_OES_depth32")) {
+		halDesc->dwDeviceZBufferBitDepth |= DDBD_32;
+	}
 	helDesc->dwDeviceRenderBitDepth = DDBD_32;
 	halDesc->dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
 	halDesc->dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;


### PR DESCRIPTION
OpenGL ES 2.0 has optional extensions for 24 and 32bit depth buffer that can be proved for at runtime