### PR TITLE
Clear screen when resizing

### DIFF
--- a/miniwin/src/d3drm/d3drmdevice.cpp
+++ b/miniwin/src/d3drm/d3drmdevice.cpp
@@ -158,6 +158,7 @@ void Direct3DRMDevice2Impl::Resize()
 #endif
 	m_viewportTransform = CalculateViewportTransform(m_virtualWidth, m_virtualHeight, width, height);
 	m_renderer->Resize(width, height, m_viewportTransform);
+	m_renderer->Clear(0, 0, 0);
 	for (int i = 0; i < m_viewports->GetSize(); i++) {
 		IDirect3DRMViewport* viewport;
 		m_viewports->GetElement(i, &viewport);


### PR DESCRIPTION
Resizing can leave artifacts on screen as things moves around, this includes switching in and out of full screen:

![image](https://github.com/user-attachments/assets/9bd13cfc-3f1a-4d42-8de7-73bc24d72d45)