### PR TITLE
Package for Debian-based distributions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,8 +656,11 @@ elseif(DPKG)
   # Don't replace system SDL3
   list(REMOVE_ITEM install_extra_targets "SDL3-shared")
 
-  # "config" is a vague binary name
-  set_property(TARGET config PROPERTY OUTPUT_NAME "isle-config")
+
+  if(ISLE_BUILD_CONFIG)
+    # "config" is a vague binary name
+    set_property(TARGET config PROPERTY OUTPUT_NAME "isle-config")
+  endif()
 
   set(CPACK_GENERATOR DEB)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -627,10 +627,6 @@ set(ISLE_PACKAGE_NAME "${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}" CACHE STR
 if(BUILD_SHARED_LIBS)
   list(APPEND install_extra_targets lego1)
 endif()
-install(TARGETS isle ${install_extra_targets}
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-)
 if (ISLE_BUILD_CONFIG)
   install(TARGETS config
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
@@ -644,9 +640,33 @@ endif()
 
 set(CPACK_PACKAGE_DIRECTORY "dist")
 set(CPACK_PACKAGE_FILE_NAME "isle-${PROJECT_VERSION}-${ISLE_PACKAGE_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+
+find_program(DPKG dpkg)
 if(MSVC)
   set(CPACK_GENERATOR ZIP)
+elseif(DPKG)
+  set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "LEGO Island for Debian-based distros")
+  set(CPACK_DEBIAN_PACKAGE_VERSION ${PROJECT_VERSION})
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt6core6t64 libsdl3-0")
+  set(CPACK_DEBIAN_PACKAGE_SECTION games)
+  set(CPACK_DEBIAN_PACKAGE_PRIORITY optional)
+  set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/isledecomp/isle-portable")
+  set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Joshua Peisach <itzswirlz2020@outlook.com>")
+
+  # Don't replace system SDL3
+  list(REMOVE_ITEM install_extra_targets "SDL3-shared")
+
+  # "config" is a vague binary name
+  set_property(TARGET config PROPERTY OUTPUT_NAME "isle-config")
+
+  set(CPACK_GENERATOR DEB)
 else()
   set(CPACK_GENERATOR TGZ)
 endif()
+
+install(TARGETS isle ${install_extra_targets}
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+)
+
 include(CPack)


### PR DESCRIPTION
Closes: #366 

I moved the install section a bit later so we ensure that we don't include our built SDL3 in our package, otherwise we will overwrite the system sdl3

I put myself down as the maintainer.

My only thing with this is that we *could* use a [Personal Package Archive](https://launchpad.net/ubuntu/+ppas) (PPA) that then users can add to their apt source list, and then install with `sudo apt install isle`. Then, when we push an update (new backend or whatnot), they can `sudo apt upgrade isle`.

If we did that, we would have to maintain our own *actual* Debian packaging (debian/control, Debian/copyright, debian/rules, all that fun stuff). I can do that, I just don't know if anyone here would be okay with maintaining those files. But we would need to do this in order to actually upload to a PPA (or any archive for that matter), otherwise people will need to reinstall the debs every update from GitHub


---------

TODO: .desktop file entries, but I guess maybe we can save that for another PR since it would probably rely on an `Assets` folder for us to store icons (which we could really use tbh) and generating the executable file path