### PR TITLE
Allow for building on slightly older SDL3 versions

### DIFF
--- a/ISLE/isledebug.cpp
+++ b/ISLE/isledebug.cpp
@@ -184,9 +184,9 @@ void IsleDebug_Init()
 		g_videoPalette =
 			SDL_CreateTexture(g_debugRenderer, SDL_PIXELFORMAT_RGBX32, SDL_TEXTUREACCESS_STREAMING, 16, 16);
 #if SDL_VERSION_ATLEAST(3, 2, 0)
-    SDL_SetTextureScaleMode(g_videoPalette, SDL_SCALEMODE_PIXELART);
+		SDL_SetTextureScaleMode(g_videoPalette, SDL_SCALEMODE_PIXELART);
 #else
-    SDL_SetTextureScaleMode(g_videoPalette, SDL_SCALEMODE_NEAREST);
+		SDL_SetTextureScaleMode(g_videoPalette, SDL_SCALEMODE_NEAREST);
 #endif
 		if (!ImGui_ImplSDLRenderer3_Init(g_debugRenderer)) {
 			g_debugEnabled = false;

--- a/ISLE/isledebug.cpp
+++ b/ISLE/isledebug.cpp
@@ -183,7 +183,11 @@ void IsleDebug_Init()
 		}
 		g_videoPalette =
 			SDL_CreateTexture(g_debugRenderer, SDL_PIXELFORMAT_RGBX32, SDL_TEXTUREACCESS_STREAMING, 16, 16);
-		SDL_SetTextureScaleMode(g_videoPalette, SDL_SCALEMODE_PIXELART);
+#if SDL_VERSION_ATLEAST(3, 2, 0)
+    SDL_SetTextureScaleMode(g_videoPalette, SDL_SCALEMODE_PIXELART);
+#else
+    SDL_SetTextureScaleMode(g_videoPalette, SDL_SCALEMODE_NEAREST);
+#endif
 		if (!ImGui_ImplSDLRenderer3_Init(g_debugRenderer)) {
 			g_debugEnabled = false;
 			break;


### PR DESCRIPTION
SDL_SCALEMODE_PIXELART as introduced in SDL 3.2.0. Not all distros currently has this available, falling back to SDL_SCALEMODE_NEAREST should be good enough to let them build and would only affect things in the debug window.