### PR TITLE
Add new touch control scheme ("gamepad")

### DIFF
--- a/ISLE/isleapp.h
+++ b/ISLE/isleapp.h
@@ -3,6 +3,7 @@
 
 #include "cursor.h"
 #include "lego1_export.h"
+#include "legoinputmanager.h"
 #include "legoutils.h"
 #include "mxtransitionmanager.h"
 #include "mxtypes.h"
@@ -53,6 +54,7 @@ public:
 	MxS32 GetDrawCursor() { return m_drawCursor; }
 	MxS32 GetGameStarted() { return m_gameStarted; }
 	MxFloat GetCursorSensitivity() { return m_cursorSensitivity; }
+	LegoInputManager::TouchScheme GetTouchScheme() { return m_touchScheme; }
 
 	void SetWindowActive(MxS32 p_windowActive) { m_windowActive = p_windowActive; }
 	void SetGameStarted(MxS32 p_gameStarted) { m_gameStarted = p_gameStarted; }
@@ -102,6 +104,7 @@ private:
 	MxFloat m_maxLod;
 	MxU32 m_maxAllowedExtras;
 	MxTransitionManager::TransitionType m_transitionType;
+	LegoInputManager::TouchScheme m_touchScheme;
 };
 
 extern IsleApp* g_isle;

--- a/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
+++ b/LEGO1/lego/legoomni/include/legoeventnotificationparam.h
@@ -18,6 +18,7 @@ public:
 		c_rButtonState = 2,
 		c_modKey1 = 4,
 		c_modKey2 = 8,
+		c_motionHandled = 16,
 	};
 
 	// FUNCTION: LEGO1 0x10028690

--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -93,7 +93,7 @@ public:
 
 	enum TouchScheme {
 		e_mouse = 0,
-		e_arrow_keys,
+		e_arrowKeys,
 		e_gamepad,
 	};
 

--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -18,6 +18,8 @@
 #include <windows.h>
 #endif
 
+#include <map>
+
 class LegoCameraController;
 class LegoControlManager;
 class LegoWorld;
@@ -89,6 +91,12 @@ public:
 		c_upOrDown = c_up | c_down
 	};
 
+	enum TouchScheme {
+		e_mouse = 0,
+		e_arrow_keys,
+		e_gamepad,
+	};
+
 	LegoInputManager();
 	~LegoInputManager() override;
 
@@ -144,6 +152,7 @@ public:
 	void GetKeyboardState();
 	MxResult GetNavigationKeyStates(MxU32& p_keyFlags);
 	MxResult GetNavigationTouchStates(MxU32& p_keyFlags);
+	MxBool HandleTouchEvent(SDL_Event* p_event, TouchScheme p_touchScheme);
 
 	// SYNTHETIC: LEGO1 0x1005b8d0
 	// LegoInputManager::`scalar deleting destructor'
@@ -171,6 +180,10 @@ private:
 	MxBool m_useJoystick;  // 0x334
 	MxBool m_unk0x335;     // 0x335
 	MxBool m_unk0x336;     // 0x336
+
+	std::map<SDL_FingerID, SDL_FPoint> m_touchOrigins;
+	std::map<SDL_FingerID, MxU32> m_touchFlags;
+	std::map<SDL_FingerID, Uint64> m_touchLastMotion;
 };
 
 // TEMPLATE: LEGO1 0x10028850

--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -152,7 +152,7 @@ public:
 	void GetKeyboardState();
 	MxResult GetNavigationKeyStates(MxU32& p_keyFlags);
 	MxResult GetNavigationTouchStates(MxU32& p_keyFlags);
-	MxBool HandleTouchEvent(SDL_Event* p_event, TouchScheme p_touchScheme);
+	LEGO1_EXPORT MxBool HandleTouchEvent(SDL_Event* p_event, TouchScheme p_touchScheme);
 
 	// SYNTHETIC: LEGO1 0x1005b8d0
 	// LegoInputManager::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legocameracontroller.cpp
@@ -41,6 +41,10 @@ MxResult LegoCameraController::Create()
 // FUNCTION: BETA10 0x10067852
 MxLong LegoCameraController::Notify(MxParam& p_param)
 {
+	if (((LegoEventNotificationParam&) p_param).GetModifier() & LegoEventNotificationParam::c_motionHandled) {
+		return SUCCESS;
+	}
+
 	switch (((MxNotificationParam&) p_param).GetNotification()) {
 	case c_notificationDragEnd: {
 		if (((((LegoEventNotificationParam&) p_param).GetModifier()) & LegoEventNotificationParam::c_lButtonState) ==

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -549,7 +549,7 @@ MxBool LegoInputManager::HandleTouchEvent(SDL_Event* p_event, TouchScheme p_touc
 	case e_mouse:
 		// Handled in LegoCameraController
 		return FALSE;
-	case e_arrow_keys:
+	case e_arrowKeys:
 		switch (p_event->type) {
 		case SDL_EVENT_FINGER_UP:
 			m_touchFlags.erase(event.fingerID);


### PR DESCRIPTION
Close #564 

I've added a new touch control scheme that is gamepad-like. The horizontal axis can be controlled like if you had an analog controller at the point where you put down your finger, and turns to left and right will be triggered by swipes to the left/right. This minimizes finger movement/screen obstruction if you are aiming to play the game with a single finger. It's also possible to use multiple fingers, i.e. one to control forward/backwards movement and another to turn left/right, if desired.

I've added an `.ini` option that controls which touch control scheme to use. In total, there are now 3:

<img width="432" height="394" alt="image" src="https://github.com/user-attachments/assets/3cefeb87-a0e7-4d0a-8da0-269cadd8ae4c" />
