### PR TITLE
Avoid texture updates when we just need the size

### DIFF
--- a/LEGO1/lego/sources/misc/legocontainer.cpp
+++ b/LEGO1/lego/sources/misc/legocontainer.cpp
@@ -22,10 +22,9 @@ LegoTextureInfo* LegoTextureContainer::GetCached(LegoTextureInfo* p_textureInfo)
 	memset(&desc, 0, sizeof(desc));
 	desc.dwSize = sizeof(desc);
 
-	if (p_textureInfo->m_surface->Lock(NULL, &desc, DDLOCK_SURFACEMEMORYPTR | DDLOCK_WRITEONLY, NULL) == DD_OK) {
+	if (p_textureInfo->m_surface->GetSurfaceDesc(&desc) == DD_OK) {
 		width = desc.dwWidth;
 		height = desc.dwHeight;
-		p_textureInfo->m_surface->Unlock(desc.lpSurface);
 	}
 
 	for (LegoCachedTextureList::iterator it = m_cached.begin(); it != m_cached.end(); it++) {
@@ -35,15 +34,8 @@ LegoTextureInfo* LegoTextureContainer::GetCached(LegoTextureInfo* p_textureInfo)
 				memset(&newDesc, 0, sizeof(newDesc));
 				newDesc.dwSize = sizeof(newDesc);
 
-				if (surface->Lock(NULL, &newDesc, DDLOCK_SURFACEMEMORYPTR | DDLOCK_WRITEONLY, NULL) == DD_OK) {
-					BOOL und = FALSE;
+				if (surface->GetSurfaceDesc(&newDesc) == DD_OK) {
 					if (newDesc.dwWidth == width && newDesc.dwHeight == height) {
-						und = TRUE;
-					}
-
-					surface->Unlock(newDesc.lpSurface);
-
-					if (und) {
 						(*it).second = TRUE;
 						(*it).first->m_texture->AddRef();
 						return (*it).first;


### PR DESCRIPTION
Locking a texture can cause it to be re-uploaded to the backend, all we need here is the size so just get the descriptor.