### PR TITLE
Show that CMake is grabbing SDL3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,13 +50,9 @@ message(STATUS "Internal miniwin:       ${ISLE_MINIWIN}")
 message(STATUS "Isle debugging:         ${ISLE_DEBUG}")
 message(STATUS "Compile shaders:        ${ISLE_COMPILE_SHADERS}")
 
-
-
 if (DOWNLOAD_DEPENDENCIES)
     # FetchContent downloads and configures dependencies
-
     message(STATUS "Fetching SDL3 and iniparser. This might take a while...")
-
     include(FetchContent)
     FetchContent_Declare(
         SDL3


### PR DESCRIPTION
During the `cmake ..` process, during the first run, CMake grabs SDL3. This process takes a moment, and CMake shows no indication that anything is happening, which could lead to users believing the process has crashed or otherwise frozen.

This PR adds a simple status message to show what it is doing.

Before:
![image](https://github.com/user-attachments/assets/0d7524d5-c1cd-4ef5-8d9b-3d6604fbe561)

After:
![image](https://github.com/user-attachments/assets/2ac67f7e-8e0f-41c7-8bfa-e3b04cc938ec)
