### PR TITLE
Fix 'incomplete type ‘LegoGameState’ used in nested name specifier'

### DIFF
--- a/LEGO1/lego/legoomni/include/registrationbook.h
+++ b/LEGO1/lego/legoomni/include/registrationbook.h
@@ -1,6 +1,7 @@
 #ifndef REGISTRATIONBOOK_H
 #define REGISTRATIONBOOK_H
 
+#include "legogamestate.h"
 #include "legoworld.h"
 
 class InfocenterState;


### PR DESCRIPTION
This fixed a build error introduced by 6cdbfa86a:
`sizeOfArray(LegoGameState::g_intCharacters)` needs to see the declaration of the `LegoGameState` type