### PR TITLE
Add haptic feedback (rumble)

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -791,6 +791,11 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 			SDL_Log("Game started");
 		}
 	}
+	else if (event->user.type == g_legoSdlEvents.m_hitActor) {
+		if (InputManager()) {
+			InputManager()->HandleRumbleEvent();
+		}
+	}
 
 	return SDL_APP_CONTINUE;
 }

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -173,6 +173,7 @@ IsleApp::IsleApp()
 	m_transitionType = MxTransitionManager::e_mosaic;
 	m_cursorSensitivity = 4;
 	m_touchScheme = LegoInputManager::e_gamepad;
+	m_haptic = TRUE;
 }
 
 // FUNCTION: ISLE 0x4011a0
@@ -791,7 +792,7 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 			SDL_Log("Game started");
 		}
 	}
-	else if (event->user.type == g_legoSdlEvents.m_hitActor) {
+	else if (event->user.type == g_legoSdlEvents.m_hitActor && g_isle->GetHaptic()) {
 		if (InputManager()) {
 			InputManager()->HandleRumbleEvent();
 		}
@@ -1047,6 +1048,7 @@ bool IsleApp::LoadConfig()
 		iniparser_set(dict, "isle:Max Allowed Extras", SDL_itoa(m_maxAllowedExtras, buf, 10));
 		iniparser_set(dict, "isle:Transition Type", SDL_itoa(m_transitionType, buf, 10));
 		iniparser_set(dict, "isle:Touch Scheme", SDL_itoa(m_touchScheme, buf, 10));
+		iniparser_set(dict, "isle:Haptic", m_haptic ? "true" : "false");
 
 #ifdef EXTENSIONS
 		iniparser_set(dict, "extensions", NULL);
@@ -1118,6 +1120,7 @@ bool IsleApp::LoadConfig()
 	m_transitionType =
 		(MxTransitionManager::TransitionType) iniparser_getint(dict, "isle:Transition Type", m_transitionType);
 	m_touchScheme = (LegoInputManager::TouchScheme) iniparser_getint(dict, "isle:Touch Scheme", m_touchScheme);
+	m_haptic = iniparser_getboolean(dict, "isle:Haptic", m_haptic);
 
 	const char* deviceId = iniparser_getstring(dict, "isle:3D Device ID", NULL);
 	if (deviceId != NULL) {

--- a/ISLE/isleapp.h
+++ b/ISLE/isleapp.h
@@ -55,6 +55,7 @@ public:
 	MxS32 GetGameStarted() { return m_gameStarted; }
 	MxFloat GetCursorSensitivity() { return m_cursorSensitivity; }
 	LegoInputManager::TouchScheme GetTouchScheme() { return m_touchScheme; }
+	MxBool GetHaptic() { return m_haptic; }
 
 	void SetWindowActive(MxS32 p_windowActive) { m_windowActive = p_windowActive; }
 	void SetGameStarted(MxS32 p_gameStarted) { m_gameStarted = p_gameStarted; }
@@ -105,6 +106,7 @@ private:
 	MxU32 m_maxAllowedExtras;
 	MxTransitionManager::TransitionType m_transitionType;
 	LegoInputManager::TouchScheme m_touchScheme;
+	MxBool m_haptic;
 };
 
 extern IsleApp* g_isle;

--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -153,6 +153,7 @@ public:
 	MxResult GetNavigationKeyStates(MxU32& p_keyFlags);
 	MxResult GetNavigationTouchStates(MxU32& p_keyFlags);
 	LEGO1_EXPORT MxBool HandleTouchEvent(SDL_Event* p_event, TouchScheme p_touchScheme);
+	LEGO1_EXPORT void HandleRumbleEvent();
 
 	// SYNTHETIC: LEGO1 0x1005b8d0
 	// LegoInputManager::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -153,7 +153,7 @@ public:
 	MxResult GetNavigationKeyStates(MxU32& p_keyFlags);
 	MxResult GetNavigationTouchStates(MxU32& p_keyFlags);
 	LEGO1_EXPORT MxBool HandleTouchEvent(SDL_Event* p_event, TouchScheme p_touchScheme);
-	LEGO1_EXPORT void HandleRumbleEvent();
+	LEGO1_EXPORT MxBool HandleRumbleEvent();
 
 	// SYNTHETIC: LEGO1 0x1005b8d0
 	// LegoInputManager::`scalar deleting destructor'

--- a/LEGO1/lego/legoomni/include/legoutils.h
+++ b/LEGO1/lego/legoomni/include/legoutils.h
@@ -71,6 +71,7 @@ LegoNamedTexture* ReadNamedTexture(LegoStorage* p_storage);
 void WriteDefaultTexture(LegoStorage* p_storage, const char* p_name);
 void WriteNamedTexture(LegoStorage* p_storage, LegoNamedTexture* p_namedTexture);
 void LoadFromNamedTexture(LegoNamedTexture* p_namedTexture);
+void HitActorEvent();
 
 // FUNCTION: BETA10 0x100260a0
 inline void StartIsleAction(IsleScript::Script p_objectId)

--- a/LEGO1/lego/legoomni/src/common/legoutils.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoutils.cpp
@@ -782,3 +782,10 @@ void LoadFromNamedTexture(LegoNamedTexture* p_namedTexture)
 		textureInfo->LoadBits(p_namedTexture->GetTexture()->GetImage()->GetBits());
 	}
 }
+
+void HitActorEvent()
+{
+	SDL_Event event;
+	event.user.type = g_legoSdlEvents.m_hitActor;
+	SDL_PushEvent(&event);
+}

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -627,13 +627,17 @@ MxBool LegoInputManager::HandleTouchEvent(SDL_Event* p_event, TouchScheme p_touc
 	return TRUE;
 }
 
-void LegoInputManager::HandleRumbleEvent()
+MxBool LegoInputManager::HandleRumbleEvent()
 {
 	if (m_joystick != NULL && SDL_GamepadConnected(m_joystick) == TRUE) {
-		const Uint16 frequency = 65535 / 3;
-		const Uint32 durationMs = 1000;
+		const Uint16 frequency = 65535 / 2;
+		const Uint32 durationMs = 700;
 		SDL_RumbleGamepad(m_joystick, frequency, frequency, durationMs);
+	}
+	else {
+		return FALSE;
 	}
 
 	// Add support for SDL Haptic API
+	return TRUE;
 }

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -626,3 +626,14 @@ MxBool LegoInputManager::HandleTouchEvent(SDL_Event* p_event, TouchScheme p_touc
 
 	return TRUE;
 }
+
+void LegoInputManager::HandleRumbleEvent()
+{
+	if (m_joystick != NULL && SDL_GamepadConnected(m_joystick) == TRUE) {
+		const Uint16 frequency = 65535 / 3;
+		const Uint32 durationMs = 1000;
+		SDL_RumbleGamepad(m_joystick, frequency, frequency, durationMs);
+	}
+
+	// Add support for SDL Haptic API
+}

--- a/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
+++ b/LEGO1/lego/legoomni/src/paths/legoextraactor.cpp
@@ -235,6 +235,7 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 				assert(m_roi);
 				assert(SoundManager()->GetCacheSoundManager());
 				SoundManager()->GetCacheSoundManager()->Play("crash5", m_roi->GetName(), FALSE);
+				HitActorEvent();
 				m_scheduledTime = Timer()->GetTime() + m_disAnim->GetDuration();
 				m_prevWorldSpeed = GetWorldSpeed();
 				VTable0xc4();
@@ -248,6 +249,7 @@ MxResult LegoExtraActor::HitActor(LegoPathActor* p_actor, MxBool p_bool)
 			LegoROI* roi = GetROI();
 			assert(roi);
 			SoundManager()->GetCacheSoundManager()->Play("crash5", m_roi->GetName(), FALSE);
+			HitActorEvent();
 			VTable0xc4();
 			SetActorState(c_two | c_noCollide);
 			Mx3DPointFloat dir = p_actor->GetWorldDirection();

--- a/LEGO1/omni/include/mxutilities.h
+++ b/LEGO1/omni/include/mxutilities.h
@@ -10,6 +10,7 @@
 struct LegoSdlEvents {
 	Uint32 m_windowsMessage;
 	Uint32 m_presenterProgress;
+	Uint32 m_hitActor;
 };
 
 LEGO1_EXPORT extern LegoSdlEvents g_legoSdlEvents;

--- a/LEGO1/omni/src/main/mxomni.cpp
+++ b/LEGO1/omni/src/main/mxomni.cpp
@@ -163,9 +163,10 @@ MxResult MxOmni::Create(MxOmniCreateParam& p_param)
 	}
 
 	{
-		Uint32 event = SDL_RegisterEvents(2);
+		Uint32 event = SDL_RegisterEvents(3);
 		g_legoSdlEvents.m_windowsMessage = event + 0;
 		g_legoSdlEvents.m_presenterProgress = event + 1;
+		g_legoSdlEvents.m_hitActor = event + 2;
 	}
 
 	result = SUCCESS;


### PR DESCRIPTION
This adds a basic rumble effect, supported on certain gamepads. It also adds an `.ini` option `Haptic`, which is on by default since I think it's a natural fit.

Currently, the only game event that triggers a rumble is when you run into a Lego character (crash), but I'm planning to add it to other places (i.e. bumping into race cars)

We should also integrate SDL's Haptic API, however since it is not supported on Emscripten I have no device available that supports this API. Someone with iOS/iPad/NDS could give it a shot.
