### PR TITLE
Fix android build

### DIFF
--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -79,7 +79,7 @@ tasks.register('compileSDL3AndroidArchive', Exec) {
     commandLine 'python', "${sdl3Dir}/build-scripts/build-release.py",
             '--actions', 'android',
             '--fast', '--force',
-            "--root=${sdl3Dir}"
+            "--root=${sdl3Dir}", "--android-api=${android.defaultConfig.minSdk}"
 
     doLast {
         def aarFile = file("${androidProject}/${sdl3Dir}/build-android").listFiles().find {


### PR DESCRIPTION
Fixes #700 
Older android versions don't have iconv support (it was added for Android 9 versions and up), SDL3 has a fallback that can be enabled by passing the minimum SDK version (in this case, 21) declared on `app/build.gradle` to `build-release.py` as an argument.