### PR TITLE
Add `MA_NO_RUNTIME_LINKING`

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -27,6 +27,7 @@ target_compile_definitions(miniaudio PUBLIC
     MA_NO_RESOURCE_MANAGER
     MA_NO_GENERATION
     MA_NO_THREADING
+    MA_NO_RUNTIME_LINKING
 )
 
 if(DOWNLOAD_DEPENDENCIES)


### PR DESCRIPTION
Since we aren't using any of miniaudio's backends, we don't need any runtime linking.