### PR TITLE
MxVariable::Destroy() calls `delete this`, and is also used by subclasses

### DIFF
--- a/LEGO1/omni/include/mxvariable.h
+++ b/LEGO1/omni/include/mxvariable.h
@@ -12,6 +12,8 @@ public:
 	// FUNCTION: BETA10 0x1007b750
 	MxVariable() {}
 
+	virtual ~MxVariable() {}
+
 	// FUNCTION: BETA10 0x1012a840
 	MxVariable(const char* p_key, const char* p_value)
 	{


### PR DESCRIPTION

Making the destructor virtual assures the destructor of the subclass is called.

This fixes a Fix new-delete-type-mismatch sanitizer error, emitted when exiting the game.