### PR TITLE
(Pepper) Fix building variant switch bug

### DIFF
--- a/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
@@ -394,6 +394,7 @@ MxResult LegoBuildingManager::Read(LegoStorage* p_storage)
 		m_nextVariant = 0;
 	}
 
+	// Bugfix: allow Pepper to change variant building after save game load
 	g_buildingInfo[HAUS1_INDEX].m_variant = g_buildingInfoVariants[m_nextVariant];
 
 	result = SUCCESS;

--- a/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legobuildingmanager.cpp
@@ -394,6 +394,8 @@ MxResult LegoBuildingManager::Read(LegoStorage* p_storage)
 		m_nextVariant = 0;
 	}
 
+	g_buildingInfo[HAUS1_INDEX].m_variant = g_buildingInfoVariants[m_nextVariant];
+
 	result = SUCCESS;
 
 done:


### PR DESCRIPTION
This fixes a bug whereas Pepper is unable to change the variant building on the west side of the Island, after a save game has been loaded. The reason for this is that the developers forgot to update the `m_variant` attribute in the building info based on the save data, which causes `GetInfo` to fail for the created entity since the variant name is incorrect.