### PR TITLE
Fix debug, improve `isle-config`

### DIFF
--- a/CONFIG/AboutDlg.cpp
+++ b/CONFIG/AboutDlg.cpp
@@ -7,12 +7,9 @@
 DECOMP_SIZE_ASSERT(CDialog, 0x60)
 DECOMP_SIZE_ASSERT(CAboutDialog, 0x60)
 
-// FIXME: disable dialog resizing
-
 // FUNCTION: CONFIG 0x00403c20
 CAboutDialog::CAboutDialog() : QDialog()
 {
 	m_ui = new Ui::AboutDialog;
 	m_ui->setupUi(this);
-	layout()->setSizeConstraint(QLayout::SetFixedSize);
 }

--- a/CONFIG/MainDlg.cpp
+++ b/CONFIG/MainDlg.cpp
@@ -505,14 +505,15 @@ void CMainDialog::SelectDataPathDialog()
 		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks
 	);
 
-	QDir data_dir = QDir(data_path);
-
-	if (data_dir.exists()) {
-		currentConfigApp->m_cd_path = data_dir.absolutePath().toStdString();
-		data_dir.cd(QString("DATA"));
-		data_dir.cd(QString("disk"));
-		currentConfigApp->m_base_path = data_dir.absolutePath().toStdString();
-		m_modified = true;
+	if (!data_path.isEmpty()) {
+		QDir data_dir = QDir(data_path);
+		if (data_dir.exists()) {
+			currentConfigApp->m_cd_path = data_dir.absolutePath().toStdString();
+			data_dir.cd(QString("DATA"));
+			data_dir.cd(QString("disk"));
+			currentConfigApp->m_base_path = data_dir.absolutePath().toStdString();
+			m_modified = true;
+		}
 	}
 	UpdateInterface();
 }
@@ -527,11 +528,12 @@ void CMainDialog::SelectSavePathDialog()
 		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks
 	);
 
-	QDir save_dir = QDir(save_path);
-
-	if (save_dir.exists()) {
-		currentConfigApp->m_save_path = save_dir.absolutePath().toStdString();
-		m_modified = true;
+	if (!save_path.isEmpty()) {
+		QDir save_dir = QDir(save_path);
+		if (save_dir.exists()) {
+			currentConfigApp->m_save_path = save_dir.absolutePath().toStdString();
+			m_modified = true;
+		}
 	}
 	UpdateInterface();
 }
@@ -547,13 +549,11 @@ void CMainDialog::DataPathEdited()
 		currentConfigApp->m_base_path = data_dir.absolutePath().toStdString();
 		m_modified = true;
 	}
-
 	UpdateInterface();
 }
 
 void CMainDialog::SavePathEdited()
 {
-
 	QDir save_dir = QDir(m_ui->savePath->text());
 
 	if (save_dir.exists()) {
@@ -606,7 +606,7 @@ void CMainDialog::SelectTexturePathDialog()
 		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks
 	);
 
-	if (data_path.exists(texture_path)) {
+	if (!texture_path.isEmpty() && data_path.exists(texture_path)) {
 		texture_path = data_path.relativeFilePath(texture_path);
 		texture_path.prepend(QDir::separator());
 		currentConfigApp->m_texture_path = texture_path.toStdString();
@@ -623,7 +623,7 @@ void CMainDialog::TexturePathEdited()
 	if (texture_path.startsWith(QDir::separator())) {
 		texture_path.remove(0, 1);
 	}
-	if (data_path.exists(texture_path)) {
+	if (data_path.exists(data_path.absoluteFilePath(texture_path))) {
 		texture_path = data_path.relativeFilePath(texture_path);
 		texture_path.prepend(QDir::separator());
 		currentConfigApp->m_texture_path = texture_path.toStdString();

--- a/CONFIG/res/about.ui
+++ b/CONFIG/res/about.ui
@@ -14,6 +14,9 @@
    <string>About Configure LEGO© Island</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,0">
+   <property name="sizeConstraint">
+    <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+   </property>
    <item>
     <widget class="QLabel" name="houseIcon">
      <property name="sizePolicy">
@@ -36,14 +39,14 @@
       <item>
        <widget class="QLabel" name="configureLabel">
         <property name="text">
-         <string>Configure LEGO Island Version 1.0</string>
+         <string>Configure LEGO Island Version 2.0</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QLabel" name="copyrightLabel">
         <property name="text">
-         <string>Copyright © 1997 mindscape</string>
+         <string>Copyright © 2025</string>
         </property>
        </widget>
       </item>
@@ -53,7 +56,7 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -1391,12 +1391,12 @@ SDL_AppResult IsleApp::ParseArguments(int argc, char** argv)
 			consumed = 1;
 		}
 		else if (strcmp(argv[i], "--help") == 0) {
-			DisplayArgumentHelp();
+			DisplayArgumentHelp(argv[0]);
 			return SDL_APP_SUCCESS;
 		}
 		if (consumed <= 0) {
 			SDL_Log("Invalid argument(s): %s", argv[i]);
-			DisplayArgumentHelp();
+			DisplayArgumentHelp(argv[0]);
 			return SDL_APP_FAILURE;
 		}
 	}
@@ -1404,9 +1404,9 @@ SDL_AppResult IsleApp::ParseArguments(int argc, char** argv)
 	return SDL_APP_CONTINUE;
 }
 
-void IsleApp::DisplayArgumentHelp()
+void IsleApp::DisplayArgumentHelp(char* execName)
 {
-	SDL_Log("Usage: isle [options]");
+	SDL_Log("Usage: %s [options]", execName);
 	SDL_Log("Options:");
 	SDL_Log("	--ini <path>		Set custom path to .ini config");
 #ifdef ISLE_DEBUG

--- a/ISLE/isleapp.h
+++ b/ISLE/isleapp.h
@@ -99,7 +99,7 @@ private:
 	const CursorBitmap* m_cursorCurrentBitmap;
 	char* m_mediaPath;
 	MxFloat m_cursorSensitivity;
-	void DisplayArgumentHelp();
+	void DisplayArgumentHelp(char* execName);
 
 	char* m_iniPath;
 	MxFloat m_maxLod;

--- a/ISLE/isledebug.cpp
+++ b/ISLE/isledebug.cpp
@@ -68,10 +68,10 @@ public:
 	static void InsideBuildingManager()
 	{
 		auto buildingManager = Lego()->GetBuildingManager();
-		ImGui::Text("nextVariant: %d", buildingManager->m_nextVariant);
+		ImGui::Text("nextVariant: %u", buildingManager->m_nextVariant);
 		ImGui::Text("m_boundariesDetermined: %d", buildingManager->m_boundariesDetermined);
 		ImGui::Text("m_hideAfterAnimation: %d", buildingManager->m_hideAfterAnimation);
-		ImGui::Text("#Animated Entries", buildingManager->m_numEntries);
+		ImGui::Text("#Animated Entries: %d", buildingManager->m_numEntries);
 		if (buildingManager->m_numEntries) {
 			if (ImGui::BeginTable("Animated Entries", 6, ImGuiTableFlags_Borders)) {
 				ImGui::TableSetupColumn("ROI Name");


### PR DESCRIPTION
- Fix warning that was occurring with `isledebug.cpp`:
```
/home/voxeltek/isle-portable/ISLE/isledebug.cpp: In static member function ‘static void DebugViewer::InsideBuildingManager()’:
/home/voxeltek/isle-portable/ISLE/isledebug.cpp:74:29: warning: too many arguments for format [-Wformat-extra-args]
   74 |                 ImGui::Text("#Animated Entries", buildingManager->m_numEntries);
      |                             ^~~~~~~~~~~~~~~~~~~
```
- Misc fixes and improvements to `isle-config` tool
- Slight CLI improvement to `isle`