### PR TITLE
SDL_GPU: Fix transitions on scenes with 2D overlay

### DIFF
--- a/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
+++ b/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
@@ -1009,7 +1009,7 @@ void Direct3DRMSDL3GPURenderer::Download(SDL_Surface* target)
 	}
 
 	SDL_Surface* renderedImage =
-		SDL_CreateSurfaceFrom(width, height, SDL_PIXELFORMAT_ARGB8888, downloadedData, width * 4);
+		SDL_CreateSurfaceFrom(width, height, SDL_PIXELFORMAT_XRGB8888, downloadedData, width * 4);
 
 	SDL_BlitSurfaceScaled(renderedImage, nullptr, target, nullptr, SDL_SCALEMODE_NEAREST);
 	SDL_DestroySurface(renderedImage);

--- a/miniwin/src/d3drm/backends/software/renderer.cpp
+++ b/miniwin/src/d3drm/backends/software/renderer.cpp
@@ -761,10 +761,9 @@ void Direct3DRMSoftwareRenderer::Resize(int width, int height, const ViewportTra
 
 void Direct3DRMSoftwareRenderer::Clear(float r, float g, float b)
 {
-	SDL_Rect rect = {0, 0, m_renderedImage->w, m_renderedImage->h};
 	const SDL_PixelFormatDetails* details = SDL_GetPixelFormatDetails(m_renderedImage->format);
 	Uint32 color = SDL_MapRGB(details, m_palette, r * 255, g * 255, b * 255);
-	SDL_FillSurfaceRect(m_renderedImage, &rect, color);
+	SDL_FillSurfaceRect(m_renderedImage, nullptr, color);
 }
 
 void Direct3DRMSoftwareRenderer::Flip()

--- a/miniwin/src/ddraw/framebuffer.cpp
+++ b/miniwin/src/ddraw/framebuffer.cpp
@@ -172,11 +172,10 @@ HRESULT FrameBufferImpl::Lock(LPRECT lpDestRect, DDSURFACEDESC* lpDDSurfaceDesc,
 		return DDERR_GENERIC;
 	}
 	if ((dwFlags & DDLOCK_WRITEONLY) == DDLOCK_WRITEONLY) {
-		SDL_Rect rect = {0, 0, m_transferBuffer->m_surface->w, m_transferBuffer->m_surface->h};
 		const SDL_PixelFormatDetails* details = SDL_GetPixelFormatDetails(m_transferBuffer->m_surface->format);
 		SDL_Palette* palette = m_palette ? static_cast<DirectDrawPaletteImpl*>(m_palette)->m_palette : nullptr;
 		Uint32 color = SDL_MapRGBA(details, palette, 0, 0, 0, 0);
-		SDL_FillSurfaceRect(m_transferBuffer->m_surface, &rect, color);
+		SDL_FillSurfaceRect(m_transferBuffer->m_surface, nullptr, color);
 	}
 	else {
 		DDRenderer->Download(m_transferBuffer->m_surface);


### PR DESCRIPTION
When downloading the rendered image 2D with transparent  colors would affect the transparency of the buffer making the transition not affect any area that had transparency on the overlay. Simply discard the transparency when downloading.

Also some minor optimizations to fill operations that affect the full screen.