### PR TITLE
(Emscripten) Add external full screen support

### DIFF
--- a/ISLE/emscripten/config.cpp
+++ b/ISLE/emscripten/config.cpp
@@ -3,6 +3,7 @@
 #include "filesystem.h"
 
 #include <SDL3/SDL_log.h>
+#include <emscripten.h>
 #include <iniparser.h>
 
 void Emscripten_SetupDefaultConfigOverrides(dictionary* p_dictionary)
@@ -14,4 +15,8 @@ void Emscripten_SetupDefaultConfigOverrides(dictionary* p_dictionary)
 	iniparser_set(p_dictionary, "isle:savepath", Emscripten_savePath);
 	iniparser_set(p_dictionary, "isle:Full Screen", "false");
 	iniparser_set(p_dictionary, "isle:Flip Surfaces", "true");
+
+	// clang-format off
+	MAIN_THREAD_EM_ASM({JSEvents.fullscreenEnabled = function() { return false; }});
+// clang-format on
 }

--- a/miniwin/src/ddraw/ddraw.cpp
+++ b/miniwin/src/ddraw/ddraw.cpp
@@ -311,11 +311,11 @@ HRESULT DirectDrawImpl::SetCooperativeLevel(HWND hWnd, DDSCLFlags dwFlags)
 			return DDERR_INVALIDPARAMS;
 		}
 
-		if (!SDL_SetWindowFullscreen(sdlWindow, fullscreen)) {
 #ifndef __EMSCRIPTEN__
+		if (!SDL_SetWindowFullscreen(sdlWindow, fullscreen)) {
 			return DDERR_GENERIC;
-#endif
 		}
+#endif
 		DDWindow = sdlWindow;
 	}
 	return DD_OK;


### PR DESCRIPTION
Browsers are special in that they need user permission (generally an interaction, like a click) to enter full screen. For this reason, it's best to control full screen outside the app, in a clean interface such as the isle.pizza config:

![image](https://github.com/user-attachments/assets/d419a259-b040-4b48-ba00-06dd11e37953)

This adds minor adjustments to support this external configuration.