### PR TITLE
Handle `SDL_EVENT_FINGER_CANCELED`

### DIFF
--- a/ISLE/emscripten/window.cpp
+++ b/ISLE/emscripten/window.cpp
@@ -84,7 +84,8 @@ void Emscripten_ConvertEventToRenderCoordinates(SDL_Event* event)
 	}
 	case SDL_EVENT_FINGER_MOTION:
 	case SDL_EVENT_FINGER_DOWN:
-	case SDL_EVENT_FINGER_UP: {
+	case SDL_EVENT_FINGER_UP:
+	case SDL_EVENT_FINGER_CANCELED: {
 		const float scale = std::min(g_fullWidth / g_targetWidth, g_fullHeight / g_targetHeight);
 		const float widthRatio = (g_targetWidth * scale) / g_fullWidth;
 		const float heightRatio = (g_targetHeight * scale) / g_fullHeight;

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -460,6 +460,7 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 	case SDL_EVENT_FINGER_MOTION:
 	case SDL_EVENT_FINGER_DOWN:
 	case SDL_EVENT_FINGER_UP:
+	case SDL_EVENT_FINGER_CANCELED:
 		IDirect3DRMMiniwinDevice* device = GetD3DRMMiniwinDevice();
 		if (device && !device->ConvertEventToRenderCoordinates(event)) {
 			SDL_Log("Failed to convert event coordinates: %s", SDL_GetError());
@@ -754,7 +755,8 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 			);
 		}
 		break;
-	case SDL_EVENT_FINGER_UP: {
+	case SDL_EVENT_FINGER_UP:
+	case SDL_EVENT_FINGER_CANCELED: {
 		g_mousedown = FALSE;
 
 		float x = SDL_clamp(event->tfinger.x, 0, 1) * g_targetWidth;

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -612,6 +612,7 @@ MxBool LegoInputManager::HandleTouchEvent(SDL_Event* p_event, TouchScheme p_touc
 	case e_arrowKeys:
 		switch (p_event->type) {
 		case SDL_EVENT_FINGER_UP:
+		case SDL_EVENT_FINGER_CANCELED:
 			m_touchFlags.erase(event.fingerID);
 			break;
 		case SDL_EVENT_FINGER_DOWN:
@@ -647,6 +648,7 @@ MxBool LegoInputManager::HandleTouchEvent(SDL_Event* p_event, TouchScheme p_touc
 			}
 			break;
 		case SDL_EVENT_FINGER_UP:
+		case SDL_EVENT_FINGER_CANCELED:
 			if (event.fingerID == g_finger) {
 				g_finger = 0;
 				m_touchVirtualThumb = {0, 0};
@@ -795,6 +797,7 @@ void LegoInputManager::UpdateLastInputMethod(SDL_Event* p_event)
 	case SDL_EVENT_FINGER_MOTION:
 	case SDL_EVENT_FINGER_DOWN:
 	case SDL_EVENT_FINGER_UP:
+	case SDL_EVENT_FINGER_CANCELED:
 		m_lastInputMethod = SDL_TouchID_v{p_event->tfinger.touchID};
 		break;
 	}

--- a/miniwin/src/d3drm/d3drmdevice.cpp
+++ b/miniwin/src/d3drm/d3drmdevice.cpp
@@ -185,7 +185,8 @@ bool Direct3DRMDevice2Impl::ConvertEventToRenderCoordinates(SDL_Event* event)
 	}
 	case SDL_EVENT_FINGER_MOTION:
 	case SDL_EVENT_FINGER_DOWN:
-	case SDL_EVENT_FINGER_UP: {
+	case SDL_EVENT_FINGER_UP:
+	case SDL_EVENT_FINGER_CANCELED: {
 		float x = (event->tfinger.x * m_windowWidth - m_viewportTransform.offsetX) / m_viewportTransform.scale;
 		float y = (event->tfinger.y * m_windowHeight - m_viewportTransform.offsetY) / m_viewportTransform.scale;
 		event->tfinger.x = x / m_virtualWidth;


### PR DESCRIPTION
`SDL_EVENT_FINGER_CANCELED` is a special event that is emitted after a fullscreen exit touch gesture on Android for instance. We should treat it the same way as a finger up event.