### PR TITLE
Implement real transition for 3DS

### DIFF
--- a/ISLE/3ds/config.cpp
+++ b/ISLE/3ds/config.cpp
@@ -16,7 +16,4 @@ void N3DS_SetupDefaultConfigOverrides(dictionary* p_dictionary)
 	// TODO: Save path: can we use libctru FS save data functions? Would be neat, especially for CIA install
 	// Extra / at the end causes some issues
 	iniparser_set(p_dictionary, "isle:savepath", "sdmc:/3ds/isle");
-
-	// Use e_noAnimation/cut transition
-	iniparser_set(p_dictionary, "isle:Transition Type", "7");
 }


### PR DESCRIPTION
With the optimized Mosaic transition it's now viable to use it on 3DS:


https://github.com/user-attachments/assets/47b7b4a2-e62b-4134-823e-483c04e24332

This took a full day to implement just because the Azahar emulator has a bug in it that corrupts the framebuffer data.