### PR TITLE
Fix uninitialized ddpfPixelFormat in VTable0x44

### DIFF
--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -827,6 +827,7 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 	ddsd.dwFlags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT;
 	ddsd.dwWidth = p_bitmap->GetBmiWidth();
 	ddsd.dwHeight = p_bitmap->GetBmiHeightAbs();
+	ddsd.ddpfPixelFormat = m_surfaceDesc.ddpfPixelFormat;
 	ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN;
 	*p_ret = 0;
 	ddsd.ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;

--- a/miniwin/include/miniwin/ddraw.h
+++ b/miniwin/include/miniwin/ddraw.h
@@ -143,9 +143,12 @@ enum class DDBltFlags : uint32_t {
 };
 ENABLE_BITMASK_OPERATORS(DDBltFlags)
 
+#define DDPF_ALPHAPIXELS DDPixelFormatFlags::ALPHAPIXELS
 #define DDPF_PALETTEINDEXED8 DDPixelFormatFlags::PALETTEINDEXED8
 #define DDPF_RGB DDPixelFormatFlags::RGB
+#define DDPF_ALPHAPIXELS DDPixelFormatFlags::ALPHAPIXELS
 enum class DDPixelFormatFlags : uint32_t {
+	ALPHAPIXELS = 1 << 0,     // dwRGBAlphaBitMask is valid
 	PALETTEINDEXED8 = 1 << 5, // The texture uses an 8 bit palette
 	RGB = 1 << 6,             // dwRGBBitCount, dwRBitMask, dwGBitMask, and dwBBitMask is valid
 };

--- a/miniwin/src/ddraw/ddraw.cpp
+++ b/miniwin/src/ddraw/ddraw.cpp
@@ -106,13 +106,17 @@ HRESULT DirectDrawImpl::CreateSurface(
 #endif
 	if ((lpDDSurfaceDesc->dwFlags & DDSD_PIXELFORMAT) == DDSD_PIXELFORMAT) {
 		if ((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_RGB) == DDPF_RGB) {
-			switch (lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount) {
-			case 8:
-				format = SDL_PIXELFORMAT_INDEX8;
-				break;
-			case 16:
-				format = SDL_PIXELFORMAT_RGB565;
-				break;
+			int bpp = lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount;
+			Uint32 rMask = lpDDSurfaceDesc->ddpfPixelFormat.dwRBitMask;
+			Uint32 gMask = lpDDSurfaceDesc->ddpfPixelFormat.dwGBitMask;
+			Uint32 bMask = lpDDSurfaceDesc->ddpfPixelFormat.dwBBitMask;
+			Uint32 aMask = (lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_ALPHAPIXELS) == DDPF_ALPHAPIXELS
+							   ? lpDDSurfaceDesc->ddpfPixelFormat.dwRGBAlphaBitMask
+							   : 0;
+
+			format = SDL_GetPixelFormatForMasks(bpp, rMask, gMask, bMask, aMask);
+			if (format == SDL_PIXELFORMAT_UNKNOWN) {
+				return DDERR_INVALIDPIXELFORMAT;
 			}
 		}
 	}
@@ -168,7 +172,7 @@ HRESULT DirectDrawImpl::EnumDisplayModes(
 		ddsd.dwWidth = modes[i]->w;
 		ddsd.dwHeight = modes[i]->h;
 		ddsd.ddpfPixelFormat.dwSize = sizeof(DDPIXELFORMAT);
-		ddsd.ddpfPixelFormat.dwFlags = DDPF_RGB;
+		ddsd.ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
 		ddsd.ddpfPixelFormat.dwRGBBitCount = details->bits_per_pixel;
 		if (details->bits_per_pixel == 8) {
 			ddsd.ddpfPixelFormat.dwFlags |= DDPF_PALETTEINDEXED8;
@@ -271,7 +275,7 @@ HRESULT DirectDrawImpl::GetDisplayMode(LPDDSURFACEDESC lpDDSurfaceDesc)
 	lpDDSurfaceDesc->dwWidth = mode->w;
 	lpDDSurfaceDesc->dwHeight = mode->h;
 	lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount = details->bits_per_pixel;
-	lpDDSurfaceDesc->ddpfPixelFormat.dwFlags = DDPF_RGB;
+	lpDDSurfaceDesc->ddpfPixelFormat.dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
 	if (details->bits_per_pixel == 8) {
 		lpDDSurfaceDesc->ddpfPixelFormat.dwFlags |= DDPF_PALETTEINDEXED8;
 	}

--- a/miniwin/src/ddraw/ddsurface.cpp
+++ b/miniwin/src/ddraw/ddsurface.cpp
@@ -145,7 +145,7 @@ HRESULT DirectDrawSurfaceImpl::GetPalette(LPDIRECTDRAWPALETTE* lplpDDPalette)
 HRESULT DirectDrawSurfaceImpl::GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat)
 {
 	memset(lpDDPixelFormat, 0, sizeof(*lpDDPixelFormat));
-	lpDDPixelFormat->dwFlags = DDPF_RGB;
+	lpDDPixelFormat->dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
 	const SDL_PixelFormatDetails* details = SDL_GetPixelFormatDetails(m_surface->format);
 	if (details->bits_per_pixel == 8) {
 		lpDDPixelFormat->dwFlags |= DDPF_PALETTEINDEXED8;

--- a/miniwin/src/ddraw/framebuffer.cpp
+++ b/miniwin/src/ddraw/framebuffer.cpp
@@ -143,7 +143,7 @@ HRESULT FrameBufferImpl::GetPalette(LPDIRECTDRAWPALETTE* lplpDDPalette)
 HRESULT FrameBufferImpl::GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat)
 {
 	memset(lpDDPixelFormat, 0, sizeof(*lpDDPixelFormat));
-	lpDDPixelFormat->dwFlags = DDPF_RGB;
+	lpDDPixelFormat->dwFlags = DDPF_RGB | DDPF_ALPHAPIXELS;
 	const SDL_PixelFormatDetails* details = SDL_GetPixelFormatDetails(m_transferBuffer->m_surface->format);
 	if (details->bits_per_pixel == 8) {
 		lpDDPixelFormat->dwFlags |= DDPF_PALETTEINDEXED8;


### PR DESCRIPTION
The surface format was not being set correctly in ddpfPixelFormat. With that corrected miniwin can now properly determin the format instead of making specific assumptions.