### PR TITLE
Correct link to Actions yml file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To achieve our goal of platform independence, we need to replace any Windows-onl
 
 ## Building
 
-This project uses the [CMake](https://cmake.org/) build system, which allows for a high degree of versatility regarding compilers and development environments. Please refer to the [GitHub action](/.github/workflows//build.yml) for guidance.
+This project uses the [CMake](https://cmake.org/) build system, which allows for a high degree of versatility regarding compilers and development environments. Please refer to the [GitHub action](/.github/workflows//ci.yml) for guidance.
 
 ## Contributing
 


### PR DESCRIPTION
This just corrects a link in the README to point to ci.yml instead of build.yml (which is a 404).