### PR TITLE
Fix Windows file finding

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -1062,21 +1062,22 @@ MxResult IsleApp::VerifyFilesystem()
 	Emscripten_SetupFilesystem();
 #else
 	for (const char* file : g_files) {
-		MxString path(&file[1]);
-		path.MapPathToFilesystem();
-
 		const char* searchPaths[] = {".", m_hdPath, m_cdPath};
-		char buffer[1024];
-
 		bool found = false;
+
 		for (const char* base : searchPaths) {
-			SDL_snprintf(buffer, sizeof(buffer), "%s%s", base, path.GetData());
-			found = SDL_GetPathInfo(buffer, NULL);
-			if (found) {
+			MxString path(base);
+			path += file;
+			path.MapPathToFilesystem();
+
+			if (SDL_GetPathInfo(path.GetData(), NULL)) {
+				found = true;
 				break;
 			}
 		}
+
 		if (!found) {
+			char buffer[1024];
 			SDL_snprintf(
 				buffer,
 				sizeof(buffer),

--- a/LEGO1/omni/include/mxstring.h
+++ b/LEGO1/omni/include/mxstring.h
@@ -24,7 +24,7 @@ public:
 	const MxString& operator=(const char* p_str);
 	MxString operator+(const MxString& p_str) const;
 	MxString operator+(const char* p_str) const;
-	MxString& operator+=(const char* p_str);
+	LEGO1_EXPORT MxString& operator+=(const char* p_str);
 
 	static void CharSwap(char* p_a, char* p_b);
 	LEGO1_EXPORT static void MapPathToFilesystem(char* p_path);

--- a/LEGO1/omni/src/common/mxstring.cpp
+++ b/LEGO1/omni/src/common/mxstring.cpp
@@ -229,5 +229,14 @@ void MxString::MapPathToFilesystem(char* p_path)
 	if (!mapPath(MxOmni::GetHDFiles())) {
 		mapPath(MxOmni::GetCDFiles());
 	}
+#else
+	char* path = p_path;
+	while (*path) {
+		if (*path == '/') {
+			*path = '\\';
+		}
+
+		path++;
+	}
 #endif
 }


### PR DESCRIPTION
The current solution does not take into account that the file path needs to be converted to Windows backslashes.