### PR TITLE
Add Anisotropic Filtering to `isle-config`

### DIFF
--- a/CONFIG/MainDlg.cpp
+++ b/CONFIG/MainDlg.cpp
@@ -88,6 +88,8 @@ CMainDialog::CMainDialog(QWidget* pParent) : QDialog(pParent)
 
 	connect(m_ui->msaaSlider, &QSlider::valueChanged, this, &CMainDialog::MSAAChanged);
 	connect(m_ui->msaaSlider, &QSlider::sliderMoved, this, &CMainDialog::MSAAChanged);
+	connect(m_ui->AFSlider, &QSlider::valueChanged, this, &CMainDialog::AFChanged);
+	connect(m_ui->AFSlider, &QSlider::sliderMoved, this, &CMainDialog::AFChanged);
 
 	connect(m_ui->aspectRatioComboBox, &QComboBox::currentIndexChanged, this, &CMainDialog::AspectRatioChanged);
 	connect(m_ui->xResSpinBox, &QSpinBox::valueChanged, this, &CMainDialog::XResChanged);
@@ -321,6 +323,8 @@ void CMainDialog::UpdateInterface()
 	m_ui->maxActorsNum->setNum(currentConfigApp->m_max_actors);
 	m_ui->msaaSlider->setValue(log2(currentConfigApp->m_msaa));
 	m_ui->msaaNum->setNum(currentConfigApp->m_msaa);
+	m_ui->AFSlider->setValue(log2(currentConfigApp->m_anisotropy));
+	m_ui->AFNum->setNum(currentConfigApp->m_anisotropy);
 }
 
 // FUNCTION: CONFIG 0x004045e0
@@ -546,6 +550,13 @@ void CMainDialog::MaxActorsChanged(int value)
 void CMainDialog::MSAAChanged(int value)
 {
 	currentConfigApp->m_msaa = exp2(value);
+	m_modified = true;
+	UpdateInterface();
+}
+
+void CMainDialog::AFChanged(int value)
+{
+	currentConfigApp->m_anisotropy = exp2(value);
 	m_modified = true;
 	UpdateInterface();
 }

--- a/CONFIG/MainDlg.h
+++ b/CONFIG/MainDlg.h
@@ -61,6 +61,7 @@ private slots:
 	void MaxLoDChanged(int value);
 	void MaxActorsChanged(int value);
 	void MSAAChanged(int value);
+	void AFChanged(int value);
 	void SelectTexturePathDialog();
 	void TexturePathEdited();
 	void XResChanged(int i);

--- a/CONFIG/config.cpp
+++ b/CONFIG/config.cpp
@@ -85,6 +85,7 @@ bool CConfigApp::InitInstance()
 	m_joystick_index = -1;
 	m_display_bit_depth = 16;
 	m_msaa = 1;
+	m_anisotropy = 1;
 	m_haptic = TRUE;
 	m_touch_scheme = 2;
 	m_texture_load = TRUE;
@@ -184,6 +185,7 @@ bool CConfigApp::ReadRegisterSettings()
 	m_max_lod = iniparser_getdouble(dict, "isle:Max LOD", m_max_lod);
 	m_max_actors = iniparser_getint(dict, "isle:Max Allowed Extras", m_max_actors);
 	m_msaa = iniparser_getint(dict, "isle:MSAA", m_msaa);
+	m_anisotropy = iniparser_getint(dict, "isle:Anisotropic", m_anisotropy);
 	m_texture_load = iniparser_getboolean(dict, "extensions:texture loader", m_texture_load);
 	m_texture_path = iniparser_getstring(dict, "texture loader:texture path", m_texture_path.c_str());
 	m_aspect_ratio = iniparser_getint(dict, "isle:Aspect Ratio", m_aspect_ratio);
@@ -281,6 +283,18 @@ bool CConfigApp::ValidateSettings()
 		m_msaa = 1;
 		is_modified = TRUE;
 	}
+	if (!(m_anisotropy & (m_anisotropy - 1))) {         // Check if anisotropy is power of 2 (1, 2, 4, 8, etc)
+		m_anisotropy = exp2(round(log2(m_anisotropy))); // Closest power of 2
+		is_modified = TRUE;
+	}
+	if (m_anisotropy > 16) {
+		m_anisotropy = 16;
+		is_modified = TRUE;
+	}
+	else if (m_anisotropy < 1) {
+		m_anisotropy = 1;
+		is_modified = TRUE;
+	}
 
 	return is_modified;
 }
@@ -360,6 +374,7 @@ void CConfigApp::WriteRegisterSettings() const
 
 	SetIniInt(dict, "isle:Display Bit Depth", m_display_bit_depth);
 	SetIniInt(dict, "isle:MSAA", m_msaa);
+	SetIniInt(dict, "isle:Anisotropic", m_anisotropy);
 	SetIniBool(dict, "isle:Flip Surfaces", m_flip_surfaces);
 	SetIniBool(dict, "isle:Full Screen", m_full_screen);
 	SetIniBool(dict, "isle:Exclusive Full Screen", m_exclusive_full_screen);

--- a/CONFIG/config.h
+++ b/CONFIG/config.h
@@ -71,6 +71,7 @@ public:
 	Direct3DDeviceInfo* m_device;
 	int m_display_bit_depth;
 	int m_msaa;
+	int m_anisotropy;
 	bool m_flip_surfaces;
 	bool m_full_screen;
 	bool m_exclusive_full_screen;

--- a/CONFIG/res/maindialog.ui
+++ b/CONFIG/res/maindialog.ui
@@ -631,7 +631,7 @@ The game will gradually increase the number of actors until this maximum is reac
                </property>
                <layout class="QVBoxLayout" name="fullscreenRadioContainer">
                 <property name="spacing">
-                 <number>3</number>
+                 <number>6</number>
                 </property>
                 <property name="leftMargin">
                  <number>0</number>
@@ -823,64 +823,116 @@ The game will gradually increase the number of actors until this maximum is reac
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="msaaBox">
-            <property name="title">
-             <string>MSAA</string>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <widget class="QWidget" name="msaaAFBox" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_10">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
              <item>
-              <widget class="QSlider" name="msaaSlider">
-               <property name="minimum">
-                <number>0</number>
+              <widget class="QGroupBox" name="msaaBox">
+               <property name="title">
+                <string>MSAA</string>
                </property>
-               <property name="maximum">
-                <number>4</number>
-               </property>
-               <property name="pageStep">
-                <number>1</number>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="tickPosition">
-                <enum>QSlider::TickPosition::TicksBothSides</enum>
-               </property>
-               <property name="tickInterval">
-                <number>1</number>
-               </property>
+               <layout class="QHBoxLayout" name="horizontalLayout_3">
+                <item>
+                 <widget class="QSlider" name="msaaSlider">
+                  <property name="minimum">
+                   <number>0</number>
+                  </property>
+                  <property name="maximum">
+                   <number>4</number>
+                  </property>
+                  <property name="pageStep">
+                   <number>1</number>
+                  </property>
+                  <property name="orientation">
+                   <enum>Qt::Orientation::Horizontal</enum>
+                  </property>
+                  <property name="tickPosition">
+                   <enum>QSlider::TickPosition::TicksBothSides</enum>
+                  </property>
+                  <property name="tickInterval">
+                   <number>1</number>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="msaaNum">
+                  <property name="minimumSize">
+                   <size>
+                    <width>16</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>1</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="msaaNum">
-               <property name="minimumSize">
-                <size>
-                 <width>16</width>
-                 <height>0</height>
-                </size>
+              <widget class="QGroupBox" name="AFBox">
+               <property name="title">
+                <string>Anisotropic Filtering</string>
                </property>
-               <property name="text">
-                <string>1</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignCenter</set>
-               </property>
+               <layout class="QHBoxLayout" name="horizontalLayout_11">
+                <item>
+                 <widget class="QSlider" name="AFSlider">
+                  <property name="minimum">
+                   <number>0</number>
+                  </property>
+                  <property name="maximum">
+                   <number>4</number>
+                  </property>
+                  <property name="pageStep">
+                   <number>1</number>
+                  </property>
+                  <property name="orientation">
+                   <enum>Qt::Orientation::Horizontal</enum>
+                  </property>
+                  <property name="tickPosition">
+                   <enum>QSlider::TickPosition::TicksBothSides</enum>
+                  </property>
+                  <property name="tickInterval">
+                   <number>1</number>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="AFNum">
+                  <property name="minimumSize">
+                   <size>
+                    <width>16</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>1</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </widget>
              </item>
             </layout>
            </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </widget>
@@ -1121,6 +1173,7 @@ The game will gradually increase the number of actors until this maximum is reac
   <tabstop>yResSpinBox</tabstop>
   <tabstop>exFullResComboBox</tabstop>
   <tabstop>msaaSlider</tabstop>
+  <tabstop>AFSlider</tabstop>
   <tabstop>touchComboBox</tabstop>
   <tabstop>rumbleCheckBox</tabstop>
   <tabstop>textureCheckBox</tabstop>


### PR DESCRIPTION
Added Anisotropic Filtering as an option in isle-config.

<img width="683" height="633" alt="Screenshot_20250724_120529" src="https://github.com/user-attachments/assets/6e07662c-59d9-400f-9e3e-d3eeda160886" />

Related to #641.