### PR TITLE
Use minimal test for SDL_GPU on macOS

### DIFF
--- a/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
+++ b/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
@@ -120,11 +120,19 @@ private:
 
 inline static void Direct3DRMSDL3GPU_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
+#ifdef __APPLE__
+	SDL_GPUDevice* device = SDL_CreateGPUDevice(SDL_GPU_SHADERFORMAT_MSL, false, nullptr);
+	if (!device) {
+		return;
+	}
+	SDL_DestroyGPUDevice(device);
+#else
 	Direct3DRMRenderer* device = Direct3DRMSDL3GPURenderer::Create(640, 480);
 	if (!device) {
 		return;
 	}
 	delete device;
+#endif
 
 	D3DDEVICEDESC halDesc = {};
 	halDesc.dcmColorModel = D3DCOLOR_RGB;


### PR DESCRIPTION
This attempts to address #519 

Apparently Metal does not properly restore Window state after shutdown which prevents OpenGL from functioning properly. This avoids the issue by only checking for a functional device.