### PR TITLE
Bump version for SDL_SCALEMODE_PIXELART to 3.3.0

### DIFF
--- a/ISLE/isledebug.cpp
+++ b/ISLE/isledebug.cpp
@@ -183,7 +183,7 @@ void IsleDebug_Init()
 		}
 		g_videoPalette =
 			SDL_CreateTexture(g_debugRenderer, SDL_PIXELFORMAT_RGBX32, SDL_TEXTUREACCESS_STREAMING, 16, 16);
-#if SDL_VERSION_ATLEAST(3, 2, 0)
+#if SDL_VERSION_ATLEAST(3, 3, 0)
 		SDL_SetTextureScaleMode(g_videoPalette, SDL_SCALEMODE_PIXELART);
 #else
 		SDL_SetTextureScaleMode(g_videoPalette, SDL_SCALEMODE_NEAREST);


### PR DESCRIPTION
This feature isn't available in 3.2.0 which lead to compilation error.

Currently mainline is on 3.3.0 and the feature should land there.