### PR TITLE
Remove touch clamping to support clicks on touch devices on widescreen

### DIFF
--- a/ISLE/emscripten/window.cpp
+++ b/ISLE/emscripten/window.cpp
@@ -70,7 +70,9 @@ void Emscripten_ConvertEventToRenderCoordinates(SDL_Event* event)
 		const float widthRatio = (g_targetWidth * scale) / g_fullWidth;
 		const float heightRatio = (g_targetHeight * scale) / g_fullHeight;
 		event->motion.x = (event->motion.x - (g_targetWidth * (1.0f - widthRatio) / 2.0f)) / widthRatio;
+		event->motion.x = SDL_clamp(event->motion.x, 0, g_targetWidth);
 		event->motion.y = (event->motion.y - (g_targetHeight * (1.0f - heightRatio) / 2.0f)) / heightRatio;
+		event->motion.y = SDL_clamp(event->motion.y, 0, g_targetHeight);
 		break;
 	}
 	case SDL_EVENT_MOUSE_BUTTON_DOWN:
@@ -79,7 +81,9 @@ void Emscripten_ConvertEventToRenderCoordinates(SDL_Event* event)
 		const float widthRatio = (g_targetWidth * scale) / g_fullWidth;
 		const float heightRatio = (g_targetHeight * scale) / g_fullHeight;
 		event->button.x = (event->button.x - (g_targetWidth * (1.0f - widthRatio) / 2.0f)) / widthRatio;
+		event->button.x = SDL_clamp(event->button.x, 0, g_targetWidth);
 		event->button.y = (event->button.y - (g_targetHeight * (1.0f - heightRatio) / 2.0f)) / heightRatio;
+		event->button.y = SDL_clamp(event->button.y, 0, g_targetHeight);
 		break;
 	}
 	case SDL_EVENT_FINGER_MOTION:
@@ -91,8 +95,10 @@ void Emscripten_ConvertEventToRenderCoordinates(SDL_Event* event)
 		const float heightRatio = (g_targetHeight * scale) / g_fullHeight;
 		event->tfinger.x = (event->tfinger.x * g_targetWidth - (g_targetWidth * (1.0f - widthRatio) / 2.0f)) /
 						   widthRatio / g_targetWidth;
+		event->tfinger.x = SDL_clamp(event->tfinger.x, 0, 1);
 		event->tfinger.y = (event->tfinger.y * g_targetHeight - (g_targetHeight * (1.0f - heightRatio) / 2.0f)) /
 						   heightRatio / g_targetHeight;
+		event->tfinger.y = SDL_clamp(event->tfinger.y, 0, 1);
 		break;
 	}
 	}

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -718,8 +718,8 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 	case SDL_EVENT_FINGER_MOTION: {
 		g_mousemoved = TRUE;
 
-		float x = SDL_clamp(event->tfinger.x, 0, 1) * g_targetWidth;
-		float y = SDL_clamp(event->tfinger.y, 0, 1) * g_targetHeight;
+		float x = event->tfinger.x * g_targetWidth;
+		float y = event->tfinger.y * g_targetHeight;
 
 		if (InputManager()) {
 			MxU8 modifier = LegoEventNotificationParam::c_lButtonState;
@@ -756,8 +756,8 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 	case SDL_EVENT_FINGER_DOWN: {
 		g_mousedown = TRUE;
 
-		float x = SDL_clamp(event->tfinger.x, 0, 1) * g_targetWidth;
-		float y = SDL_clamp(event->tfinger.y, 0, 1) * g_targetHeight;
+		float x = event->tfinger.x * g_targetWidth;
+		float y = event->tfinger.y * g_targetHeight;
 
 		if (InputManager()) {
 			InputManager()->HandleTouchEvent(event, g_isle->GetTouchScheme());
@@ -791,8 +791,8 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 	case SDL_EVENT_FINGER_CANCELED: {
 		g_mousedown = FALSE;
 
-		float x = SDL_clamp(event->tfinger.x, 0, 1) * g_targetWidth;
-		float y = SDL_clamp(event->tfinger.y, 0, 1) * g_targetHeight;
+		float x = event->tfinger.x * g_targetWidth;
+		float y = event->tfinger.y * g_targetHeight;
 
 		g_isle->DetectDoubleTap(event->tfinger);
 


### PR DESCRIPTION
Until now it wasn't possible to click objects using touch input outside the target width/height.