### PR TITLE
legoinputmanager: Don't set default value for numJoysticks

### DIFF
--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -152,7 +152,7 @@ MxResult LegoInputManager::GetJoystick()
 		return SUCCESS;
 	}
 
-	MxS32 numJoysticks = 0;
+	MxS32 numJoysticks;
 	if (m_joyids == NULL) {
 		m_joyids = SDL_GetJoysticks(&numJoysticks);
 	}


### PR DESCRIPTION
Fixes joysticks not working

--------

For some reason it will find numJoysticks to be 0... even though that's not the case? I found disabling the default value (I guess the time it takes for `SDL_GetJoysticks` to return is too long) to fix this, though I expect compilers to not be happy with me...


If this doesn't work I'll move this to a static or class variable