### PR TITLE
Remove SDL mouse/touch event bug workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,9 @@ if (ISLE_BUILD_APP)
   # Allow unconditional include of miniwin/miniwindevice.h
   target_link_libraries(isle PRIVATE miniwin-headers)
 
+  # Vector math
+  target_link_libraries(isle PRIVATE Vec::Vec)
+
   # Link DSOUND and WINMM
   if (WIN32)
     target_link_libraries(isle PRIVATE winmm)

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -706,8 +706,9 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 		float x = SDL_clamp(event->tfinger.x, 0, 1) * g_targetWidth;
 		float y = SDL_clamp(event->tfinger.y, 0, 1) * g_targetHeight;
 
+		g_isle->DetectDoubleTap(event->tfinger);
+
 		if (InputManager()) {
-			g_isle->DetectDoubleTap(event->tfinger);
 			InputManager()->HandleTouchEvent(event, g_isle->GetTouchScheme());
 			InputManager()->QueueEvent(c_notificationButtonUp, 0, x, y, 0);
 		}
@@ -1449,7 +1450,11 @@ void IsleApp::DetectDoubleTap(const SDL_TouchFingerEvent& p_event)
 	LastTap currentTap = {p_event.timestamp, {p_event.x, p_event.y}};
 	if (SDL_NS_TO_MS(currentTap.first - lastTap.first) < doubleTapMs &&
 		DISTSQRD2(currentTap.second, lastTap.second) < doubleTapDist) {
-		InputManager()->QueueEvent(c_notificationKeyPress, SDLK_SPACE, 0, 0, SDLK_SPACE);
+
+		if (InputManager()) {
+			InputManager()->QueueEvent(c_notificationKeyPress, SDLK_SPACE, 0, 0, SDLK_SPACE);
+		}
+
 		lastTap = {0, {0, 0}};
 	}
 	else {

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -37,6 +37,7 @@
 #include "tgl/d3drm/impl.h"
 #include "viewmanager/viewmanager.h"
 
+#include <array>
 #include <extensions/extensions.h>
 #include <miniwin/miniwindevice.h>
 #include <vec.h>

--- a/ISLE/isleapp.h
+++ b/ISLE/isleapp.h
@@ -65,6 +65,7 @@ public:
 	MxResult VerifyFilesystem();
 	void DetectGameVersion();
 	void MoveVirtualMouseViaJoystick();
+	void DetectDoubleTap(const SDL_TouchFingerEvent& p_event);
 
 private:
 	char* m_hdPath;              // 0x00


### PR DESCRIPTION
Close #599 

Also implements double tap detection to trigger interrupts. This should now work on all touch devices and not just the Emscripten port.