### PR TITLE
miniwin: Use PRIu32 for printing uint32_t

### DIFF
--- a/miniwin/src/ddraw/ddraw.cpp
+++ b/miniwin/src/ddraw/ddraw.cpp
@@ -18,6 +18,7 @@
 
 #include <SDL3/SDL.h>
 #include <assert.h>
+#include <cinttypes>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -75,7 +76,7 @@ HRESULT DirectDrawImpl::CreateSurface(
 			if ((lpDDSurfaceDesc->dwFlags & DDSD_ZBUFFERBITDEPTH) != DDSD_ZBUFFERBITDEPTH) {
 				return DDERR_INVALIDPARAMS;
 			}
-			SDL_Log("Todo: Set %dbit Z-Buffer", lpDDSurfaceDesc->dwZBufferBitDepth);
+			SDL_Log("Todo: Set %" PRIu32 "bit Z-Buffer", lpDDSurfaceDesc->dwZBufferBitDepth);
 			*lplpDDSurface = static_cast<IDirectDrawSurface*>(new DummySurfaceImpl);
 			return DD_OK;
 		}


### PR DESCRIPTION
Some architecture uses different type for uint32_t.

| Arch | Type |
| ------ | ------- |
| x86_64,  aarch64        | unsigned int
| xtensa,  riscv32, arm | long unsigned int

This may led to compile error on platform that has a strict warning policy.