### PR TITLE
citro3d: Let SDL3 take care of initiatizing/deinitializing GFX

### DIFF
--- a/miniwin/src/d3drm/backends/citro3d/renderer.cpp
+++ b/miniwin/src/d3drm/backends/citro3d/renderer.cpp
@@ -26,7 +26,7 @@ Citro3DRenderer::Citro3DRenderer(DWORD width, DWORD height)
 	m_virtualWidth = width;
 	m_virtualHeight = height;
 
-	gfxInitDefault();
+	gfxSetScreenFormat(GFX_BOTTOM, GSP_BGR8_OES);
 	consoleInit(GFX_TOP, nullptr);
 	C3D_Init(C3D_DEFAULT_CMDBUF_SIZE);
 
@@ -66,7 +66,6 @@ Citro3DRenderer::~Citro3DRenderer()
 	shaderProgramFree(&program);
 	DVLB_Free(vshader_dvlb);
 	C3D_Fini();
-	gfxExit();
 }
 
 void Citro3DRenderer::PushLights(const SceneLight* lights, size_t count)


### PR DESCRIPTION
Closes https://github.com/ItzSwirlz/isle-portable/issues/6

Fixes crashes that sometimes occur when exiting the game through the home menu or by pressing the power button.

SDL3 actually does [initialize gfx](https://github.com/libsdl-org/SDL/blob/f3bf387caf1eb30ba1a80e5232b4aa7b3036ba1d/src/video/n3ds/SDL_n3dsvideo.c#L127) but they use something else instead of gfxInitDefault (see https://github.com/libsdl-org/SDL/issues/13313). So we just need to set the frame buffer to the frame buffers gfxInitDefault would use.

What was likely causing a lot of the crashes, which sometimes happened and sometimes didn't  (which would occur at the `syncAddressAttribute` function) was the extra `gfxExit`.  An underlying function,`gspExit` was being called twice, which would cause a crash, and it explains the empty stack dump.

Thank you to @kynex7510 , @ZeroSkill1 and aw2501 in the Nintendo Homebrew discord for the help.