### PR TITLE
MxSoundManager: use buffer size and don't rely on buffer capacity

### DIFF
--- a/LEGO1/omni/src/audio/mxsoundmanager.cpp
+++ b/LEGO1/omni/src/audio/mxsoundmanager.cpp
@@ -149,7 +149,6 @@ void MxSoundManager::AudioStreamCallback(
 {
 	static vector<MxU8> g_buffer;
 	if (p_additionalAmount > g_buffer.size()) {
-		// We resize and don't reserve memory to avoid an AddressSanitizerContainerOverflow asan error
 		g_buffer.resize(p_additionalAmount);
 	}
 


### PR DESCRIPTION
This fixes a detect_container_overflow address sanitizer error.