### PR TITLE
Fix insufficient float precision

### DIFF
--- a/miniwin/src/d3drm/backends/opengles3/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengles3/renderer.cpp
@@ -71,7 +71,7 @@ Direct3DRMRenderer* OpenGLES3Renderer::Create(DWORD width, DWORD height, DWORD m
 	glFrontFace(GL_CW);
 
 	const char* vertexShaderSource = R"(#version 300 es
-		precision mediump float;
+		precision highp float;
 
 		in vec3 a_position;
 		in vec3 a_normal;


### PR DESCRIPTION
On mobile WebGL systems, this causes textures to glitch, see #642 