### PR TITLE
For MaxLOD values > 5, disable LOD threshold and view limits

### DIFF
--- a/CONFIG/res/maindialog.ui
+++ b/CONFIG/res/maindialog.ui
@@ -291,7 +291,7 @@ A higher setting will cause higher quality textures to be drawn regardless of di
                </sizepolicy>
               </property>
               <property name="maximum">
-               <number>50</number>
+               <number>60</number>
               </property>
               <property name="singleStep">
                <number>5</number>

--- a/LEGO1/viewmanager/viewmanager.cpp
+++ b/LEGO1/viewmanager/viewmanager.cpp
@@ -235,7 +235,7 @@ inline void ViewManager::ManageVisibilityAndDetailRecursively(ViewROI* p_from, i
 			if (p_from->GetWorldBoundingSphere().Radius() > 0.001F) {
 				float projectedSize = ProjectedSize(p_from->GetWorldBoundingSphere());
 
-				if (projectedSize < seconds_allowed * g_viewDistance) {
+				if (RealtimeView::GetUserMaxLOD() <= 5.0f && projectedSize < seconds_allowed * g_viewDistance) {
 					if (p_from->GetLodLevel() != ViewROI::c_lodLevelInvisible) {
 						ManageVisibilityAndDetailRecursively(p_from, ViewROI::c_lodLevelInvisible);
 					}
@@ -361,7 +361,7 @@ inline int ViewManager::CalculateLODLevel(float p_maximumScale, float p_initialS
 	assert(from);
 
 	if (GetFirstLODIndex(from) != 0) {
-		if (p_maximumScale < g_minLODThreshold) {
+		if (RealtimeView::GetUserMaxLOD() <= 5.0f && p_maximumScale < g_minLODThreshold) {
 			return 0;
 		}
 		else {


### PR DESCRIPTION
If a user specifies a `MaxLOD` value greater than 5, view limits and LOD threshold will be removed entirely. This means everything will be drawn at any distance at maximum quality. Previously, LEGO heads would fall back to a low LOD level at mid-distance, and smaller plants or LEGO minifigures far away would disappear. Using a MaxLOD value above 5 will fix this.