### PR TITLE
Fix build errors on macOS 26.

### DIFF
--- a/miniwin/src/d3drm/backends/opengles2/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengles2/renderer.cpp
@@ -3,7 +3,7 @@
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
-#if defined(TARGET_OS_IOS)
+#if TARGET_OS_IOS
 #include <OpenGLES/ES2/gl.h>
 #include <OpenGLES/ES2/glext.h>
 #else

--- a/miniwin/src/d3drm/backends/opengles3/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengles3/renderer.cpp
@@ -3,7 +3,7 @@
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
-#if defined(TARGET_OS_IOS)
+#if TARGET_OS_IOS
 #include <OpenGLES/ES2/glext.h>
 #include <OpenGLES/ES3/gl.h>
 #else

--- a/miniwin/src/internal/d3drmrenderer_opengles2.h
+++ b/miniwin/src/internal/d3drmrenderer_opengles2.h
@@ -6,7 +6,7 @@
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
-#if defined(TARGET_OS_IOS)
+#if TARGET_OS_IOS
 #include <OpenGLES/ES2/gl.h>
 #else
 #include <OpenGL/gl.h>

--- a/miniwin/src/internal/d3drmrenderer_opengles3.h
+++ b/miniwin/src/internal/d3drmrenderer_opengles3.h
@@ -6,7 +6,7 @@
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
-#if defined(TARGET_OS_IOS)
+#if TARGET_OS_IOS
 #include <OpenGLES/ES3/gl.h>
 #else
 #include <OpenGL/gl.h>


### PR DESCRIPTION
This pull request affects the OpenGL ES 2.x and 3.x rendering code.

- Adds some `#if` statements for macOS.
- Adds macOS-specific macros that point to macOS-equivalent OpenGL functions.
- Adds macOS-specific macros that point to two OpenGL macros, since OpenGL ES is not supported.