### PR TITLE
Expose window during device probing

### DIFF
--- a/CONFIG/config.cpp
+++ b/CONFIG/config.cpp
@@ -56,9 +56,17 @@ bool CConfigApp::InitInstance()
 		return false;
 	}
 	m_device_enumerator = new LegoDeviceEnumerate;
-	if (m_device_enumerator->DoEnumerate()) {
+	SDL_Window* window = SDL_CreateWindow("Test window", 640, 480, SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL);
+	HWND hWnd;
+#ifdef MINIWIN
+	hWnd = reinterpret_cast<HWND>(window);
+#else
+	hWnd = (HWND) SDL_GetPointerProperty(SDL_GetWindowProperties(window), SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL);
+#endif
+	if (m_device_enumerator->DoEnumerate(hWnd)) {
 		return FALSE;
 	}
+	SDL_DestroyWindow(window);
 	m_driver = NULL;
 	m_device = NULL;
 	m_full_screen = TRUE;

--- a/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
+++ b/LEGO1/lego/legoomni/src/video/legovideomanager.cpp
@@ -108,7 +108,7 @@ MxResult LegoVideoManager::Create(MxVideoParam& p_videoParam, MxU32 p_frequencyM
 		goto done;
 	}
 
-	if (deviceEnumerate.DoEnumerate() != SUCCESS) {
+	if (deviceEnumerate.DoEnumerate(hwnd) != SUCCESS) {
 		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "LegoDeviceEnumerate::DoEnumerate failed");
 		goto done;
 	}

--- a/LEGO1/mxdirectx/mxdirectxinfo.h
+++ b/LEGO1/mxdirectx/mxdirectxinfo.h
@@ -194,7 +194,7 @@ public:
 	MxDeviceEnumerate();
 	~MxDeviceEnumerate();
 
-	virtual int DoEnumerate(); // vtable+0x00
+	virtual int DoEnumerate(HWND hWnd); // vtable+0x00
 
 	BOOL EnumDirectDrawCallback(LPGUID p_guid, LPSTR p_driverDesc, LPSTR p_driverName);
 	HRESULT EnumDevicesCallback(
@@ -242,6 +242,7 @@ public:
 protected:
 	list<MxDriver> m_list;       // 0x04
 	unsigned char m_initialized; // 0x10
+	HWND m_hWnd;
 };
 
 // TEMPLATE: BETA10 0x1011c1b0

--- a/miniwin/src/d3drm/backends/opengl1/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengl1/renderer.cpp
@@ -28,39 +28,24 @@ Direct3DRMRenderer* OpenGL1Renderer::Create(DWORD width, DWORD height)
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
 
-	SDL_Window* window = DDWindow;
-	bool testWindow = false;
-	if (!window) {
-		window = SDL_CreateWindow("OpenGL 1.1 test", width, height, SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL);
-		if (!window) {
-			SDL_Log("SDL_CreateWindow: %s", SDL_GetError());
-			return nullptr;
-		}
-		testWindow = true;
-	}
-
-	SDL_GLContext context = SDL_GL_CreateContext(window);
-	if (!context) {
-		SDL_Log("SDL_GL_CreateContext: %s", SDL_GetError());
-		if (testWindow) {
-			SDL_DestroyWindow(window);
-		}
+	if (!DDWindow) {
+		SDL_Log("No window handler");
 		return nullptr;
 	}
 
-	if (!SDL_GL_MakeCurrent(window, context)) {
+	SDL_GLContext context = SDL_GL_CreateContext(DDWindow);
+	if (!context) {
+		SDL_Log("SDL_GL_CreateContext: %s", SDL_GetError());
+		return nullptr;
+	}
+
+	if (!SDL_GL_MakeCurrent(DDWindow, context)) {
+		SDL_GL_DestroyContext(context);
 		SDL_Log("SDL_GL_MakeCurrent: %s", SDL_GetError());
-		if (testWindow) {
-			SDL_DestroyWindow(window);
-		}
 		return nullptr;
 	}
 
 	GL11_InitState();
-
-	if (testWindow) {
-		SDL_DestroyWindow(window);
-	}
 
 	return new OpenGL1Renderer(width, height, context);
 }
@@ -78,6 +63,7 @@ OpenGL1Renderer::OpenGL1Renderer(DWORD width, DWORD height, SDL_GLContext contex
 OpenGL1Renderer::~OpenGL1Renderer()
 {
 	SDL_DestroySurface(m_renderedImage);
+	SDL_GL_DestroyContext(m_context);
 }
 
 void OpenGL1Renderer::PushLights(const SceneLight* lightsArray, size_t count)

--- a/miniwin/src/d3drm/backends/opengles2/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengles2/renderer.cpp
@@ -40,25 +40,18 @@ Direct3DRMRenderer* OpenGLES2Renderer::Create(DWORD width, DWORD height)
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 
-	SDL_Window* window = DDWindow;
-	bool testWindow = false;
-	if (!window) {
-		window = SDL_CreateWindow("OpenGL ES 2.0 test", width, height, SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL);
-		testWindow = true;
-	}
-
-	SDL_GLContext context = SDL_GL_CreateContext(window);
-	if (!context) {
-		if (testWindow) {
-			SDL_DestroyWindow(window);
-		}
+	if (!DDWindow) {
+		SDL_Log("No window handler");
 		return nullptr;
 	}
 
-	if (!SDL_GL_MakeCurrent(window, context)) {
-		if (testWindow) {
-			SDL_DestroyWindow(window);
-		}
+	SDL_GLContext context = SDL_GL_CreateContext(DDWindow);
+	if (!context) {
+		return nullptr;
+	}
+
+	if (!SDL_GL_MakeCurrent(DDWindow, context)) {
+		SDL_GL_DestroyContext(context);
 		return nullptr;
 	}
 
@@ -174,10 +167,6 @@ Direct3DRMRenderer* OpenGLES2Renderer::Create(DWORD width, DWORD height)
 	glDeleteShader(vs);
 	glDeleteShader(fs);
 
-	if (testWindow) {
-		SDL_DestroyWindow(window);
-	}
-
 	return new OpenGLES2Renderer(width, height, context, shaderProgram);
 }
 
@@ -285,6 +274,7 @@ OpenGLES2Renderer::OpenGLES2Renderer(DWORD width, DWORD height, SDL_GLContext co
 OpenGLES2Renderer::~OpenGLES2Renderer()
 {
 	SDL_DestroySurface(m_renderedImage);
+	SDL_GL_DestroyContext(m_context);
 	glDeleteProgram(m_shaderProgram);
 }
 


### PR DESCRIPTION
This exposes the window context to min win during device probing. The window context is needed by several of the renderers in order to validate that they are functional on the system.

This also makes render testing viable on platforms that do not support multiple windows meaning that less workarounds will be needed.

Instead the config app is now the one that creates a hidden window when it probes other devices, which at least to me makes more sens.