### PR TITLE
Add fake mosaic to config tool

### DIFF
--- a/CONFIG/res/maindialog.ui
+++ b/CONFIG/res/maindialog.ui
@@ -455,6 +455,11 @@
           <string>Unknown - Broken</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>Fake Mosaic</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item>

--- a/ISLE/3ds/config.cpp
+++ b/ISLE/3ds/config.cpp
@@ -18,5 +18,5 @@ void N3DS_SetupDefaultConfigOverrides(dictionary* p_dictionary)
 	iniparser_set(p_dictionary, "isle:savepath", "sdmc:/3ds/isle");
 
 	// Use e_noAnimation/cut transition
-	iniparser_set(p_dictionary, "isle:Transition Type", "1");
+	iniparser_set(p_dictionary, "isle:Transition Type", "7");
 }

--- a/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/mxtransitionmanager.cpp
@@ -637,7 +637,7 @@ int GetColorIndexWithLocality(int p_col, int p_row)
 	int scrambled = (hash >> 16) % 32;
 
 	int finalIndex = scrambled + SDL_rand(3) - 1;
-	return finalIndex % 32;
+	return abs(finalIndex) % 32;
 }
 
 void MxTransitionManager::FakeMosaicTransition()


### PR DESCRIPTION
- Add Fake Mosaic to config options.
- Fix UB with negative palette indexes.
- Make it the new default for 3DS.