### PR TITLE
Add new directives to SiLoader, allow specifying directives in `.ini`

### DIFF
--- a/LEGO1/omni/src/notify/mxnotificationmanager.cpp
+++ b/LEGO1/omni/src/notify/mxnotificationmanager.cpp
@@ -2,6 +2,7 @@
 
 #include "compat.h"
 #include "decomp.h"
+#include "extensions/siloader.h"
 #include "mxautolock.h"
 #include "mxmisc.h"
 #include "mxnotificationparam.h"
@@ -11,6 +12,8 @@
 
 DECOMP_SIZE_ASSERT(MxNotification, 0x08);
 DECOMP_SIZE_ASSERT(MxNotificationManager, 0x40);
+
+using namespace Extensions;
 
 // FUNCTION: LEGO1 0x100ac220
 MxNotification::MxNotification(MxCore* p_target, const MxNotificationParam& p_param)
@@ -105,6 +108,11 @@ MxResult MxNotificationManager::Tickle()
 		while (m_sendList->size() != 0) {
 			MxNotification* notif = m_sendList->front();
 			m_sendList->pop_front();
+
+			if (notif->GetParam()->GetNotification() == c_notificationEndAction) {
+				Extension<SiLoader>::Call(HandleEndAction, (MxEndActionNotificationParam&) *notif->GetParam());
+			}
+
 			notif->GetTarget()->Notify(*notif->GetParam());
 			delete notif;
 		}
@@ -159,6 +167,11 @@ void MxNotificationManager::FlushPending(MxCore* p_listener)
 	while (pending.size() != 0) {
 		notif = pending.front();
 		pending.pop_front();
+
+		if (notif->GetParam()->GetNotification() == c_notificationEndAction) {
+			Extension<SiLoader>::Call(HandleEndAction, (MxEndActionNotificationParam&) *notif->GetParam());
+		}
+
 		notif->GetTarget()->Notify(*notif->GetParam());
 		delete notif;
 	}

--- a/LEGO1/omni/src/stream/mxstreamer.cpp
+++ b/LEGO1/omni/src/stream/mxstreamer.cpp
@@ -66,7 +66,7 @@ MxStreamController* MxStreamer::Open(const char* p_name, MxU16 p_lookupType)
 
 	MxStreamController* stream = NULL;
 
-	if (GetOpenStream(p_name)) {
+	if ((stream = GetOpenStream(p_name))) {
 		goto done;
 	}
 

--- a/extensions/include/extensions/siloader.h
+++ b/extensions/include/extensions/siloader.h
@@ -2,6 +2,7 @@
 
 #include "extensions/extensions.h"
 #include "legoworld.h"
+#include "mxactionnotificationparam.h"
 #include "mxatom.h"
 
 #include <map>
@@ -24,18 +25,23 @@ public:
 	static std::optional<MxResult> HandleStart(MxDSAction& p_action);
 	static std::optional<MxBool> HandleRemove(StreamObject p_object, LegoWorld* world);
 	static std::optional<MxBool> HandleDelete(MxDSAction& p_action);
+	static MxBool HandleEndAction(MxEndActionNotificationParam& p_param);
 
 	static std::map<std::string, std::string> options;
 	static std::vector<std::string> files;
+	static std::vector<std::string> directives;
 	static bool enabled;
 
 private:
 	static std::vector<std::pair<StreamObject, StreamObject>> startWith;
 	static std::vector<std::pair<StreamObject, StreamObject>> removeWith;
 	static std::vector<std::pair<StreamObject, StreamObject>> replace;
+	static std::vector<std::pair<StreamObject, StreamObject>> prepend;
 
 	static bool LoadFile(const char* p_file);
-	static void ParseDirectives(const MxAtomId& p_atom, si::Core* p_core, MxAtomId p_parentReplacedAtom = MxAtomId());
+	static bool LoadDirective(const char* p_directive);
+	static MxStreamController* OpenStream(const char* p_file);
+	static void ParseExtra(const MxAtomId& p_atom, si::Core* p_core, MxAtomId p_parentReplacedAtom = MxAtomId());
 };
 
 #ifdef EXTENSIONS
@@ -44,11 +50,13 @@ constexpr auto HandleFind = &SiLoader::HandleFind;
 constexpr auto HandleStart = &SiLoader::HandleStart;
 constexpr auto HandleRemove = &SiLoader::HandleRemove;
 constexpr auto HandleDelete = &SiLoader::HandleDelete;
+constexpr auto HandleEndAction = &SiLoader::HandleEndAction;
 #else
 constexpr decltype(&SiLoader::Load) Load = nullptr;
 constexpr decltype(&SiLoader::HandleFind) HandleFind = nullptr;
 constexpr decltype(&SiLoader::HandleStart) HandleStart = nullptr;
 constexpr decltype(&SiLoader::HandleRemove) HandleRemove = nullptr;
 constexpr decltype(&SiLoader::HandleDelete) HandleDelete = nullptr;
+constexpr decltype(&SiLoader::HandleEndAction) HandleEndAction = nullptr;
 #endif
 }; // namespace Extensions

--- a/extensions/include/extensions/siloader.h
+++ b/extensions/include/extensions/siloader.h
@@ -37,6 +37,8 @@ private:
 	static std::vector<std::pair<StreamObject, StreamObject>> removeWith;
 	static std::vector<std::pair<StreamObject, StreamObject>> replace;
 	static std::vector<std::pair<StreamObject, StreamObject>> prepend;
+	static std::vector<StreamObject> fullScreenMovie;
+	static std::vector<StreamObject> disable3d;
 
 	static bool LoadFile(const char* p_file);
 	static bool LoadDirective(const char* p_directive);


### PR DESCRIPTION
This adds a few new directives that allow additional functionality:

`Prepend`: prepends a given asset to the referenced asset.
`FullScreenMovie`: enters full screen movie mode before launching the referenced asset.
`Disable3d`: disables 3D rendering before launching the referenced asset.

It also adds the `.ini` option `directives` to SiLoader, which allows specifying any directives outside a SI file. This is useful to modify behavior of existing assets without introducing new ones.

Using this it is now possible to i.e. add back the unused Outro animation when you exit the game:

```
directives=\
  FullScreenMovie:\lego\scripts\intro:3 \
  Disable3d:\lego\scripts\credits:499 \
  Prepend:\lego\scripts\intro:3:\lego\scripts\credits:499 \
  RemoveWith:\lego\scripts\credits:499:\lego\scripts\intro:3
```

https://github.com/user-attachments/assets/7b166a67-6b2c-4b72-bc69-15fa867d607f

