### PR TITLE
Use FBO in WebGL

### DIFF
--- a/miniwin/src/internal/d3drmrenderer_opengles2.h
+++ b/miniwin/src/internal/d3drmrenderer_opengles2.h
@@ -72,7 +72,11 @@ private:
 	bool m_dirty = false;
 	std::vector<SceneLight> m_lights;
 	SDL_GLContext m_context;
+	GLuint m_fbo;
+	GLuint m_colorTarget;
+	GLuint m_depthTarget;
 	GLuint m_shaderProgram;
+	GLuint m_dummyTexture;
 	GLint m_posLoc;
 	GLint m_normLoc;
 	GLint m_texLoc;


### PR DESCRIPTION
This enables FBO in OpenGL ES 2.0 so that WebGL can potentially read the render target in order to support the Mosaic transition.

# Mosaik on WebGL huzzah! 
![image](https://github.com/user-attachments/assets/9fb76613-c760-454a-a5d0-68c3ce80c70e)
