### PR TITLE
Reflect python 3.11 requirement for shader build script in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
 endif()
 
 find_program(SDL_SHADERCROSS_BIN NAMES "shadercross")
-find_package(Python3 COMPONENTS Interpreter)
+find_package(Python3 3.11 COMPONENTS Interpreter)
 
 option(ISLE_BUILD_APP "Build isle application" ON)
 option(ISLE_ASAN "Enable Address Sanitizer" OFF)


### PR DESCRIPTION
The shader compile script's use of StrEnum requires python 3.11, released in 2022, which I think is an acceptable requirement in this case.