### PR TITLE
Fix build with disabled precompiled headers

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -92,4 +92,5 @@ add_library(libweaver STATIC
     ${libweaver_SOURCE_DIR}/lib/object.cpp
     ${libweaver_SOURCE_DIR}/lib/sitypes.cpp
 )
+add_library(libweaver::libweaver ALIAS libweaver)
 target_include_directories(libweaver PUBLIC ${libweaver_SOURCE_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,7 +497,7 @@ if (NOT ISLE_MINIWIN)
 endif()
 
 if (ISLE_EXTENSIONS)
-  target_link_libraries(lego1 PRIVATE libweaver)
+  target_link_libraries(lego1 PRIVATE libweaver::libweaver)
   target_compile_definitions(lego1 PUBLIC EXTENSIONS)
   target_sources(lego1 PRIVATE
     extensions/src/extensions.cpp

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -7,6 +7,7 @@
 #include "legovideomanager.h"
 #include "legoworld.h"
 #include "misc.h"
+#include "misc/legoutil.h"
 #include "mxautolock.h"
 #include "mxdebug.h"
 #include "roi/legoroi.h"

--- a/LEGO1/lego/legoomni/src/main/legomain.cpp
+++ b/LEGO1/lego/legoomni/src/main/legomain.cpp
@@ -9,6 +9,7 @@
 #include "legogamestate.h"
 #include "legoinputmanager.h"
 #include "legoobjectfactory.h"
+#include "legopartpresenter.h"
 #include "legoplantmanager.h"
 #include "legosoundmanager.h"
 #include "legoutils.h"

--- a/LEGO1/mxdirectx/mxdirect3d.cpp
+++ b/LEGO1/mxdirectx/mxdirect3d.cpp
@@ -3,6 +3,7 @@
 #endif
 
 #include "mxdirect3d.h"
+#include "mxvideoparam.h"
 
 #include <SDL3/SDL.h> // for SDL_Log
 #include <assert.h>

--- a/extensions/src/siloader.cpp
+++ b/extensions/src/siloader.cpp
@@ -1,5 +1,7 @@
 #include "extensions/siloader.h"
 
+#include "legovideomanager.h"
+#include "misc.h"
 #include "mxdsaction.h"
 #include "mxmisc.h"
 #include "mxstreamer.h"

--- a/extensions/src/textureloader.cpp
+++ b/extensions/src/textureloader.cpp
@@ -1,4 +1,9 @@
 #include "extensions/textureloader.h"
+#include "legovideomanager.h"
+#include "misc.h"
+#include "mxdirectx/mxdirect3d.h"
+#include "mxmain.h"
+#include "tgl/d3drm/impl.h"
 
 using namespace Extensions;
 


### PR DESCRIPTION
The small libweaver change is in preparation for https://github.com/isledecomp/SIEdit/pull/38

(but depends on https://github.com/isledecomp/SIEdit/pull/37 to get it fully working)