### PR TITLE
OpenGL: Respect max supported texture size

### DIFF
--- a/miniwin/src/d3drm/backends/opengl1/actual.cpp
+++ b/miniwin/src/d3drm/backends/opengl1/actual.cpp
@@ -42,6 +42,13 @@ void GL11_DestroyTexture(GLuint texId)
 	glDeleteTextures(1, &texId);
 }
 
+int GL11_GetMaxTextureSize()
+{
+	GLint maxTextureSize = 0;
+	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
+	return maxTextureSize;
+}
+
 GLuint GL11_UploadTextureData(void* pixels, int width, int height, bool isUi)
 {
 	GLuint texId;

--- a/miniwin/src/d3drm/backends/opengl1/actual.h
+++ b/miniwin/src/d3drm/backends/opengl1/actual.h
@@ -64,6 +64,7 @@ struct GLMeshCacheEntry {
 void GL11_InitState();
 void GL11_LoadExtensions();
 void GL11_DestroyTexture(GLuint texId);
+int GL11_GetMaxTextureSize();
 GLuint GL11_UploadTextureData(void* pixels, int width, int height, bool isUI);
 void GL11_UploadMesh(GLMeshCacheEntry& cache, bool hasTexture);
 void GL11_DestroyMesh(GLMeshCacheEntry& cache);

--- a/miniwin/src/d3drm/backends/opengl1/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengl1/renderer.cpp
@@ -132,10 +132,21 @@ static Uint32 UploadTextureData(SDL_Surface* src, bool useNPOT, bool isUi)
 
 	SDL_Surface* finalSurface = working;
 
-	int newW = NextPowerOfTwo(working->w);
-	int newH = NextPowerOfTwo(working->h);
+	int newW = working->w;
+	int newH = working->h;
+	if (!useNPOT) {
+		newW = NextPowerOfTwo(newW);
+		newH = NextPowerOfTwo(newH);
+	}
+	int max = GL11_GetMaxTextureSize();
+	if (newW > max) {
+		newW = max;
+	}
+	if (newH > max) {
+		newH = max;
+	}
 
-	if (!useNPOT && (newW != working->w || newH != working->h)) {
+	if (newW != working->w || newH != working->h) {
 		SDL_Surface* resized = SDL_CreateSurface(newW, newH, working->format);
 		if (!resized) {
 			SDL_Log("SDL_CreateSurface (resize) failed: %s", SDL_GetError());


### PR DESCRIPTION
Respect max texture size, this can be relevant on some older hardware like PSP when pushing the game background (640x480) as they exceed the 512x512. Early cards even had 256x256 (like the period correct Voodoo) as a limit ... I guess that explains why backgrounds where not hardware accelerated, though it would be possible to do using multiple textures ... I'm not going to implement that though. PSP screen size is 480x270 anyway.