### PR TITLE
Rendering refactoring

### DIFF
--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -926,7 +926,7 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 				transparentColor = RGB555_CREATE(0x1f, 0, 0x1f);
 				break;
 			default:
-				transparentColor = RGB8888_CREATE(0xff, 0, 0xff, 0);
+				transparentColor = RGB8888_CREATE(0, 0, 0, 0);
 				break;
 			}
 
@@ -971,25 +971,11 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 				surfacePtr += adjustedPitch;
 			}
 
-			if (p_transparent && surface) {
-				DDCOLORKEY key;
-				key.dwColorSpaceLowValue = key.dwColorSpaceHighValue = transparentColor;
-				surface->SetColorKey(DDCKEY_SRCBLT, &key);
-			}
-
 			surface->Unlock(ddsd.lpSurface);
 
-			if (p_transparent && surface) {
+			if (p_transparent && surface && bytesPerPixel != 4) {
 				DDCOLORKEY key;
-				if (bytesPerPixel == 1) {
-					key.dwColorSpaceLowValue = key.dwColorSpaceHighValue = 0;
-				}
-				else if (bytesPerPixel == 2) {
-					key.dwColorSpaceLowValue = key.dwColorSpaceHighValue = RGB555_CREATE(0x1f, 0, 0x1f);
-				}
-				else {
-					key.dwColorSpaceLowValue = key.dwColorSpaceHighValue = RGB8888_CREATE(0xff, 0, 0xff, 0);
-				}
+				key.dwColorSpaceLowValue = key.dwColorSpaceHighValue = transparentColor;
 				surface->SetColorKey(DDCKEY_SRCBLT, &key);
 			}
 		}

--- a/miniwin/src/d3drm/backends/directx9/renderer.cpp
+++ b/miniwin/src/d3drm/backends/directx9/renderer.cpp
@@ -76,7 +76,7 @@ void DirectX9Renderer::AddTextureDestroyCallback(Uint32 id, IDirect3DRMTexture* 
 	);
 }
 
-Uint32 DirectX9Renderer::GetTextureId(IDirect3DRMTexture* iTexture)
+Uint32 DirectX9Renderer::GetTextureId(IDirect3DRMTexture* iTexture, bool isUi)
 {
 	auto texture = static_cast<Direct3DRMTextureImpl*>(iTexture);
 	auto surface = static_cast<DirectDrawSurfaceImpl*>(texture->m_surface);
@@ -221,7 +221,7 @@ void DirectX9Renderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc)
 	halDesc->dcmColorModel = D3DCOLORMODEL::RGB;
 	halDesc->dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
 	halDesc->dwDeviceZBufferBitDepth = DDBD_24;
-	helDesc->dwDeviceRenderBitDepth = DDBD_32;
+	halDesc->dwDeviceRenderBitDepth = DDBD_32;
 	halDesc->dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
 	halDesc->dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
 	halDesc->dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;

--- a/miniwin/src/d3drm/backends/directx9/renderer.cpp
+++ b/miniwin/src/d3drm/backends/directx9/renderer.cpp
@@ -216,24 +216,6 @@ Uint32 DirectX9Renderer::GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshG
 	return static_cast<Uint32>(m_meshs.size() - 1);
 }
 
-void DirectX9Renderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc)
-{
-	halDesc->dcmColorModel = D3DCOLORMODEL::RGB;
-	halDesc->dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
-	halDesc->dwDeviceZBufferBitDepth = DDBD_24;
-	halDesc->dwDeviceRenderBitDepth = DDBD_32;
-	halDesc->dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
-	halDesc->dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
-	halDesc->dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;
-
-	memset(helDesc, 0, sizeof(D3DDEVICEDESC));
-}
-
-const char* DirectX9Renderer::GetName()
-{
-	return "DirectX 9 HAL";
-}
-
 HRESULT DirectX9Renderer::BeginFrame()
 {
 	return Actual_BeginFrame();

--- a/miniwin/src/d3drm/backends/opengl1/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengl1/renderer.cpp
@@ -122,7 +122,7 @@ void OpenGL1Renderer::AddTextureDestroyCallback(Uint32 id, IDirect3DRMTexture* t
 	);
 }
 
-Uint32 OpenGL1Renderer::GetTextureId(IDirect3DRMTexture* iTexture)
+Uint32 OpenGL1Renderer::GetTextureId(IDirect3DRMTexture* iTexture, bool isUi)
 {
 	auto texture = static_cast<Direct3DRMTextureImpl*>(iTexture);
 	auto surface = static_cast<DirectDrawSurfaceImpl*>(texture->m_surface);
@@ -270,7 +270,7 @@ void OpenGL1Renderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc)
 	halDesc->dcmColorModel = D3DCOLORMODEL::RGB;
 	halDesc->dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
 	halDesc->dwDeviceZBufferBitDepth = DDBD_24;
-	helDesc->dwDeviceRenderBitDepth = DDBD_32;
+	halDesc->dwDeviceRenderBitDepth = DDBD_32;
 	halDesc->dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
 	halDesc->dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
 	halDesc->dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;

--- a/miniwin/src/d3drm/backends/opengl1/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengl1/renderer.cpp
@@ -265,24 +265,6 @@ Uint32 OpenGL1Renderer::GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGr
 	return (Uint32) (m_meshs.size() - 1);
 }
 
-void OpenGL1Renderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc)
-{
-	halDesc->dcmColorModel = D3DCOLORMODEL::RGB;
-	halDesc->dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
-	halDesc->dwDeviceZBufferBitDepth = DDBD_24;
-	halDesc->dwDeviceRenderBitDepth = DDBD_32;
-	halDesc->dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
-	halDesc->dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
-	halDesc->dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;
-
-	memset(helDesc, 0, sizeof(D3DDEVICEDESC));
-}
-
-const char* OpenGL1Renderer::GetName()
-{
-	return "OpenGL 1.1 HAL";
-}
-
 HRESULT OpenGL1Renderer::BeginFrame()
 {
 	GL11_BeginFrame((Matrix4x4*) &m_projection[0][0]);

--- a/miniwin/src/d3drm/backends/opengles2/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengles2/renderer.cpp
@@ -239,7 +239,7 @@ void OpenGLES2Renderer::AddTextureDestroyCallback(Uint32 id, IDirect3DRMTexture*
 	);
 }
 
-Uint32 OpenGLES2Renderer::GetTextureId(IDirect3DRMTexture* iTexture)
+Uint32 OpenGLES2Renderer::GetTextureId(IDirect3DRMTexture* iTexture, bool isUi)
 {
 	auto texture = static_cast<Direct3DRMTextureImpl*>(iTexture);
 	auto surface = static_cast<DirectDrawSurfaceImpl*>(texture->m_surface);
@@ -425,7 +425,7 @@ void OpenGLES2Renderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc)
 			halDesc->dwDeviceZBufferBitDepth |= DDBD_32;
 		}
 	}
-	helDesc->dwDeviceRenderBitDepth = DDBD_32;
+	halDesc->dwDeviceRenderBitDepth = DDBD_32;
 	halDesc->dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
 	halDesc->dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
 	halDesc->dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;

--- a/miniwin/src/d3drm/backends/opengles2/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengles2/renderer.cpp
@@ -181,14 +181,88 @@ Direct3DRMRenderer* OpenGLES2Renderer::Create(DWORD width, DWORD height)
 	return new OpenGLES2Renderer(width, height, context, shaderProgram);
 }
 
+GLES2MeshCacheEntry GLES2UploadMesh(const MeshGroup& meshGroup, bool forceUV = false)
+{
+	GLES2MeshCacheEntry cache{&meshGroup, meshGroup.version};
+
+	cache.flat = meshGroup.quality == D3DRMRENDER_FLAT || meshGroup.quality == D3DRMRENDER_UNLITFLAT;
+
+	std::vector<D3DRMVERTEX> vertices;
+	if (cache.flat) {
+		FlattenSurfaces(
+			meshGroup.vertices.data(),
+			meshGroup.vertices.size(),
+			meshGroup.indices.data(),
+			meshGroup.indices.size(),
+			meshGroup.texture != nullptr || forceUV,
+			vertices,
+			cache.indices
+		);
+	}
+	else {
+		vertices = meshGroup.vertices;
+		cache.indices.resize(meshGroup.indices.size());
+		std::transform(meshGroup.indices.begin(), meshGroup.indices.end(), cache.indices.begin(), [](DWORD index) {
+			return static_cast<uint16_t>(index);
+		});
+	}
+
+	std::vector<TexCoord> texcoords;
+	if (meshGroup.texture || forceUV) {
+		texcoords.resize(vertices.size());
+		std::transform(vertices.begin(), vertices.end(), texcoords.begin(), [](const D3DRMVERTEX& v) {
+			return v.texCoord;
+		});
+	}
+	std::vector<D3DVECTOR> positions(vertices.size());
+	std::transform(vertices.begin(), vertices.end(), positions.begin(), [](const D3DRMVERTEX& v) {
+		return v.position;
+	});
+	std::vector<D3DVECTOR> normals(vertices.size());
+	std::transform(vertices.begin(), vertices.end(), normals.begin(), [](const D3DRMVERTEX& v) { return v.normal; });
+
+	glGenBuffers(1, &cache.vboPositions);
+	glBindBuffer(GL_ARRAY_BUFFER, cache.vboPositions);
+	glBufferData(GL_ARRAY_BUFFER, positions.size() * sizeof(D3DVECTOR), positions.data(), GL_STATIC_DRAW);
+
+	glGenBuffers(1, &cache.vboNormals);
+	glBindBuffer(GL_ARRAY_BUFFER, cache.vboNormals);
+	glBufferData(GL_ARRAY_BUFFER, normals.size() * sizeof(D3DVECTOR), normals.data(), GL_STATIC_DRAW);
+
+	if (meshGroup.texture || forceUV) {
+		glGenBuffers(1, &cache.vboTexcoords);
+		glBindBuffer(GL_ARRAY_BUFFER, cache.vboTexcoords);
+		glBufferData(GL_ARRAY_BUFFER, texcoords.size() * sizeof(TexCoord), texcoords.data(), GL_STATIC_DRAW);
+	}
+
+	glGenBuffers(1, &cache.ibo);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, cache.ibo);
+	glBufferData(
+		GL_ELEMENT_ARRAY_BUFFER,
+		cache.indices.size() * sizeof(cache.indices[0]),
+		cache.indices.data(),
+		GL_STATIC_DRAW
+	);
+
+	return cache;
+}
+
 OpenGLES2Renderer::OpenGLES2Renderer(DWORD width, DWORD height, SDL_GLContext context, GLuint shaderProgram)
 	: m_context(context), m_shaderProgram(shaderProgram)
 {
-	m_width = width;
-	m_height = height;
 	m_virtualWidth = width;
 	m_virtualHeight = height;
-	m_renderedImage = SDL_CreateSurface(m_width, m_height, SDL_PIXELFORMAT_RGBA32);
+	ViewportTransform viewportTransform = {1.0f, 0.0f, 0.0f};
+	Resize(width, height, viewportTransform);
+
+	m_uiMesh.vertices = {
+		{{0.0f, 0.0f, 0.0f}, {0, 0, -1}, {0.0f, 0.0f}},
+		{{1.0f, 0.0f, 0.0f}, {0, 0, -1}, {1.0f, 0.0f}},
+		{{1.0f, 1.0f, 0.0f}, {0, 0, -1}, {1.0f, 1.0f}},
+		{{0.0f, 1.0f, 0.0f}, {0, 0, -1}, {0.0f, 1.0f}}
+	};
+	m_uiMesh.indices = {0, 1, 2, 0, 2, 3};
+	m_uiMeshCache = GLES2UploadMesh(m_uiMesh, true);
 }
 
 OpenGLES2Renderer::~OpenGLES2Renderer()
@@ -239,6 +313,47 @@ void OpenGLES2Renderer::AddTextureDestroyCallback(Uint32 id, IDirect3DRMTexture*
 	);
 }
 
+bool UploadTexture(SDL_Surface* source, GLuint& outTexId, bool isUi)
+{
+	SDL_Surface* surf = source;
+	if (source->format != SDL_PIXELFORMAT_RGBA32) {
+		surf = SDL_ConvertSurface(source, SDL_PIXELFORMAT_RGBA32);
+		if (!surf) {
+			return false;
+		}
+	}
+
+	glGenTextures(1, &outTexId);
+	glBindTexture(GL_TEXTURE_2D, outTexId);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, surf->w, surf->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, surf->pixels);
+
+	if (isUi) {
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	}
+	else {
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		if (strstr((const char*) glGetString(GL_EXTENSIONS), "GL_EXT_texture_filter_anisotropic")) {
+			GLfloat maxAniso = 0.0f;
+			glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAniso);
+			GLfloat desiredAniso = fminf(8.0f, maxAniso);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, desiredAniso);
+		}
+		glGenerateMipmap(GL_TEXTURE_2D);
+	}
+
+	if (surf != source) {
+		SDL_DestroySurface(surf);
+	}
+
+	return true;
+}
+
 Uint32 OpenGLES2Renderer::GetTextureId(IDirect3DRMTexture* iTexture, bool isUi)
 {
 	auto texture = static_cast<Direct3DRMTextureImpl*>(iTexture);
@@ -249,31 +364,18 @@ Uint32 OpenGLES2Renderer::GetTextureId(IDirect3DRMTexture* iTexture, bool isUi)
 		if (tex.texture == texture) {
 			if (tex.version != texture->m_version) {
 				glDeleteTextures(1, &tex.glTextureId);
-				glGenTextures(1, &tex.glTextureId);
-				glBindTexture(GL_TEXTURE_2D, tex.glTextureId);
-
-				SDL_Surface* surf = SDL_ConvertSurface(surface->m_surface, SDL_PIXELFORMAT_RGBA32);
-				if (!surf) {
-					return NO_TEXTURE_ID;
+				if (UploadTexture(surface->m_surface, tex.glTextureId, isUi)) {
+					tex.version = texture->m_version;
 				}
-				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, surf->w, surf->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, surf->pixels);
-				SDL_DestroySurface(surf);
-
-				tex.version = texture->m_version;
 			}
 			return i;
 		}
 	}
 
 	GLuint texId;
-	glGenTextures(1, &texId);
-	glBindTexture(GL_TEXTURE_2D, texId);
-
-	SDL_Surface* surf = SDL_ConvertSurface(surface->m_surface, SDL_PIXELFORMAT_RGBA32);
-	if (!surf) {
+	if (!UploadTexture(surface->m_surface, texId, isUi)) {
 		return NO_TEXTURE_ID;
 	}
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, surf->w, surf->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, surf->pixels);
 
 	for (Uint32 i = 0; i < m_textures.size(); ++i) {
 		auto& tex = m_textures[i];
@@ -281,83 +383,18 @@ Uint32 OpenGLES2Renderer::GetTextureId(IDirect3DRMTexture* iTexture, bool isUi)
 			tex.texture = texture;
 			tex.version = texture->m_version;
 			tex.glTextureId = texId;
-			tex.width = surf->w;
-			tex.height = surf->h;
+			tex.width = surface->m_surface->w;
+			tex.height = surface->m_surface->h;
 			AddTextureDestroyCallback(i, texture);
 			return i;
 		}
 	}
 
-	m_textures.push_back({texture, texture->m_version, texId, (uint16_t) surf->w, (uint16_t) surf->h});
-	SDL_DestroySurface(surf);
+	m_textures.push_back(
+		{texture, texture->m_version, texId, (uint16_t) surface->m_surface->w, (uint16_t) surface->m_surface->h}
+	);
 	AddTextureDestroyCallback((Uint32) (m_textures.size() - 1), texture);
 	return (Uint32) (m_textures.size() - 1);
-}
-
-GLES2MeshCacheEntry GLES2UploadMesh(const MeshGroup& meshGroup)
-{
-	GLES2MeshCacheEntry cache{&meshGroup, meshGroup.version};
-
-	cache.flat = meshGroup.quality == D3DRMRENDER_FLAT || meshGroup.quality == D3DRMRENDER_UNLITFLAT;
-
-	std::vector<D3DRMVERTEX> vertices;
-	if (cache.flat) {
-		FlattenSurfaces(
-			meshGroup.vertices.data(),
-			meshGroup.vertices.size(),
-			meshGroup.indices.data(),
-			meshGroup.indices.size(),
-			meshGroup.texture != nullptr,
-			vertices,
-			cache.indices
-		);
-	}
-	else {
-		vertices = meshGroup.vertices;
-		cache.indices.resize(meshGroup.indices.size());
-		std::transform(meshGroup.indices.begin(), meshGroup.indices.end(), cache.indices.begin(), [](DWORD index) {
-			return static_cast<uint16_t>(index);
-		});
-	}
-
-	std::vector<TexCoord> texcoords;
-	if (meshGroup.texture) {
-		texcoords.resize(vertices.size());
-		std::transform(vertices.begin(), vertices.end(), texcoords.begin(), [](const D3DRMVERTEX& v) {
-			return v.texCoord;
-		});
-	}
-	std::vector<D3DVECTOR> positions(vertices.size());
-	std::transform(vertices.begin(), vertices.end(), positions.begin(), [](const D3DRMVERTEX& v) {
-		return v.position;
-	});
-	std::vector<D3DVECTOR> normals(vertices.size());
-	std::transform(vertices.begin(), vertices.end(), normals.begin(), [](const D3DRMVERTEX& v) { return v.normal; });
-
-	glGenBuffers(1, &cache.vboPositions);
-	glBindBuffer(GL_ARRAY_BUFFER, cache.vboPositions);
-	glBufferData(GL_ARRAY_BUFFER, positions.size() * sizeof(D3DVECTOR), positions.data(), GL_STATIC_DRAW);
-
-	glGenBuffers(1, &cache.vboNormals);
-	glBindBuffer(GL_ARRAY_BUFFER, cache.vboNormals);
-	glBufferData(GL_ARRAY_BUFFER, normals.size() * sizeof(D3DVECTOR), normals.data(), GL_STATIC_DRAW);
-
-	if (meshGroup.texture) {
-		glGenBuffers(1, &cache.vboTexcoords);
-		glBindBuffer(GL_ARRAY_BUFFER, cache.vboTexcoords);
-		glBufferData(GL_ARRAY_BUFFER, texcoords.size() * sizeof(TexCoord), texcoords.data(), GL_STATIC_DRAW);
-	}
-
-	glGenBuffers(1, &cache.ibo);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, cache.ibo);
-	glBufferData(
-		GL_ELEMENT_ARRAY_BUFFER,
-		cache.indices.size() * sizeof(cache.indices[0]),
-		cache.indices.data(),
-		GL_STATIC_DRAW
-	);
-
-	return cache;
 }
 
 struct GLES2MeshDestroyContext {
@@ -411,37 +448,11 @@ Uint32 OpenGLES2Renderer::GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* mesh
 	return (Uint32) (m_meshs.size() - 1);
 }
 
-void OpenGLES2Renderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc)
-{
-	halDesc->dcmColorModel = D3DCOLORMODEL::RGB;
-	halDesc->dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
-	halDesc->dwDeviceZBufferBitDepth = DDBD_16;
-	const char* extensions = (const char*) glGetString(GL_EXTENSIONS);
-	if (extensions) {
-		if (strstr(extensions, "GL_OES_depth24")) {
-			halDesc->dwDeviceZBufferBitDepth |= DDBD_24;
-		}
-		if (strstr(extensions, "GL_OES_depth32")) {
-			halDesc->dwDeviceZBufferBitDepth |= DDBD_32;
-		}
-	}
-	halDesc->dwDeviceRenderBitDepth = DDBD_32;
-	halDesc->dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
-	halDesc->dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
-	halDesc->dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;
-
-	memset(helDesc, 0, sizeof(D3DDEVICEDESC));
-}
-
-const char* OpenGLES2Renderer::GetName()
-{
-	return "OpenGL ES 2.0 HAL";
-}
-
 HRESULT OpenGLES2Renderer::BeginFrame()
 {
 	m_dirty = true;
 
+	glEnable(GL_CULL_FACE);
 	glDisable(GL_BLEND);
 	glEnable(GL_DEPTH_TEST);
 	glDepthMask(GL_TRUE);
@@ -516,8 +527,6 @@ void OpenGLES2Renderer::SubmitDraw(
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, m_textures[appearance.textureId].glTextureId);
 		glUniform1i(glGetUniformLocation(m_shaderProgram, "u_texture"), 0);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	}
 	else {
 		glUniform1i(glGetUniformLocation(m_shaderProgram, "u_useTexture"), 0);
@@ -543,7 +552,6 @@ void OpenGLES2Renderer::SubmitDraw(
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.ibo);
 	glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(mesh.indices.size()), GL_UNSIGNED_SHORT, nullptr);
 
-	glDisableVertexAttribArray(posLoc);
 	glDisableVertexAttribArray(normLoc);
 	glDisableVertexAttribArray(texLoc);
 }
@@ -562,7 +570,9 @@ void OpenGLES2Renderer::Resize(int width, int height, const ViewportTransform& v
 	m_width = width;
 	m_height = height;
 	m_viewportTransform = viewportTransform;
-	SDL_DestroySurface(m_renderedImage);
+	if (m_renderedImage) {
+		SDL_DestroySurface(m_renderedImage);
+	}
 	m_renderedImage = SDL_CreateSurface(m_width, m_height, SDL_PIXELFORMAT_RGBA32);
 	glViewport(0, 0, m_width, m_height);
 }
@@ -584,35 +594,6 @@ void OpenGLES2Renderer::Flip()
 	}
 }
 
-void CreateOrthoMatrix(float left, float right, float bottom, float top, D3DRMMATRIX4D& outMatrix)
-{
-	float near = -1.0f;
-	float far = 1.0f;
-	float rl = right - left;
-	float tb = top - bottom;
-	float fn = far - near;
-
-	outMatrix[0][0] = 2.0f / rl;
-	outMatrix[0][1] = 0.0f;
-	outMatrix[0][2] = 0.0f;
-	outMatrix[0][3] = 0.0f;
-
-	outMatrix[1][0] = 0.0f;
-	outMatrix[1][1] = 2.0f / tb;
-	outMatrix[1][2] = 0.0f;
-	outMatrix[1][3] = 0.0f;
-
-	outMatrix[2][0] = 0.0f;
-	outMatrix[2][1] = 0.0f;
-	outMatrix[2][2] = -2.0f / fn;
-	outMatrix[2][3] = 0.0f;
-
-	outMatrix[3][0] = -(right + left) / rl;
-	outMatrix[3][1] = -(top + bottom) / tb;
-	outMatrix[3][2] = -(far + near) / fn;
-	outMatrix[3][3] = 1.0f;
-}
-
 void OpenGLES2Renderer::Draw2DImage(Uint32 textureId, const SDL_Rect& srcRect, const SDL_Rect& dstRect)
 {
 	m_dirty = true;
@@ -632,17 +613,29 @@ void OpenGLES2Renderer::Draw2DImage(Uint32 textureId, const SDL_Rect& srcRect, c
 	glUniform4f(glGetUniformLocation(m_shaderProgram, "u_color"), 1.0f, 1.0f, 1.0f, 1.0f);
 	glUniform1f(glGetUniformLocation(m_shaderProgram, "u_shininess"), 0.0f);
 
-	float left = -m_viewportTransform.offsetX / m_viewportTransform.scale;
-	float right = (m_width - m_viewportTransform.offsetX) / m_viewportTransform.scale;
-	float top = -m_viewportTransform.offsetY / m_viewportTransform.scale;
-	float bottom = (m_height - m_viewportTransform.offsetY) / m_viewportTransform.scale;
+	const GLES2TextureCacheEntry& texture = m_textures[textureId];
+	float scaleX = static_cast<float>(dstRect.w) / srcRect.w;
+	float scaleY = static_cast<float>(dstRect.h) / srcRect.h;
+	SDL_Rect expandedDstRect = {
+		static_cast<int>(std::round(dstRect.x - srcRect.x * scaleX)),
+		static_cast<int>(std::round(dstRect.y - srcRect.y * scaleY)),
+		static_cast<int>(std::round(texture.width * scaleX)),
+		static_cast<int>(std::round(texture.height * scaleY))
+	};
 
-	D3DRMMATRIX4D projection;
-	CreateOrthoMatrix(left, right, bottom, top, projection);
+	D3DRMMATRIX4D modelView, projection;
+	Create2DTransformMatrix(
+		expandedDstRect,
+		m_viewportTransform.scale,
+		m_viewportTransform.offsetX,
+		m_viewportTransform.offsetY,
+		modelView
+	);
 
-	D3DRMMATRIX4D identity = {{1.f, 0.f, 0.f, 0.f}, {0.f, 1.f, 0.f, 0.f}, {0.f, 0.f, 1.f, 0.f}, {0.f, 0.f, 0.f, 1.f}};
-	glUniformMatrix4fv(glGetUniformLocation(m_shaderProgram, "u_modelViewMatrix"), 1, GL_FALSE, &identity[0][0]);
+	glUniformMatrix4fv(glGetUniformLocation(m_shaderProgram, "u_modelViewMatrix"), 1, GL_FALSE, &modelView[0][0]);
+	Matrix3x3 identity = {{1.f, 0.f, 0.f}, {0.f, 1.f, 0.f}, {0.f, 0.f, 1.f}};
 	glUniformMatrix3fv(glGetUniformLocation(m_shaderProgram, "u_normalMatrix"), 1, GL_FALSE, &identity[0][0]);
+	CreateOrthographicProjection((float) m_width, (float) m_height, projection);
 	glUniformMatrix4fv(glGetUniformLocation(m_shaderProgram, "u_projectionMatrix"), 1, GL_FALSE, &projection[0][0]);
 
 	glEnable(GL_BLEND);
@@ -650,42 +643,34 @@ void OpenGLES2Renderer::Draw2DImage(Uint32 textureId, const SDL_Rect& srcRect, c
 
 	glActiveTexture(GL_TEXTURE0);
 	glUniform1i(glGetUniformLocation(m_shaderProgram, "u_useTexture"), 1);
-	const GLES2TextureCacheEntry& texture = m_textures[textureId];
 	glBindTexture(GL_TEXTURE_2D, texture.glTextureId);
 	glUniform1i(glGetUniformLocation(m_shaderProgram, "u_texture"), 0);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	float texW = texture.width;
-	float texH = texture.height;
 
-	float u1 = srcRect.x / texW;
-	float v1 = srcRect.y / texH;
-	float u2 = (srcRect.x + srcRect.w) / texW;
-	float v2 = (srcRect.y + srcRect.h) / texH;
-
-	float x1 = static_cast<float>(dstRect.x);
-	float y1 = static_cast<float>(dstRect.y);
-	float x2 = x1 + dstRect.w;
-	float y2 = y1 + dstRect.h;
-
-	GLfloat vertices[] = {x1, y1, u1, v1, x2, y1, u2, v1, x1, y2, u1, v2, x2, y2, u2, v2};
+	glEnable(GL_SCISSOR_TEST);
+	glScissor(
+		static_cast<int>(std::round(dstRect.x * m_viewportTransform.scale + m_viewportTransform.offsetX)),
+		m_height - static_cast<int>(
+					   std::round((dstRect.y + dstRect.h) * m_viewportTransform.scale + m_viewportTransform.offsetY)
+				   ),
+		static_cast<int>(std::round(dstRect.w * m_viewportTransform.scale)),
+		static_cast<int>(std::round(dstRect.h * m_viewportTransform.scale))
+	);
 
 	GLint posLoc = glGetAttribLocation(m_shaderProgram, "a_position");
-	GLint texLoc = glGetAttribLocation(m_shaderProgram, "a_texCoord");
-
+	glBindBuffer(GL_ARRAY_BUFFER, m_uiMeshCache.vboPositions);
 	glEnableVertexAttribArray(posLoc);
+	glVertexAttribPointer(posLoc, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
+
+	GLint texLoc = glGetAttribLocation(m_shaderProgram, "a_texCoord");
+	glBindBuffer(GL_ARRAY_BUFFER, m_uiMeshCache.vboTexcoords);
 	glEnableVertexAttribArray(texLoc);
+	glVertexAttribPointer(texLoc, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
 
-	glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat), vertices);
-	glVertexAttribPointer(texLoc, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat), vertices + 2);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_uiMeshCache.ibo);
+	glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(m_uiMeshCache.indices.size()), GL_UNSIGNED_SHORT, nullptr);
 
-	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-
-	glDisableVertexAttribArray(posLoc);
 	glDisableVertexAttribArray(texLoc);
-
-	glBindTexture(GL_TEXTURE_2D, 0);
-	glUseProgram(0);
+	glDisable(GL_SCISSOR_TEST);
 }
 
 void OpenGLES2Renderer::Download(SDL_Surface* target)

--- a/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
+++ b/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
@@ -533,7 +533,7 @@ SDL_GPUTexture* Direct3DRMSDL3GPURenderer::CreateTextureFromSurface(SDL_Surface*
 	return texptr;
 }
 
-Uint32 Direct3DRMSDL3GPURenderer::GetTextureId(IDirect3DRMTexture* iTexture)
+Uint32 Direct3DRMSDL3GPURenderer::GetTextureId(IDirect3DRMTexture* iTexture, bool isUi)
 {
 	auto texture = static_cast<Direct3DRMTextureImpl*>(iTexture);
 	auto surface = static_cast<DirectDrawSurfaceImpl*>(texture->m_surface);

--- a/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
+++ b/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
@@ -585,7 +585,7 @@ SDL3MeshCache Direct3DRMSDL3GPURenderer::UploadMesh(const MeshGroup& meshGroup)
 			meshGroup.vertices.size(),
 			meshGroup.indices.data(),
 			meshGroup.indices.size(),
-			meshGroup.texture != nullptr,
+			true,
 			finalVertices,
 			newIndices
 		);
@@ -710,24 +710,6 @@ Uint32 Direct3DRMSDL3GPURenderer::GetMeshId(IDirect3DRMMesh* mesh, const MeshGro
 	m_meshs.push_back(std::move(newCache));
 	AddMeshDestroyCallback((Uint32) (m_meshs.size() - 1), mesh);
 	return (Uint32) (m_meshs.size() - 1);
-}
-
-void Direct3DRMSDL3GPURenderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc)
-{
-	halDesc->dcmColorModel = D3DCOLORMODEL::RGB;
-	halDesc->dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
-	halDesc->dwDeviceZBufferBitDepth = DDBD_32; // Todo add support for other depths
-	halDesc->dwDeviceRenderBitDepth = DDBD_32;
-	halDesc->dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
-	halDesc->dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
-	halDesc->dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;
-
-	memset(helDesc, 0, sizeof(D3DDEVICEDESC));
-}
-
-const char* Direct3DRMSDL3GPURenderer::GetName()
-{
-	return "SDL3 GPU HAL";
 }
 
 void PackNormalMatrix(const Matrix3x3& normalMatrix3x3, D3DRMMATRIX4D& packedNormalMatrix4x4)
@@ -938,37 +920,6 @@ void Direct3DRMSDL3GPURenderer::Flip()
 	SDL_BlitGPUTexture(m_cmdbuf, &blit);
 	SDL_SubmitGPUCommandBuffer(m_cmdbuf);
 	m_cmdbuf = nullptr;
-}
-
-// TODO use  SDL_SetGPUScissor(SDL_GPURenderPass *render_pass, const SDL_Rect *scissor) when srcRect isn't 100% of
-// texture
-
-void Create2DTransformMatrix(
-	const SDL_Rect& dstRect,
-	float scale,
-	float offsetX,
-	float offsetY,
-	D3DRMMATRIX4D& outMatrix
-)
-{
-	float x = static_cast<float>(dstRect.x) * scale + offsetX;
-	float y = static_cast<float>(dstRect.y) * scale + offsetY;
-	float w = static_cast<float>(dstRect.w) * scale;
-	float h = static_cast<float>(dstRect.h) * scale;
-
-	D3DVALUE tmp[4][4] = {{w, 0, 0, 0}, {0, h, 0, 0}, {0, 0, 1, 0}, {x, y, 0, 1}};
-	memcpy(outMatrix, tmp, sizeof(tmp));
-}
-
-void CreateOrthographicProjection(float width, float height, D3DRMMATRIX4D& outProj)
-{
-	D3DVALUE tmp[4][4] = {
-		{2.0f / width, 0.0f, 0.0f, 0.0f},
-		{0.0f, -2.0f / height, 0.0f, 0.0f},
-		{0.0f, 0.0f, 1.0f, 0.0f},
-		{-1.0f, 1.0f, 0.0f, 1.0f}
-	};
-	memcpy(outProj, tmp, sizeof(tmp));
 }
 
 void Direct3DRMSDL3GPURenderer::Draw2DImage(Uint32 textureId, const SDL_Rect& srcRect, const SDL_Rect& dstRect)

--- a/miniwin/src/d3drm/backends/software/renderer.cpp
+++ b/miniwin/src/d3drm/backends/software/renderer.cpp
@@ -554,7 +554,7 @@ void Direct3DRMSoftwareRenderer::AddTextureDestroyCallback(Uint32 id, IDirect3DR
 	);
 }
 
-Uint32 Direct3DRMSoftwareRenderer::GetTextureId(IDirect3DRMTexture* iTexture)
+Uint32 Direct3DRMSoftwareRenderer::GetTextureId(IDirect3DRMTexture* iTexture, bool isUi)
 {
 	auto texture = static_cast<Direct3DRMTextureImpl*>(iTexture);
 	auto surface = static_cast<DirectDrawSurfaceImpl*>(texture->m_surface);

--- a/miniwin/src/d3drm/backends/software/renderer.cpp
+++ b/miniwin/src/d3drm/backends/software/renderer.cpp
@@ -664,24 +664,6 @@ Uint32 Direct3DRMSoftwareRenderer::GetMeshId(IDirect3DRMMesh* mesh, const MeshGr
 	return (Uint32) (m_meshs.size() - 1);
 }
 
-void Direct3DRMSoftwareRenderer::GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc)
-{
-	memset(halDesc, 0, sizeof(D3DDEVICEDESC));
-
-	helDesc->dcmColorModel = D3DCOLORMODEL::RGB;
-	helDesc->dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
-	helDesc->dwDeviceZBufferBitDepth = DDBD_32;
-	helDesc->dwDeviceRenderBitDepth = DDBD_32;
-	helDesc->dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
-	helDesc->dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
-	helDesc->dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;
-}
-
-const char* Direct3DRMSoftwareRenderer::GetName()
-{
-	return "Miniwin Emulation";
-}
-
 HRESULT Direct3DRMSoftwareRenderer::BeginFrame()
 {
 	if (!m_renderedImage || !SDL_LockSurface(m_renderedImage)) {

--- a/miniwin/src/ddraw/ddraw.cpp
+++ b/miniwin/src/ddraw/ddraw.cpp
@@ -207,14 +207,18 @@ HRESULT DirectDrawImpl::GetCaps(LPDDCAPS lpDDDriverCaps, LPDDCAPS lpDDHELCaps)
 	return S_OK;
 }
 
-void EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx, Direct3DRMRenderer* device, GUID deviceGuid)
+void EnumDevice(
+	LPD3DENUMDEVICESCALLBACK cb,
+	void* ctx,
+	const char* name,
+	D3DDEVICEDESC* halDesc,
+	D3DDEVICEDESC* helDesc,
+	GUID deviceGuid
+)
 {
-	D3DDEVICEDESC halDesc = {};
-	D3DDEVICEDESC helDesc = {};
-	device->GetDesc(&halDesc, &helDesc);
-	char* deviceNameDup = SDL_strdup(device->GetName());
+	char* deviceNameDup = SDL_strdup(name);
 	char* deviceDescDup = SDL_strdup("Miniwin driver");
-	cb(&deviceGuid, deviceNameDup, deviceDescDup, &halDesc, &helDesc, ctx);
+	cb(&deviceGuid, deviceNameDup, deviceDescDup, halDesc, helDesc, ctx);
 	SDL_free(deviceDescDup);
 	SDL_free(deviceNameDup);
 }

--- a/miniwin/src/ddraw/framebuffer.cpp
+++ b/miniwin/src/ddraw/framebuffer.cpp
@@ -62,7 +62,7 @@ HRESULT FrameBufferImpl::Blt(
 	if (!surface) {
 		return DDERR_GENERIC;
 	}
-	Uint32 textureId = DDRenderer->GetTextureId(surface->ToTexture());
+	Uint32 textureId = DDRenderer->GetTextureId(surface->ToTexture(), true);
 	SDL_Rect srcRect =
 		lpSrcRect ? ConvertRect(lpSrcRect) : SDL_Rect{0, 0, surface->m_surface->w, surface->m_surface->h};
 	SDL_Rect dstRect =

--- a/miniwin/src/internal/d3drmrenderer.h
+++ b/miniwin/src/internal/d3drmrenderer.h
@@ -31,7 +31,7 @@ public:
 	virtual void PushLights(const SceneLight* vertices, size_t count) = 0;
 	virtual void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) = 0;
 	virtual void SetFrustumPlanes(const Plane* frustumPlanes) = 0;
-	virtual Uint32 GetTextureId(IDirect3DRMTexture* texture) = 0;
+	virtual Uint32 GetTextureId(IDirect3DRMTexture* texture, bool isUi = false) = 0;
 	virtual Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) = 0;
 	int GetWidth() { return m_width; }
 	int GetHeight() { return m_height; }

--- a/miniwin/src/internal/d3drmrenderer.h
+++ b/miniwin/src/internal/d3drmrenderer.h
@@ -37,8 +37,6 @@ public:
 	int GetHeight() { return m_height; }
 	int GetVirtualWidth() { return m_virtualWidth; }
 	int GetVirtualHeight() { return m_virtualHeight; }
-	virtual void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) = 0;
-	virtual const char* GetName() = 0;
 	virtual HRESULT BeginFrame() = 0;
 	virtual void EnableTransparency() = 0;
 	virtual void SubmitDraw(

--- a/miniwin/src/internal/d3drmrenderer_directx9.h
+++ b/miniwin/src/internal/d3drmrenderer_directx9.h
@@ -18,7 +18,7 @@ public:
 	void PushLights(const SceneLight* lightsArray, size_t count) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
 	void SetFrustumPlanes(const Plane* frustumPlanes) override;
-	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
+	Uint32 GetTextureId(IDirect3DRMTexture* texture, bool isUi) override;
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
 	const char* GetName() override;

--- a/miniwin/src/internal/d3drmrenderer_directx9.h
+++ b/miniwin/src/internal/d3drmrenderer_directx9.h
@@ -20,8 +20,6 @@ public:
 	void SetFrustumPlanes(const Plane* frustumPlanes) override;
 	Uint32 GetTextureId(IDirect3DRMTexture* texture, bool isUi) override;
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
-	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
-	const char* GetName() override;
 	HRESULT BeginFrame() override;
 	void EnableTransparency() override;
 	void SubmitDraw(
@@ -52,8 +50,21 @@ private:
 inline static void DirectX9Renderer_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
 	Direct3DRMRenderer* device = DirectX9Renderer::Create(640, 480);
-	if (device) {
-		EnumDevice(cb, ctx, device, DirectX9_GUID);
-		delete device;
+	if (!device) {
+		return;
 	}
+	delete device;
+
+	D3DDEVICEDESC halDesc = {};
+	halDesc.dcmColorModel = D3DCOLOR_RGB;
+	halDesc.dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
+	halDesc.dwDeviceZBufferBitDepth = DDBD_24;
+	halDesc.dwDeviceRenderBitDepth = DDBD_32;
+	halDesc.dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
+	halDesc.dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
+	halDesc.dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;
+
+	D3DDEVICEDESC helDesc = {};
+
+	EnumDevice(cb, ctx, "DirectX 9 HAL", &halDesc, &helDesc, DirectX9_GUID);
 }

--- a/miniwin/src/internal/d3drmrenderer_opengl1.h
+++ b/miniwin/src/internal/d3drmrenderer_opengl1.h
@@ -18,7 +18,7 @@ public:
 	void PushLights(const SceneLight* lightsArray, size_t count) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
 	void SetFrustumPlanes(const Plane* frustumPlanes) override;
-	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
+	Uint32 GetTextureId(IDirect3DRMTexture* texture, bool isUi) override;
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
 	const char* GetName() override;

--- a/miniwin/src/internal/d3drmrenderer_opengl1.h
+++ b/miniwin/src/internal/d3drmrenderer_opengl1.h
@@ -20,8 +20,6 @@ public:
 	void SetFrustumPlanes(const Plane* frustumPlanes) override;
 	Uint32 GetTextureId(IDirect3DRMTexture* texture, bool isUi) override;
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
-	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
-	const char* GetName() override;
 	HRESULT BeginFrame() override;
 	void EnableTransparency() override;
 	void SubmitDraw(
@@ -57,8 +55,21 @@ private:
 inline static void OpenGL1Renderer_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
 	Direct3DRMRenderer* device = OpenGL1Renderer::Create(640, 480);
-	if (device) {
-		EnumDevice(cb, ctx, device, OpenGL1_GUID);
-		delete device;
+	if (!device) {
+		return;
 	}
+	delete device;
+
+	D3DDEVICEDESC halDesc = {};
+	halDesc.dcmColorModel = D3DCOLORMODEL::RGB;
+	halDesc.dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
+	halDesc.dwDeviceZBufferBitDepth = DDBD_24;
+	halDesc.dwDeviceRenderBitDepth = DDBD_32;
+	halDesc.dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
+	halDesc.dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
+	halDesc.dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;
+
+	D3DDEVICEDESC helDesc = {};
+
+	EnumDevice(cb, ctx, "OpenGL 1.1 HAL", &halDesc, &helDesc, OpenGL1_GUID);
 }

--- a/miniwin/src/internal/d3drmrenderer_opengles2.h
+++ b/miniwin/src/internal/d3drmrenderer_opengles2.h
@@ -39,7 +39,7 @@ public:
 	void PushLights(const SceneLight* lightsArray, size_t count) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
 	void SetFrustumPlanes(const Plane* frustumPlanes) override;
-	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
+	Uint32 GetTextureId(IDirect3DRMTexture* texture, bool isUi) override;
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
 	const char* GetName() override;

--- a/miniwin/src/internal/d3drmrenderer_opengles2.h
+++ b/miniwin/src/internal/d3drmrenderer_opengles2.h
@@ -41,8 +41,6 @@ public:
 	void SetFrustumPlanes(const Plane* frustumPlanes) override;
 	Uint32 GetTextureId(IDirect3DRMTexture* texture, bool isUi) override;
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
-	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
-	const char* GetName() override;
 	HRESULT BeginFrame() override;
 	void EnableTransparency() override;
 	void SubmitDraw(
@@ -64,10 +62,12 @@ private:
 	void AddTextureDestroyCallback(Uint32 id, IDirect3DRMTexture* texture);
 	void AddMeshDestroyCallback(Uint32 id, IDirect3DRMMesh* mesh);
 
+	MeshGroup m_uiMesh;
+	GLES2MeshCacheEntry m_uiMeshCache;
 	std::vector<GLES2TextureCacheEntry> m_textures;
 	std::vector<GLES2MeshCacheEntry> m_meshs;
 	D3DRMMATRIX4D m_projection;
-	SDL_Surface* m_renderedImage;
+	SDL_Surface* m_renderedImage = nullptr;
 	bool m_dirty = false;
 	std::vector<SceneLight> m_lights;
 	SDL_GLContext m_context;
@@ -78,8 +78,32 @@ private:
 inline static void OpenGLES2Renderer_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
 	Direct3DRMRenderer* device = OpenGLES2Renderer::Create(640, 480);
-	if (device) {
-		EnumDevice(cb, ctx, device, OpenGLES2_GUID);
-		delete device;
+	if (!device) {
+		return;
 	}
+
+	D3DDEVICEDESC halDesc = {};
+	halDesc.dcmColorModel = D3DCOLOR_RGB;
+	halDesc.dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
+	halDesc.dwDeviceZBufferBitDepth = DDBD_16;
+	halDesc.dwDeviceRenderBitDepth = DDBD_32;
+	halDesc.dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
+	halDesc.dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
+	halDesc.dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;
+
+	const char* extensions = (const char*) glGetString(GL_EXTENSIONS);
+	if (extensions) {
+		if (strstr(extensions, "GL_OES_depth24")) {
+			halDesc.dwDeviceZBufferBitDepth |= DDBD_24;
+		}
+		if (strstr(extensions, "GL_OES_depth32")) {
+			halDesc.dwDeviceZBufferBitDepth |= DDBD_32;
+		}
+	}
+
+	delete device;
+
+	D3DDEVICEDESC helDesc = {};
+
+	EnumDevice(cb, ctx, "OpenGL ES 2.0 HAL", &halDesc, &helDesc, OpenGLES2_GUID);
 }

--- a/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
+++ b/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
@@ -47,7 +47,7 @@ public:
 	static Direct3DRMRenderer* Create(DWORD width, DWORD height);
 	~Direct3DRMSDL3GPURenderer() override;
 	void PushLights(const SceneLight* vertices, size_t count) override;
-	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
+	Uint32 GetTextureId(IDirect3DRMTexture* texture, bool isUi) override;
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
 	void SetFrustumPlanes(const Plane* frustumPlanes) override;

--- a/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
+++ b/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
@@ -51,8 +51,6 @@ public:
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
 	void SetFrustumPlanes(const Plane* frustumPlanes) override;
-	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
-	const char* GetName() override;
 	HRESULT BeginFrame() override;
 	void EnableTransparency() override;
 	void SubmitDraw(
@@ -122,8 +120,21 @@ private:
 inline static void Direct3DRMSDL3GPU_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
 	Direct3DRMRenderer* device = Direct3DRMSDL3GPURenderer::Create(640, 480);
-	if (device) {
-		EnumDevice(cb, ctx, device, SDL3_GPU_GUID);
-		delete device;
+	if (!device) {
+		return;
 	}
+	delete device;
+
+	D3DDEVICEDESC halDesc = {};
+	halDesc.dcmColorModel = D3DCOLOR_RGB;
+	halDesc.dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
+	halDesc.dwDeviceZBufferBitDepth = DDBD_32;
+	halDesc.dwDeviceRenderBitDepth = DDBD_32;
+	halDesc.dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
+	halDesc.dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
+	halDesc.dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;
+
+	D3DDEVICEDESC helDesc = {};
+
+	EnumDevice(cb, ctx, "SDL3 GPU HAL", &halDesc, &helDesc, SDL3_GPU_GUID);
 }

--- a/miniwin/src/internal/d3drmrenderer_software.h
+++ b/miniwin/src/internal/d3drmrenderer_software.h
@@ -29,7 +29,7 @@ public:
 	Direct3DRMSoftwareRenderer(DWORD width, DWORD height);
 	~Direct3DRMSoftwareRenderer() override;
 	void PushLights(const SceneLight* vertices, size_t count) override;
-	Uint32 GetTextureId(IDirect3DRMTexture* texture) override;
+	Uint32 GetTextureId(IDirect3DRMTexture* texture, bool isUi) override;
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
 	void SetFrustumPlanes(const Plane* frustumPlanes) override;

--- a/miniwin/src/internal/d3drmrenderer_software.h
+++ b/miniwin/src/internal/d3drmrenderer_software.h
@@ -33,8 +33,6 @@ public:
 	Uint32 GetMeshId(IDirect3DRMMesh* mesh, const MeshGroup* meshGroup) override;
 	void SetProjection(const D3DRMMATRIX4D& projection, D3DVALUE front, D3DVALUE back) override;
 	void SetFrustumPlanes(const Plane* frustumPlanes) override;
-	void GetDesc(D3DDEVICEDESC* halDesc, D3DDEVICEDESC* helDesc) override;
-	const char* GetName() override;
 	HRESULT BeginFrame() override;
 	void EnableTransparency() override;
 	void SubmitDraw(
@@ -87,8 +85,16 @@ private:
 
 inline static void Direct3DRMSoftware_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
-	Direct3DRMRenderer* device = nullptr;
-	device = new Direct3DRMSoftwareRenderer(640, 480);
-	EnumDevice(cb, ctx, device, SOFTWARE_GUID);
-	delete device;
+	D3DDEVICEDESC halDesc = {};
+
+	D3DDEVICEDESC helDesc = {};
+	helDesc.dcmColorModel = D3DCOLOR_RGB;
+	helDesc.dwFlags = D3DDD_DEVICEZBUFFERBITDEPTH;
+	helDesc.dwDeviceZBufferBitDepth = DDBD_32;
+	helDesc.dwDeviceRenderBitDepth = DDBD_32;
+	helDesc.dpcTriCaps.dwTextureCaps = D3DPTEXTURECAPS_PERSPECTIVE;
+	helDesc.dpcTriCaps.dwShadeCaps = D3DPSHADECAPS_ALPHAFLATBLEND;
+	helDesc.dpcTriCaps.dwTextureFilterCaps = D3DPTFILTERCAPS_LINEAR;
+
+	EnumDevice(cb, ctx, "Miniwin Emulation", &halDesc, &helDesc, SOFTWARE_GUID);
 }

--- a/miniwin/src/internal/ddraw_impl.h
+++ b/miniwin/src/internal/ddraw_impl.h
@@ -56,4 +56,11 @@ HRESULT DirectDrawEnumerate(LPDDENUMCALLBACKA cb, void* context);
 
 HRESULT DirectDrawCreate(LPGUID lpGuid, LPDIRECTDRAW* lplpDD, IUnknown* pUnkOuter);
 
-void EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx, Direct3DRMRenderer* device, GUID deviceGuid);
+void EnumDevice(
+	LPD3DENUMDEVICESCALLBACK cb,
+	void* ctx,
+	const char* name,
+	D3DDEVICEDESC* halDesc,
+	D3DDEVICEDESC* helDesc,
+	GUID deviceGuid
+);

--- a/miniwin/src/internal/meshutils.cpp
+++ b/miniwin/src/internal/meshutils.cpp
@@ -75,3 +75,31 @@ void FlattenSurfaces(
 		}
 	}
 }
+
+void Create2DTransformMatrix(
+	const SDL_Rect& dstRect,
+	float scale,
+	float offsetX,
+	float offsetY,
+	D3DRMMATRIX4D& outMatrix
+)
+{
+	float x = static_cast<float>(dstRect.x) * scale + offsetX;
+	float y = static_cast<float>(dstRect.y) * scale + offsetY;
+	float w = static_cast<float>(dstRect.w) * scale;
+	float h = static_cast<float>(dstRect.h) * scale;
+
+	D3DVALUE tmp[4][4] = {{w, 0, 0, 0}, {0, h, 0, 0}, {0, 0, 1, 0}, {x, y, 0, 1}};
+	memcpy(outMatrix, tmp, sizeof(tmp));
+}
+
+void CreateOrthographicProjection(float width, float height, D3DRMMATRIX4D& outProj)
+{
+	D3DVALUE tmp[4][4] = {
+		{2.0f / width, 0.0f, 0.0f, 0.0f},
+		{0.0f, -2.0f / height, 0.0f, 0.0f},
+		{0.0f, 0.0f, 1.0f, 0.0f},
+		{-1.0f, 1.0f, 0.0f, 1.0f}
+	};
+	memcpy(outProj, tmp, sizeof(tmp));
+}

--- a/miniwin/src/internal/meshutils.h
+++ b/miniwin/src/internal/meshutils.h
@@ -13,3 +13,13 @@ void FlattenSurfaces(
 	std::vector<D3DRMVERTEX>& dedupedVertices,
 	std::vector<uint16_t>& newIndices
 );
+
+void Create2DTransformMatrix(
+	const SDL_Rect& dstRect,
+	float scale,
+	float offsetX,
+	float offsetY,
+	D3DRMMATRIX4D& outMatrix
+);
+
+void CreateOrthographicProjection(float width, float height, D3DRMMATRIX4D& outProj);


### PR DESCRIPTION
This pulls in a few fixes and cleanups for rendering mainly from 3DS and WebGL initiatives.

- Share code between OpenGL ES 2.0 and SDL_GPU's 2D rendering and fix image attributes to allow it to work with WebGL
- Split renderer enumeration from renderer class to allow for more pure enumeration which is required by some devices
- Improve rendering of transparent areas on displays running lower then 640x480 resolutions.
- Enable mip-mapping and up to 8x anisotropic filtering on OpenGL ES 2.0
- Make renderers aware of textures only intended for 2D rendering