### PR TITLE
Fix Act3: ammo not sticking / finishing animation

### DIFF
--- a/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3ammo.cpp
@@ -307,7 +307,7 @@ void Act3Ammo::Animate(float p_time)
 	MxU32 local14 = FALSE;
 	MxU32 localb8 = FALSE;
 
-	if (f >= p_time) {
+	if (f > p_time) {
 		m_actorTime = (p_time - m_lastTime) * m_worldSpeed + m_actorTime;
 		m_unk0x7c = (p_time - m_lastTime) * m_worldSpeed + m_unk0x7c;
 		m_lastTime = p_time;


### PR DESCRIPTION
This has always been a latent bug even in retail, but it was much less prevalent in the decomp/retail presumably due to floating point / timing differences (which caused this condition to be relatively rare, < 10% of ammot shots).  In portable, this bug is very common.

`f == p_time` indicates that the animation has finished, and so the other branch should be taken.

Wrong (ammo getting "stuck" in the ground, not landing):

<img width="383" height="203" alt="image" src="https://github.com/user-attachments/assets/a08e20ca-553f-4f65-9951-3bd42412c417" />

Right (this should always happen):

<img width="203" height="148" alt="image" src="https://github.com/user-attachments/assets/d869a1d4-de9a-4c94-b3dd-0340dc01e125" />
