### PR TITLE
Remake config tool, adding new settings and removing some obsolete ones

### DIFF
--- a/CONFIG/MainDlg.cpp
+++ b/CONFIG/MainDlg.cpp
@@ -130,6 +130,9 @@ bool CMainDialog::OnInitDialog()
 		driver_i += 1;
 	}
 	m_ui->devicesList->setCurrentRow(selected);
+
+	m_ui->maxLoDSlider->setValue((int)currentConfigApp->m_max_lod * 10);
+	m_ui->maxActorsSlider->setValue(currentConfigApp->m_max_actors);
 	UpdateInterface();
 	return true;
 }
@@ -353,9 +356,12 @@ void CMainDialog::SelectDiskPathDialog()
                                                     disk_path,
                                                     QFileDialog::ShowDirsOnly
                                                     | QFileDialog::DontResolveSymlinks);
-	currentConfigApp->m_base_path = disk_path.toStdString();
-	m_modified = true;
-	UpdateInterface();
+
+	if (disk_path.toStdString() != "") {
+		currentConfigApp->m_base_path = disk_path.toStdString();
+		m_modified = true;
+		UpdateInterface();
+	}
 }
 
 void CMainDialog::SelectCDPathDialog()
@@ -365,9 +371,12 @@ void CMainDialog::SelectCDPathDialog()
                                                     cd_path,
                                                     QFileDialog::ShowDirsOnly
                                                     | QFileDialog::DontResolveSymlinks);
-	currentConfigApp->m_cd_path = cd_path.toStdString();
-	m_modified = true;
-	UpdateInterface();
+
+	if (cd_path.toStdString() != "") {
+		currentConfigApp->m_cd_path = cd_path.toStdString();
+		m_modified = true;
+		UpdateInterface();
+	}
 }
 
 void CMainDialog::SelectMediaPathDialog()
@@ -377,9 +386,11 @@ void CMainDialog::SelectMediaPathDialog()
                                                     media_path,
                                                     QFileDialog::ShowDirsOnly
                                                     | QFileDialog::DontResolveSymlinks);
-	currentConfigApp->m_media_path = media_path.toStdString();
-	m_modified = true;
-	UpdateInterface();
+	if (media_path.toStdString() != "") {
+		currentConfigApp->m_media_path = media_path.toStdString();
+		m_modified = true;
+		UpdateInterface();
+	}
 }
 
 void CMainDialog::SelectSavePathDialog()
@@ -389,34 +400,37 @@ void CMainDialog::SelectSavePathDialog()
                                                     save_path,
                                                     QFileDialog::ShowDirsOnly
                                                     | QFileDialog::DontResolveSymlinks);
-	currentConfigApp->m_save_path = save_path.toStdString();
-	m_modified = true;
-	UpdateInterface();
+
+	if (save_path.toStdString() != "") {
+		currentConfigApp->m_save_path = save_path.toStdString();
+		m_modified = true;
+		UpdateInterface();
+	}
 }
 
 
-void CMainDialog::DiskPathEdited(QString &text)
+void CMainDialog::DiskPathEdited(const QString &text)
 {
 	currentConfigApp->m_base_path = text.toStdString();
 	m_modified = true;
 	UpdateInterface();
 }
 
-void CMainDialog::CDPathEdited(QString &text)
+void CMainDialog::CDPathEdited(const QString &text)
 {
 	currentConfigApp->m_cd_path = text.toStdString();
 	m_modified = true;
 	UpdateInterface();
 }
 
-void CMainDialog::MediaPathEdited(QString &text)
+void CMainDialog::MediaPathEdited(const QString &text)
 {
 	currentConfigApp->m_media_path = text.toStdString();
 	m_modified = true;
 	UpdateInterface();
 }
 
-void CMainDialog::SavePathEdited(QString &text)
+void CMainDialog::SavePathEdited(const QString &text)
 {
 	currentConfigApp->m_save_path = text.toStdString();
 	m_modified = true;

--- a/CONFIG/MainDlg.h
+++ b/CONFIG/MainDlg.h
@@ -6,6 +6,7 @@
 #include "res/resource.h"
 
 #include <QDialog>
+#include <QFileDialog>
 
 namespace Ui
 {
@@ -22,7 +23,6 @@ public:
 
 protected:
 	void UpdateInterface();
-	void SwitchToAdvanced(bool p_advanced);
 
 private:
 	bool m_modified = false;
@@ -39,14 +39,24 @@ private slots:
 	void OnRadiobuttonPalette256(bool checked);
 	void OnCheckboxFlipVideoMemPages(bool checked);
 	void OnRadiobuttonModelLowQuality(bool checked);
+	void OnRadiobuttonModelMediumQuality(bool checked);
 	void OnRadiobuttonModelHighQuality(bool checked);
 	void OnRadiobuttonTextureLowQuality(bool checked);
 	void OnRadiobuttonTextureHighQuality(bool checked);
-	void OnCheckboxJoystick(bool chedked);
+	void OnCheckboxJoystick(bool checked);
 	void OnCheckboxMusic(bool checked);
-	void OnButtonAdvanced();
 	void accept() override;
 	void reject() override;
+	void SelectDiskPathDialog();
+	void SelectCDPathDialog();
+	void SelectMediaPathDialog();
+	void SelectSavePathDialog();
+	void DiskPathEdited(QString &text);
+	void CDPathEdited(QString &text);
+	void MediaPathEdited(QString &text);
+	void SavePathEdited(QString &text);
+	void MaxLoDChanged(int value);
+	void MaxActorsChanged(int value);
 };
 
 // SYNTHETIC: CONFIG 0x00403de0

--- a/CONFIG/MainDlg.h
+++ b/CONFIG/MainDlg.h
@@ -51,10 +51,10 @@ private slots:
 	void SelectCDPathDialog();
 	void SelectMediaPathDialog();
 	void SelectSavePathDialog();
-	void DiskPathEdited(QString &text);
-	void CDPathEdited(QString &text);
-	void MediaPathEdited(QString &text);
-	void SavePathEdited(QString &text);
+	void DiskPathEdited(const QString &text);
+	void CDPathEdited(const QString &text);
+	void MediaPathEdited(const QString &text);
+	void SavePathEdited(const QString &text);
 	void MaxLoDChanged(int value);
 	void MaxActorsChanged(int value);
 };

--- a/CONFIG/config.cpp
+++ b/CONFIG/config.cpp
@@ -74,16 +74,22 @@ bool CConfigApp::InitInstance()
 		m_3d_sound = FALSE;
 		m_model_quality = 0;
 		m_texture_quality = 1;
+		m_max_lod = 1.5f;
+		m_max_actors = 5;
 	}
 	else if (totalRamMiB < 20) {
 		m_3d_sound = FALSE;
 		m_model_quality = 1;
 		m_texture_quality = 1;
+		m_max_lod = 2.5f;
+		m_max_actors = 10;
 	}
 	else {
 		m_model_quality = 2;
 		m_3d_sound = TRUE;
 		m_texture_quality = 1;
+		m_max_lod = 3.5f;
+		m_max_actors = 20;
 	}
 	return true;
 }
@@ -149,6 +155,8 @@ bool CConfigApp::ReadRegisterSettings()
 	m_use_joystick = iniparser_getboolean(dict, "isle:UseJoystick", m_use_joystick);
 	m_music = iniparser_getboolean(dict, "isle:Music", m_music);
 	m_joystick_index = iniparser_getint(dict, "isle:JoystickIndex", m_joystick_index);
+	m_max_lod = iniparser_getdouble(dict, "isle:Max LOD", m_max_lod);
+	m_max_actors = iniparser_getint(dict, "isle:Max Allowed Extras", m_max_actors);
 	return true;
 }
 
@@ -211,6 +219,16 @@ bool CConfigApp::ValidateSettings()
 		m_texture_quality = 0;
 		is_modified = TRUE;
 	}
+
+	if (m_max_lod < 0.0f || m_max_lod > 5.0f) {
+		m_max_lod = 3.5f;
+		is_modified = TRUE;
+	}
+	if (m_max_actors < 5 || m_max_actors > 40) {
+		m_max_actors = 20;
+		is_modified = TRUE;
+	}
+
 	return is_modified;
 }
 
@@ -302,6 +320,9 @@ void CConfigApp::WriteRegisterSettings() const
 
 	SetIniInt(dict, "isle:Island Quality", m_model_quality);
 	SetIniInt(dict, "isle:Island Texture", m_texture_quality);
+
+	iniparser_set(dict, "isle:Max LOD", (const char)m_max_lod);
+	SetIniInt(dict, "isle:Max Allowed Extras", m_max_actors);
 
 #undef SetIniBool
 #undef SetIniInt

--- a/CONFIG/config.cpp
+++ b/CONFIG/config.cpp
@@ -321,7 +321,7 @@ void CConfigApp::WriteRegisterSettings() const
 	SetIniInt(dict, "isle:Island Quality", m_model_quality);
 	SetIniInt(dict, "isle:Island Texture", m_texture_quality);
 
-	iniparser_set(dict, "isle:Max LOD", (const char)m_max_lod);
+	iniparser_set(dict, "isle:Max LOD", std::to_string(m_max_lod).c_str());
 	SetIniInt(dict, "isle:Max Allowed Extras", m_max_actors);
 
 #undef SetIniBool

--- a/CONFIG/config.h
+++ b/CONFIG/config.h
@@ -79,6 +79,8 @@ public:
 	std::string m_cd_path;
 	std::string m_media_path;
 	std::string m_save_path;
+	float m_max_lod;
+	int m_max_actors;
 };
 
 extern CConfigApp g_theApp;

--- a/CONFIG/res/maindialog.ui
+++ b/CONFIG/res/maindialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>549</width>
-    <height>563</height>
+    <width>575</width>
+    <height>750</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -27,7 +27,7 @@
    <item>
     <widget class="QLabel" name="sharkImageLabel">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -35,7 +35,13 @@
      <property name="minimumSize">
       <size>
        <width>143</width>
-       <height>545</height>
+       <height>383</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
       </size>
      </property>
      <property name="text">
@@ -45,81 +51,216 @@
       <pixmap resource="config.qrc">:/shark.png</pixmap>
      </property>
      <property name="scaledContents">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
     </widget>
    </item>
    <item>
     <widget class="QWidget" name="settingsWidget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
       <item>
-       <widget class="QWidget" name="normalWidget" native="true">
+       <widget class="QWidget" name="dataPaths" native="true">
         <property name="minimumSize">
          <size>
           <width>0</width>
-          <height>41</height>
+          <height>0</height>
          </size>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
+        <layout class="QGridLayout" name="gridLayout_2">
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="cdPath"/>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLineEdit" name="mediaPath"/>
+         </item>
+         <item row="7" column="2">
+          <widget class="QPushButton" name="savePathOpen">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>55</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Open</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QPushButton" name="mediaPathOpen">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>55</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Open</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QPushButton" name="cdPathOpen">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>55</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Open</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="cdPathLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>CD Path:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="diskPath"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QPushButton" name="diskPathOpen">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>55</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Open</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="diskPathLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Disk Path:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="savePathLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Save Path:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="mediaPathLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Media Path:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QLineEdit" name="savePath"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="QualityOptionsHolder" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>80</height>
+         </size>
+        </property>
+        <layout class="QGridLayout" name="gridLayout">
          <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
           <number>0</number>
          </property>
          <property name="rightMargin">
           <number>0</number>
          </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QGroupBox" name="textureQualityGroup">
-           <property name="title">
-            <string>Island Texture Quality</string>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QRadioButton" name="textureQualityFastRadioButton">
-              <property name="text">
-               <string>Fast</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="textureQualityHighRadioButton">
-              <property name="text">
-               <string>High</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
+         <item row="0" column="3">
           <widget class="QGroupBox" name="modelQualityGroup">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>120</height>
+            </size>
+           </property>
            <property name="title">
             <string>Island Model Quality</string>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <layout class="QVBoxLayout" name="verticalLayout_6">
             <item>
              <widget class="QRadioButton" name="modelQualityLowRadioButton">
               <property name="text">
@@ -144,107 +285,121 @@
            </layout>
           </widget>
          </item>
-         <item>
-          <widget class="QGroupBox" name="colorPaletteGroup">
-           <property name="title">
-            <string>Color Palette</string>
+         <item row="1" column="2">
+          <widget class="QGroupBox" name="maxLoDGroup">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>70</height>
+            </size>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
+           <property name="toolTip">
+            <string>Maximum Level of Detail (LOD). A higher setting will cause higher quality textures to be drawn regardless of distance.</string>
+           </property>
+           <property name="title">
+            <string>Maximum LOD</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
             <item>
-             <widget class="QRadioButton" name="colorPalette256RadioButton">
-              <property name="text">
-               <string>256 Color</string>
+             <widget class="QSlider" name="maxLoDSlider">
+              <property name="maximum">
+               <number>50</number>
               </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="colorPalette16bitRadioButton">
-              <property name="text">
-               <string>High Color (16 bit)</string>
+              <property name="singleStep">
+               <number>5</number>
               </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QWidget" name="musicJoystickWidget" native="true">
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QCheckBox" name="sound3DCheckBox">
-              <property name="text">
-               <string>3D Sound</string>
+              <property name="pageStep">
+               <number>10</number>
               </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="musicCheckBox">
-              <property name="text">
-               <string>Music</string>
+              <property name="value">
+               <number>35</number>
               </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="joystickCheckBox">
-              <property name="text">
-               <string>Use Joystick</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QWidget" name="buttonWidgets" native="true">
-           <layout class="QHBoxLayout" name="horizontalLayout_6">
-            <property name="spacing">
-             <number>30</number>
-            </property>
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QPushButton" name="advancedButton">
-              <property name="text">
-               <string>Advanced</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="okButton">
-              <property name="text">
-               <string>OK</string>
-              </property>
-              <property name="default">
+              <property name="tracking">
                <bool>true</bool>
               </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="tickPosition">
+               <enum>QSlider::TicksBothSides</enum>
+              </property>
+              <property name="tickInterval">
+               <number>10</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QGroupBox" name="textureQualityGroup">
+           <property name="title">
+            <string>Island Texture Quality</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_5">
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QRadioButton" name="textureQualityFastRadioButton">
+              <property name="text">
+               <string>Fast</string>
+              </property>
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="cancelButton">
+             <widget class="QRadioButton" name="textureQualityHighRadioButton">
               <property name="text">
-               <string>Cancel</string>
+               <string>High</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="1" column="3">
+          <widget class="QGroupBox" name="maxActorsGroup">
+           <property name="toolTip">
+            <string>Maximum number of LEGO actors to exist in the world at a time. The game will gradually increase the number of actors until this maximum is reached and while performance is acceptable.</string>
+           </property>
+           <property name="title">
+            <string>Maximum Actors (5..40)</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <item>
+             <widget class="QSlider" name="maxActorsSlider">
+              <property name="minimum">
+               <number>5</number>
+              </property>
+              <property name="maximum">
+               <number>40</number>
+              </property>
+              <property name="singleStep">
+               <number>5</number>
+              </property>
+              <property name="value">
+               <number>20</number>
+              </property>
+              <property name="sliderPosition">
+               <number>20</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="tickPosition">
+               <enum>QSlider::TicksBothSides</enum>
+              </property>
+              <property name="tickInterval">
+               <number>5</number>
               </property>
              </widget>
             </item>
@@ -255,9 +410,89 @@
        </widget>
       </item>
       <item>
-       <widget class="QGroupBox" name="advancedGroup">
+       <widget class="QGroupBox" name="colorPaletteGroup">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>60</height>
+         </size>
+        </property>
         <property name="title">
-         <string>Advanced Settings</string>
+         <string>Color Palette</string>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QRadioButton" name="colorPalette256RadioButton">
+           <property name="text">
+            <string>256 Color</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="colorPalette16bitRadioButton">
+           <property name="text">
+            <string>High Color (16 bit)</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="musicJoystickWidget" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="sound3DCheckBox">
+           <property name="text">
+            <string>3D Sound</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="musicCheckBox">
+           <property name="text">
+            <string>Music</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="joystickCheckBox">
+           <property name="text">
+            <string>Use Joystick</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="advancedGroup">
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>225</height>
+         </size>
+        </property>
+        <property name="title">
+         <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <property name="leftMargin">
@@ -293,6 +528,12 @@
            <property name="enabled">
             <bool>true</bool>
            </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>125</height>
+            </size>
+           </property>
            <property name="editTriggers">
             <set>QAbstractItemView::NoEditTriggers</set>
            </property>
@@ -306,7 +547,13 @@
          </item>
          <item>
           <widget class="QWidget" name="D3DCheckboxWidget" native="true">
-           <layout class="QVBoxLayout" name="verticalLayout_4">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>20</height>
+            </size>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -320,20 +567,65 @@
              <number>0</number>
             </property>
             <item>
-             <widget class="QCheckBox" name="videomemoryCheckBox">
-              <property name="text">
-               <string>Draw 3D to Video Memory</string>
-              </property>
-             </widget>
-            </item>
-            <item>
              <widget class="QCheckBox" name="flipVideoMemoryPagesCheckBox">
               <property name="text">
                <string>Flip Video Memory Pages</string>
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QCheckBox" name="videomemoryCheckBox">
+              <property name="text">
+               <string>Draw 3D to Video Memory</string>
+              </property>
+             </widget>
+            </item>
            </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="buttonWidgets" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <property name="spacing">
+          <number>30</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="okButton">
+           <property name="text">
+            <string>OK</string>
+           </property>
+           <property name="default">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="saveAs">
+           <property name="text">
+            <string>PushButton</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="cancelButton">
+           <property name="text">
+            <string>Cancel</string>
+           </property>
           </widget>
          </item>
         </layout>

--- a/CONFIG/res/maindialog.ui
+++ b/CONFIG/res/maindialog.ui
@@ -120,16 +120,17 @@
             <string>Island Model Quality</string>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
             <item>
-             <widget class="QRadioButton" name="modelQualityFastRadioButton">
+             <widget class="QRadioButton" name="modelQualityLowRadioButton">
               <property name="text">
-               <string>Fast</string>
+               <string>Low</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="modelQualityMediumRadioButton">
+              <property name="text">
+               <string>Medium</string>
               </property>
              </widget>
             </item>
@@ -181,6 +182,13 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
+            <item>
+             <widget class="QCheckBox" name="sound3DCheckBox">
+              <property name="text">
+               <string>3D Sound</string>
+              </property>
+             </widget>
+            </item>
             <item>
              <widget class="QCheckBox" name="musicCheckBox">
               <property name="text">
@@ -298,7 +306,7 @@
          </item>
          <item>
           <widget class="QWidget" name="D3DCheckboxWidget" native="true">
-           <layout class="QGridLayout" name="gridLayout">
+           <layout class="QVBoxLayout" name="verticalLayout_4">
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -311,24 +319,17 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <item row="1" column="0">
-             <widget class="QCheckBox" name="flipVideoMemoryPagesCheckBox">
-              <property name="text">
-               <string>Flip Video Memory Pages</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
+            <item>
              <widget class="QCheckBox" name="videomemoryCheckBox">
               <property name="text">
                <string>Draw 3D to Video Memory</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QCheckBox" name="sound3DCheckBox">
+            <item>
+             <widget class="QCheckBox" name="flipVideoMemoryPagesCheckBox">
               <property name="text">
-               <string>3D Sound</string>
+               <string>Flip Video Memory Pages</string>
               </property>
              </widget>
             </item>

--- a/CONFIG/res/maindialog.ui
+++ b/CONFIG/res/maindialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>575</width>
-    <height>750</height>
+    <height>725</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -53,6 +53,9 @@
      <property name="scaledContents">
       <bool>false</bool>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
     </widget>
    </item>
    <item>
@@ -67,6 +70,12 @@
          </size>
         </property>
         <layout class="QGridLayout" name="gridLayout_2">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
          <item row="2" column="1">
           <widget class="QLineEdit" name="cdPath"/>
          </item>
@@ -417,7 +426,7 @@
         <property name="minimumSize">
          <size>
           <width>0</width>
-          <height>60</height>
+          <height>50</height>
          </size>
         </property>
         <property name="title">
@@ -502,7 +511,7 @@
           <number>6</number>
          </property>
          <property name="topMargin">
-          <number>0</number>
+          <number>6</number>
          </property>
          <property name="rightMargin">
           <number>6</number>
@@ -513,10 +522,16 @@
          <item>
           <widget class="QLabel" name="direct3DDevicesLabel">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>25</height>
+            </size>
            </property>
            <property name="text">
             <string>Direct 3D Devices</string>
@@ -530,6 +545,12 @@
           <widget class="QListWidget" name="devicesList">
            <property name="enabled">
             <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
            <property name="maximumSize">
             <size>
@@ -553,7 +574,7 @@
            <property name="minimumSize">
             <size>
              <width>0</width>
-             <height>20</height>
+             <height>25</height>
             </size>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -567,10 +588,16 @@
              <number>0</number>
             </property>
             <property name="bottomMargin">
-             <number>0</number>
+             <number>6</number>
             </property>
             <item>
              <widget class="QCheckBox" name="flipVideoMemoryPagesCheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Flip Video Memory Pages</string>
               </property>

--- a/CONFIG/res/maindialog.ui
+++ b/CONFIG/res/maindialog.ui
@@ -318,7 +318,7 @@
                <number>35</number>
               </property>
               <property name="tracking">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
@@ -391,6 +391,9 @@
               </property>
               <property name="sliderPosition">
                <number>20</number>
+              </property>
+              <property name="tracking">
+               <bool>false</bool>
               </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
@@ -615,13 +618,6 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="saveAs">
-           <property name="text">
-            <string>PushButton</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QPushButton" name="cancelButton">
            <property name="text">
             <string>Cancel</string>
@@ -636,6 +632,33 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>diskPath</tabstop>
+  <tabstop>diskPathOpen</tabstop>
+  <tabstop>cdPath</tabstop>
+  <tabstop>cdPathOpen</tabstop>
+  <tabstop>mediaPath</tabstop>
+  <tabstop>mediaPathOpen</tabstop>
+  <tabstop>savePath</tabstop>
+  <tabstop>savePathOpen</tabstop>
+  <tabstop>textureQualityFastRadioButton</tabstop>
+  <tabstop>textureQualityHighRadioButton</tabstop>
+  <tabstop>modelQualityLowRadioButton</tabstop>
+  <tabstop>modelQualityMediumRadioButton</tabstop>
+  <tabstop>modelQualityHighRadioButton</tabstop>
+  <tabstop>maxLoDSlider</tabstop>
+  <tabstop>maxActorsSlider</tabstop>
+  <tabstop>colorPalette256RadioButton</tabstop>
+  <tabstop>colorPalette16bitRadioButton</tabstop>
+  <tabstop>sound3DCheckBox</tabstop>
+  <tabstop>musicCheckBox</tabstop>
+  <tabstop>joystickCheckBox</tabstop>
+  <tabstop>devicesList</tabstop>
+  <tabstop>flipVideoMemoryPagesCheckBox</tabstop>
+  <tabstop>videomemoryCheckBox</tabstop>
+  <tabstop>okButton</tabstop>
+  <tabstop>cancelButton</tabstop>
+ </tabstops>
  <resources>
   <include location="config.qrc"/>
  </resources>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b87f84e1-b536-4d83-8962-e1cc4186940d)

Mainly regarding #312 
- Addition of path editing
- Add "Low" model quality option (previously only accessible if the platform had limited RAM)
- Addition of LoD (Level of Detail) and Max Actors sliders
- Removal of `Draw Cursor` (already done in #330)
- Shrinking of `Direct 3D Devices` box (basically only 4 options on modern platforms anyway)
