### PR TITLE
Use DDBLT_COLORFILL to clear screen on start

### DIFF
--- a/LEGO1/mxdirectx/mxdirect3d.cpp
+++ b/LEGO1/mxdirectx/mxdirect3d.cpp
@@ -170,39 +170,16 @@ BOOL MxDirect3D::D3DSetMode()
 	LPDIRECTDRAWSURFACE frontBuffer = FrontBuffer();
 	LPDIRECTDRAWSURFACE backBuffer = BackBuffer();
 
-	DDSURFACEDESC desc;
-	memset(&desc, 0, sizeof(desc));
-	desc.dwSize = sizeof(desc);
+	DDBLTFX ddBltFx = {};
+	ddBltFx.dwSize = sizeof(DDBLTFX);
+	ddBltFx.dwFillColor = 0;
 
-	if (backBuffer->Lock(NULL, &desc, DDLOCK_WAIT | DDLOCK_WRITEONLY, NULL) == DD_OK) {
-		unsigned char* surface = (unsigned char*) desc.lpSurface;
-
-		for (int i = 0; i < mode.height; i++) {
-			memset(surface, 0, desc.lPitch);
-			surface += desc.lPitch;
-		}
-
-		backBuffer->Unlock(desc.lpSurface);
-	}
-	else {
-		SDL_Log("MxDirect3D::D3DSetMode() back lock failed\n");
+	if (backBuffer->Blt(NULL, NULL, NULL, DDBLT_WAIT | DDBLT_COLORFILL, &ddBltFx) != DD_OK) {
+		SDL_Log("MxDirect3D::D3DSetMode() color fill failed\n");
 	}
 
 	if (IsFullScreen()) {
-		memset(&desc, 0, sizeof(desc));
-		desc.dwSize = sizeof(desc);
-
-		if (frontBuffer->Lock(NULL, &desc, DDLOCK_WAIT | DDLOCK_WRITEONLY, NULL) == DD_OK) {
-			unsigned char* surface = (unsigned char*) desc.lpSurface;
-
-			for (int i = 0; i < mode.height; i++) {
-				memset(surface, 0, desc.lPitch);
-				surface += desc.lPitch;
-			}
-
-			frontBuffer->Unlock(desc.lpSurface);
-		}
-		else {
+		if (frontBuffer->Blt(NULL, NULL, NULL, DDBLT_WAIT | DDBLT_COLORFILL, &ddBltFx) != DD_OK) {
 			SDL_Log("MxDirect3D::D3DSetMode() front lock failed\n");
 		}
 	}

--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -64,8 +64,6 @@ void MxDisplaySurface::ClearScreen()
 	MxS32 width = m_videoParam.GetRect().GetWidth();
 	MxS32 height = m_videoParam.GetRect().GetHeight();
 
-	RECT rc = {0, 0, width, height};
-
 	memset(&desc, 0, sizeof(desc));
 	desc.dwSize = sizeof(desc);
 	if (m_ddSurface2->GetSurfaceDesc(&desc) != DD_OK) {
@@ -77,9 +75,9 @@ void MxDisplaySurface::ClearScreen()
 	ddBltFx.dwFillColor = 0;
 
 	for (MxS32 i = 0; i < backBuffers; i++) {
-		if (m_ddSurface2->Blt(&rc, NULL, NULL, DDBLT_COLORFILL | DDBLT_WAIT, &ddBltFx) == DDERR_SURFACELOST) {
+		if (m_ddSurface2->Blt(NULL, NULL, NULL, DDBLT_COLORFILL | DDBLT_WAIT, &ddBltFx) == DDERR_SURFACELOST) {
 			m_ddSurface2->Restore();
-			m_ddSurface2->Blt(&rc, NULL, NULL, DDBLT_COLORFILL | DDBLT_WAIT, &ddBltFx);
+			m_ddSurface2->Blt(NULL, NULL, NULL, DDBLT_COLORFILL | DDBLT_WAIT, &ddBltFx);
 		}
 
 		if (m_videoParam.Flags().GetFlipSurfaces()) {


### PR DESCRIPTION
This is another case where memset() was used to clear the screen, this causes the game to upload a black 640x480 texture to the GPU, instead we can just ask the GPU to clear it for us.

This one happens right at start up before the video.