### PR TITLE
Add `StartupWMClass` to the desktop file

### DIFF
--- a/packaging/linux/isledecomp.desktop.in
+++ b/packaging/linux/isledecomp.desktop.in
@@ -21,6 +21,7 @@ Keywords[ru]=LEGO;lego;Остров LEGO
 Keywords[uk_UA]=LEGO;lego;LEGO острів
 
 SingleMainWindow=true
+StartupWMClass=isle
 
 TryExec=isle
 Exec=isle


### PR DESCRIPTION
This explicitly adds a `StartupWMClass` to the desktop file to help desktop environments properly track the game window and associate it with the correct app icon and name. This adheres to the XDG Desktop Entry Specification [^1].

[^1]: https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html