### PR TITLE
fix WASD input conflict with debug mode

### DIFF
--- a/LEGO1/lego/legoomni/include/legoinputmanager.h
+++ b/LEGO1/lego/legoomni/include/legoinputmanager.h
@@ -132,6 +132,7 @@ public:
 	void SetUnknown335(MxBool p_unk0x335) { m_unk0x335 = p_unk0x335; }
 	void SetUnknown336(MxBool p_unk0x336) { m_unk0x336 = p_unk0x336; }
 
+	MxBool GetWasd() { return m_wasd; }
 	void SetWasd(MxBool p_wasd) { m_wasd = p_wasd; }
 
 	// FUNCTION: BETA10 0x1002e390

--- a/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
+++ b/LEGO1/lego/legoomni/src/entity/legonavcontroller.cpp
@@ -655,7 +655,44 @@ MxLong LegoNavController::Notify(MxParam& p_param)
 {
 	if (((MxNotificationParam&) p_param).GetNotification() == c_notificationKeyPress) {
 		m_unk0x5d = TRUE;
-		SDL_Keycode key = ((LegoEventNotificationParam&) p_param).GetKey();
+		SDL_Keycode originKey = ((LegoEventNotificationParam&) p_param).GetKey();
+		SDL_Keycode key = originKey;
+
+		// This is necessary so any players using the WASD movement option can
+		// also use Debug Mode, which normally makes use of the WASD keys.
+		//
+		// For those players, we just swap the two and remap
+		// those conflicting debug keys to the arrow keys.
+		if (LegoOmni::GetInstance()->GetInputManager()->GetWasd()) {
+			switch (originKey) {
+			case SDLK_W:
+				key = SDLK_UP;
+				break;
+			case SDLK_A:
+				key = SDLK_LEFT;
+				break;
+			case SDLK_S:
+				key = SDLK_DOWN;
+				break;
+			case SDLK_D:
+				key = SDLK_RIGHT;
+				break;
+			case SDLK_UP:
+				key = SDLK_W;
+				break;
+			case SDLK_LEFT:
+				key = SDLK_A;
+				break;
+			case SDLK_DOWN:
+				key = SDLK_S;
+				break;
+			case SDLK_RIGHT:
+				key = SDLK_D;
+				break;
+			default:
+				break;
+			}
+		}
 
 		switch (key) {
 		case SDLK_PAUSE: // Pause game
@@ -763,7 +800,7 @@ MxLong LegoNavController::Notify(MxParam& p_param)
 			// Check if the the key is part of the debug password
 			if (!*g_currentInput) {
 				// password "protected" debug shortcuts
-				switch (((LegoEventNotificationParam&) p_param).GetKey()) {
+				switch (key) {
 				case SDLK_TAB:
 					VideoManager()->ToggleFPS(g_fpsEnabled);
 					if (g_fpsEnabled) {


### PR DESCRIPTION
This PR addresses a slight oversight with #740, which was that it becomes impossible to use the WASD input option and Debug Mode at the same time properly, as the game uses the WASD keys for Debug functions. In this PR, I've implemented it so the conflicting keys are simply swapped at runtime in the function that handles Debug Mode, [like was done in Rebuilder](https://github.com/isledecomp/LEGOIslandRebuilder/blob/6e1c7cd263330eb466aed970f469a704ef3aad4d/lib/dllmain.cpp#L72).