### PR TITLE
Disable offscreen canvases in case of no WebGL support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,6 +532,7 @@ if (ISLE_BUILD_APP)
   endif()
   if(EMSCRIPTEN)
     target_sources(isle PRIVATE
+      ISLE/emscripten/config.cpp
       ISLE/emscripten/events.cpp
       ISLE/emscripten/filesystem.cpp
       ISLE/emscripten/messagebox.cpp

--- a/ISLE/emscripten/config.cpp
+++ b/ISLE/emscripten/config.cpp
@@ -1,0 +1,17 @@
+#include "config.h"
+
+#include "filesystem.h"
+
+#include <SDL3/SDL_log.h>
+#include <iniparser.h>
+
+void Emscripten_SetupDefaultConfigOverrides(dictionary* p_dictionary)
+{
+	SDL_Log("Overriding default config for Emscripten");
+
+	iniparser_set(p_dictionary, "isle:diskpath", Emscripten_bundledPath);
+	iniparser_set(p_dictionary, "isle:cdpath", Emscripten_streamPath);
+	iniparser_set(p_dictionary, "isle:savepath", Emscripten_savePath);
+	iniparser_set(p_dictionary, "isle:Full Screen", "false");
+	iniparser_set(p_dictionary, "isle:Flip Surfaces", "true");
+}

--- a/ISLE/emscripten/config.h
+++ b/ISLE/emscripten/config.h
@@ -1,0 +1,8 @@
+#ifndef EMSCRIPTEN_CONFIG_H
+#define EMSCRIPTEN_CONFIG_H
+
+#include "dictionary.h"
+
+void Emscripten_SetupDefaultConfigOverrides(dictionary* p_dictionary);
+
+#endif // EMSCRIPTEN_CONFIG_H

--- a/ISLE/emscripten/emscripten.patch
+++ b/ISLE/emscripten/emscripten.patch
@@ -140,20 +140,26 @@ index e8c9f7e21..caf1971d2 100644
 -
  });
 diff --git a/src/preamble.js b/src/preamble.js
-index 572694517..0d2f4421b 100644
+index 572694517..44e65c823 100644
 --- a/src/preamble.js
 +++ b/src/preamble.js
-@@ -1062,3 +1062,13 @@ function getCompilerSetting(name) {
+@@ -1062,3 +1062,19 @@ function getCompilerSetting(name) {
  // dynamic linker as symbols are loaded.
  var asyncifyStubs = {};
  #endif
 +
-+(async () => {
-+  try {
-+    await navigator.storage.getDirectory();
-+    Module["disableOpfs"] = false;
-+  } catch (e) {
-+    Module["disableOpfs"] = true;
-+  }
-+})();
++if (typeof document !== "undefined") {
++  (async () => {
++    try {
++      await navigator.storage.getDirectory();
++      Module["disableOpfs"] = false;
++    } catch (e) {
++      Module["disableOpfs"] = true;
++    }
++    console.log("disableOpfs: " + Module["disableOpfs"]);
++  })();
++
++  Module["disableOffscreenCanvases"] ||= !document.createElement('canvas').getContext('webgl');
++  console.log("disableOffscreenCanvases: " + Module["disableOffscreenCanvases"]);
++}
 +

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -48,6 +48,7 @@
 #include <time.h>
 
 #ifdef __EMSCRIPTEN__
+#include "emscripten/config.h"
 #include "emscripten/events.h"
 #include "emscripten/filesystem.h"
 #include "emscripten/messagebox.h"
@@ -1003,19 +1004,15 @@ bool IsleApp::LoadConfig()
 	}
 
 #ifdef __EMSCRIPTEN__
-	const char* hdPath = Emscripten_bundledPath;
-#else
-	const char* hdPath = iniparser_getstring(dict, "isle:diskpath", SDL_GetBasePath());
+	Emscripten_SetupDefaultConfigOverrides(dict);
 #endif
+
+	const char* hdPath = iniparser_getstring(dict, "isle:diskpath", SDL_GetBasePath());
 	m_hdPath = new char[strlen(hdPath) + 1];
 	strcpy(m_hdPath, hdPath);
 	MxOmni::SetHD(m_hdPath);
 
-#ifdef __EMSCRIPTEN__
-	const char* cdPath = Emscripten_streamPath;
-#else
 	const char* cdPath = iniparser_getstring(dict, "isle:cdpath", MxOmni::GetCD());
-#endif
 	m_cdPath = new char[strlen(cdPath) + 1];
 	strcpy(m_cdPath, cdPath);
 	MxOmni::SetCD(m_cdPath);
@@ -1025,13 +1022,7 @@ bool IsleApp::LoadConfig()
 	strcpy(m_mediaPath, mediaPath);
 
 	m_flipSurfaces = iniparser_getboolean(dict, "isle:Flip Surfaces", m_flipSurfaces);
-
-#ifdef __EMSCRIPTEN__
-	m_fullScreen = FALSE;
-#else
 	m_fullScreen = iniparser_getboolean(dict, "isle:Full Screen", m_fullScreen);
-#endif
-
 	m_wideViewAngle = iniparser_getboolean(dict, "isle:Wide View Angle", m_wideViewAngle);
 	m_use3dSound = iniparser_getboolean(dict, "isle:3DSound", m_use3dSound);
 	m_useMusic = iniparser_getboolean(dict, "isle:Music", m_useMusic);
@@ -1071,11 +1062,7 @@ bool IsleApp::LoadConfig()
 	// [library:config]
 	// The original game does not save any data if no savepath is given.
 	// Instead, we use SDLs prefPath as a default fallback and always save data.
-#ifdef __EMSCRIPTEN__
-	const char* savePath = Emscripten_savePath;
-#else
 	const char* savePath = iniparser_getstring(dict, "isle:savepath", prefPath);
-#endif
 	m_savePath = new char[strlen(savePath) + 1];
 	strcpy(m_savePath, savePath);
 


### PR DESCRIPTION
Close #556 
Close #558 

This sets `disableOffscreenCanvases` for browsers that have no WebGL support. It will then fall back to Software.

It will also set `Flip Surfaces` to `ON` for all Emscripten builds. Performance seems to be much better in WebGL, especially in Firefox.

