### PR TITLE
Recheck through gamepads when gamepad is added or removed

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -474,6 +474,13 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 		}
 		break;
 	}
+	case SDL_EVENT_GAMEPAD_ADDED:
+	case SDL_EVENT_GAMEPAD_REMOVED: {
+		if (InputManager()) {
+			InputManager()->GetJoystick();
+		}
+		break;
+	}
 	case SDL_EVENT_GAMEPAD_BUTTON_DOWN: {
 		switch (event->gbutton.button) {
 		case SDL_GAMEPAD_BUTTON_DPAD_UP:

--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -108,7 +108,7 @@ public:
 
 	MxResult Create(HWND p_hwnd);
 	void Destroy() override;
-	MxResult GetJoystick();
+	LEGO1_EXPORT MxResult GetJoystick();
 	MxResult GetJoystickState(MxU32* p_joystickX, MxU32* p_joystickY, MxU32* p_povPosition);
 	void StartAutoDragTimer();
 	void StopAutoDragTimer();


### PR DESCRIPTION
Closes #535 

How it works:
- When you connected a controller after the game launch: just works
- When you have 2 or more controllers connected: the first one it finds will work
  - When you disconnect that first one: the second one isle finds will act as a gamepad