### PR TITLE
miniwin: fix OpenGL include on macOS

### DIFF
--- a/miniwin/src/internal/d3drmrenderer_opengl1.h
+++ b/miniwin/src/internal/d3drmrenderer_opengl1.h
@@ -4,7 +4,12 @@
 #include "d3drmtexture_impl.h"
 #include "ddraw_impl.h"
 
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
+
 #include <SDL3/SDL.h>
 #include <vector>
 


### PR DESCRIPTION
Apple doesn't conform to the otherwise-universal standard and places OpenGL headers in `OpenGL` instead of `GL`, which causes macOS compilation to fail.