### PR TITLE
Remove obsolete `mediapath` stuff

### DIFF
--- a/ISLE/android/config.cpp
+++ b/ISLE/android/config.cpp
@@ -20,7 +20,6 @@ void Android_SetupDefaultConfigOverrides(dictionary* p_dictionary)
 
 	iniparser_set(p_dictionary, "isle:diskpath", data);
 	iniparser_set(p_dictionary, "isle:cdpath", data);
-	iniparser_set(p_dictionary, "isle:mediapath", data);
 	iniparser_set(p_dictionary, "isle:savepath", savedata.GetData());
 
 	// Default to Virtual Mouse

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -173,7 +173,6 @@ IsleApp::IsleApp()
 
 	LegoOmni::CreateInstance();
 
-	m_mediaPath = NULL;
 	m_iniPath = NULL;
 	m_maxLod = RealtimeView::GetUserMaxLOD();
 	m_maxAllowedExtras = m_islandQuality <= 1 ? 10 : 20;
@@ -204,7 +203,6 @@ IsleApp::~IsleApp()
 	SDL_free(m_cdPath);
 	SDL_free(m_deviceId);
 	SDL_free(m_savePath);
-	SDL_free(m_mediaPath);
 }
 
 // FUNCTION: ISLE 0x401260
@@ -244,12 +242,12 @@ MxS32 IsleApp::SetupLegoOmni()
 #ifdef COMPAT_MODE
 	MxS32 failure;
 	{
-		MxOmniCreateParam param(m_mediaPath, m_windowHandle, m_videoParam, MxOmniCreateFlags());
+		MxOmniCreateParam param(m_windowHandle, m_videoParam, MxOmniCreateFlags());
 		failure = Lego()->Create(param) == FAILURE;
 	}
 #else
 	MxS32 failure =
-		Lego()->Create(MxOmniCreateParam(m_mediaPath, m_windowHandle, m_videoParam, MxOmniCreateFlags())) == FAILURE;
+		Lego()->Create(MxOmniCreateParam(m_windowHandle, m_videoParam, MxOmniCreateFlags())) == FAILURE;
 #endif
 
 	if (!failure) {
@@ -1074,7 +1072,6 @@ bool IsleApp::LoadConfig()
 
 		iniparser_set(dict, "isle:diskpath", SDL_GetBasePath());
 		iniparser_set(dict, "isle:cdpath", MxOmni::GetCD());
-		iniparser_set(dict, "isle:mediapath", SDL_GetBasePath());
 		iniparser_set(dict, "isle:savepath", prefPath);
 
 		iniparser_set(dict, "isle:Flip Surfaces", m_flipSurfaces ? "true" : "false");
@@ -1137,7 +1134,6 @@ bool IsleApp::LoadConfig()
 	MxOmni::SetHD((m_hdPath = SDL_strdup(iniparser_getstring(dict, "isle:diskpath", SDL_GetBasePath()))));
 	MxOmni::SetCD((m_cdPath = SDL_strdup(iniparser_getstring(dict, "isle:cdpath", MxOmni::GetCD()))));
 	m_savePath = SDL_strdup(iniparser_getstring(dict, "isle:savepath", prefPath));
-	m_mediaPath = SDL_strdup(iniparser_getstring(dict, "isle:mediapath", m_hdPath));
 	m_flipSurfaces = iniparser_getboolean(dict, "isle:Flip Surfaces", m_flipSurfaces);
 	m_fullScreen = iniparser_getboolean(dict, "isle:Full Screen", m_fullScreen);
 	m_exclusiveFullScreen = iniparser_getboolean(dict, "isle:Exclusive Full Screen", m_exclusiveFullScreen);

--- a/ISLE/isleapp.h
+++ b/ISLE/isleapp.h
@@ -97,7 +97,6 @@ private:
 	const CursorBitmap* m_cursorBusyBitmap;
 	const CursorBitmap* m_cursorNoBitmap;
 	const CursorBitmap* m_cursorCurrentBitmap;
-	char* m_mediaPath;
 	MxFloat m_cursorSensitivity;
 	void DisplayArgumentHelp(const char* p_execName);
 

--- a/LEGO1/omni/include/mxmain.h
+++ b/LEGO1/omni/include/mxmain.h
@@ -114,7 +114,6 @@ protected:
 
 	static vector<MxString> GlobIsleFiles(const MxString& p_path);
 
-	MxString m_mediaPath;                         // 0x08
 	HWND m_windowHandle;                          // 0x18
 	MxObjectFactory* m_objectFactory;             // 0x1c
 	MxVariableTable* m_variableTable;             // 0x20

--- a/LEGO1/omni/include/mxomnicreateparam.h
+++ b/LEGO1/omni/include/mxomnicreateparam.h
@@ -14,7 +14,6 @@
 class MxOmniCreateParam : public MxParam {
 public:
 	LEGO1_EXPORT MxOmniCreateParam(
-		const char* p_mediaPath,
 		HWND p_windowHandle,
 		MxVideoParam& p_vparam,
 		MxOmniCreateFlags p_flags
@@ -22,8 +21,6 @@ public:
 
 	// FUNCTION: BETA10 0x10092cb0
 	MxOmniCreateFlags& CreateFlags() { return this->m_createFlags; }
-
-	const MxString& GetMediaPath() const { return m_mediaPath; }
 
 	// FUNCTION: BETA10 0x10092c50
 	const HWND GetWindowHandle() const { return m_windowHandle; }
@@ -38,7 +35,6 @@ public:
 	// MxOmniCreateParam::`scalar deleting destructor'
 
 private:
-	MxString m_mediaPath;            // 0x04
 	HWND m_windowHandle;             // 0x14
 	MxVideoParam m_videoParam;       // 0x18
 	MxOmniCreateFlags m_createFlags; // 0x3c

--- a/LEGO1/omni/src/main/mxmain.cpp
+++ b/LEGO1/omni/src/main/mxmain.cpp
@@ -95,7 +95,6 @@ MxResult MxOmni::Create(MxOmniCreateParam& p_param)
 		goto done;
 	}
 
-	m_mediaPath = p_param.GetMediaPath();
 	m_windowHandle = p_param.GetWindowHandle();
 
 	if (p_param.CreateFlags().CreateObjectFactory()) {

--- a/LEGO1/omni/src/main/mxomnicreateparam.cpp
+++ b/LEGO1/omni/src/main/mxomnicreateparam.cpp
@@ -7,13 +7,11 @@ DECOMP_SIZE_ASSERT(MxOmniCreateParam, 0x40)
 // FUNCTION: LEGO1 0x100b0b00
 // FUNCTION: BETA10 0x10130b6b
 MxOmniCreateParam::MxOmniCreateParam(
-	const char* p_mediaPath,
 	HWND p_windowHandle,
 	MxVideoParam& p_vparam,
 	MxOmniCreateFlags p_flags
 )
 {
-	this->m_mediaPath = p_mediaPath;
 	this->m_windowHandle = p_windowHandle;
 	this->m_videoParam = p_vparam;
 	this->m_createFlags = p_flags;


### PR DESCRIPTION
Removes all obsolete references to `mediapath`. 

Closes #662 