### PR TITLE
Set `UseJoystick` to true by default

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -109,7 +109,7 @@ IsleApp::IsleApp()
 	m_drawCursor = FALSE;
 	m_use3dSound = TRUE;
 	m_useMusic = TRUE;
-	m_useJoystick = FALSE;
+	m_useJoystick = TRUE;
 	m_joystickIndex = 0;
 	m_wideViewAngle = TRUE;
 	m_islandQuality = 2;


### PR DESCRIPTION
Can't think of a good reason not to have it enabled. Alternative control inputs like touch are already enabled by default.