### PR TITLE
TextureLoader::PatchTexture: unlock surface on failure paths

### DIFF
--- a/extensions/src/textureloader.cpp
+++ b/extensions/src/textureloader.cpp
@@ -64,6 +64,7 @@ bool TextureLoader::PatchTexture(LegoTextureInfo* p_textureInfo)
 	if (details->bits_per_pixel == 8) {
 		SDL_Palette* sdlPalette = SDL_GetSurfacePalette(surface);
 		if (!sdlPalette) {
+			p_textureInfo->m_surface->Unlock(desc.lpSurface);
 			SDL_DestroySurface(surface);
 			return false;
 		}
@@ -78,6 +79,7 @@ bool TextureLoader::PatchTexture(LegoTextureInfo* p_textureInfo)
 
 		LPDIRECTDRAWPALETTE ddPalette = nullptr;
 		if (pDirectDraw->CreatePalette(DDPCAPS_8BIT | DDPCAPS_ALLOW256, entries, &ddPalette, NULL) != DD_OK) {
+			p_textureInfo->m_surface->Unlock(desc.lpSurface);
 			SDL_DestroySurface(surface);
 			return false;
 		}


### PR DESCRIPTION
While testing the mortar patch, I saw the following leak which might possibly be caused by not unlocking the surface on failure paths.
I'm not 100% sure this plugs the leak.

<details>

<summary>Address Sanitizer leaks</summary>

```
==121325==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 864 byte(s) in 18 object(s) allocated from:
    #0 0x7f042aee7a3b in operator new(unsigned long) (/lib64/libasan.so.8+0xe7a3b) (BuildId: 4386f3fdd17c14d95efd91d6e6589d3e48629889)
    #1 0x7f0424ee387c in DirectDrawImpl::CreateSurface(DDSURFACEDESC*, IDirectDrawSurface**, IUnknown*) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddraw.cpp:126
    #2 0x7f0424dcb96d in Extensions::TextureLoader::PatchTexture(LegoTextureInfo*) /home/maarten/projects/isle-portable/extensions/src/textureloader.cpp:48
    #3 0x7f04247ea7b5 in bool std::__invoke_impl<bool, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(std::__invoke_other, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:63
    #4 0x7f04247ea460 in std::__invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::__invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:98
    #5 0x7f04247ea059 in std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/functional:122
    #6 0x7f04247e9ca6 in std::optional<std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type> Extensions::Extension<Extensions::TextureLoader>::Call<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /home/maarten/projects/isle-portable/extensions/include/extensions/extensions.h:23
    #7 0x7f04247e322a in LegoTextureInfo::Create(char const*, LegoTexture*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp:62
    #8 0x7f0424b87641 in LegoModelPresenter::CreateROI(MxDSChunk*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp:137
    #9 0x7f0424b8ba4d in LegoModelPresenter::CreateROI(MxDSChunk&, LegoEntity*, unsigned char, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp:211
    #10 0x7f0424916a83 in LegoWorldPresenter::LoadWorldModel(ModelDbModel&, MORTAR_IOStream*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:400
    #11 0x7f0424912e44 in LegoWorldPresenter::LoadWorld(char*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:310
    #12 0x7f0424919010 in LegoWorldPresenter::ParseExtra() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:444
    #13 0x7f042490e894 in LegoWorldPresenter::ReadyTickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:140
    #14 0x7f04242ac53b in MxPresenter::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxpresenter.cpp:130
    #15 0x7f0424bd78ff in LegoVideoManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legovideomanager.cpp:336
    #16 0x7f04242b9d68 in MxTickleManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxticklemanager.cpp:56
    #17 0x00000041ee82 in IsleApp::Tick() /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:1299
    #18 0x000000406242 in MORTAR_AppIterate(void*) /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:403
    #19 0x7f0424035b83 in sdl3_AppIterate /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:50
    #20 0x7f0422c87bea in SDL_IterateMainCallbacks /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:130
    #21 0x7f0422f42e7d in GenericIterateMainCallbacks /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:51
    #22 0x7f0422f42f6b in SDL_EnterAppMainCallbacks_REAL /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:62
    #23 0x7f0422c396a6 in SDL_EnterAppMainCallbacks /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:207
    #24 0x7f0424035d45 in mortar_sdl3_main /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:70
    #25 0x7f0422c87cde in SDL_CallMainFunction /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:164
    #26 0x7f0422c87d0c in SDL_RunApp_REAL /home/maarten/projects/SDL/src/main/SDL_runapp.c:37
    #27 0x7f0422c3e71b in SDL_RunApp /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:804
    #28 0x7f0424035dc8 in MORTAR_SDL3_main(int, char**, MORTAR_AppResult (*)(void**, int, char**), MORTAR_AppResult (*)(void*), MORTAR_AppResult (*)(void*, MORTAR_Event*), void (*)(void*, MORTAR_AppResult)) /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:93
    #29 0x7f04240292fd in MORTAR_main /home/maarten/projects/isle-portable/mortar/src/mortar.cpp:95

Direct leak of 144 byte(s) in 3 object(s) allocated from:
    #0 0x7f042aee7a3b in operator new(unsigned long) (/lib64/libasan.so.8+0xe7a3b) (BuildId: 4386f3fdd17c14d95efd91d6e6589d3e48629889)
    #1 0x7f0424ee387c in DirectDrawImpl::CreateSurface(DDSURFACEDESC*, IDirectDrawSurface**, IUnknown*) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddraw.cpp:126
    #2 0x7f0424dcb96d in Extensions::TextureLoader::PatchTexture(LegoTextureInfo*) /home/maarten/projects/isle-portable/extensions/src/textureloader.cpp:48
    #3 0x7f04247ea7b5 in bool std::__invoke_impl<bool, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(std::__invoke_other, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:63
    #4 0x7f04247ea460 in std::__invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::__invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:98
    #5 0x7f04247ea059 in std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/functional:122
    #6 0x7f04247e9ca6 in std::optional<std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type> Extensions::Extension<Extensions::TextureLoader>::Call<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /home/maarten/projects/isle-portable/extensions/include/extensions/extensions.h:23
    #7 0x7f04247e322a in LegoTextureInfo::Create(char const*, LegoTexture*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp:62
    #8 0x7f0424bc1d62 in LegoTexturePresenter::Store() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legotexturepresenter.cpp:102
    #9 0x7f0424910b18 in LegoWorldPresenter::LoadWorld(char*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:227
    #10 0x7f0424919010 in LegoWorldPresenter::ParseExtra() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:444
    #11 0x7f042490e894 in LegoWorldPresenter::ReadyTickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:140
    #12 0x7f04242ac53b in MxPresenter::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxpresenter.cpp:130
    #13 0x7f0424bd78ff in LegoVideoManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legovideomanager.cpp:336
    #14 0x7f04242b9d68 in MxTickleManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxticklemanager.cpp:56
    #15 0x00000041ee82 in IsleApp::Tick() /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:1299
    #16 0x000000406242 in MORTAR_AppIterate(void*) /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:403
    #17 0x7f0424035b83 in sdl3_AppIterate /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:50
    #18 0x7f0422c87bea in SDL_IterateMainCallbacks /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:130
    #19 0x7f0422f42e7d in GenericIterateMainCallbacks /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:51
    #20 0x7f0422f42f6b in SDL_EnterAppMainCallbacks_REAL /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:62
    #21 0x7f0422c396a6 in SDL_EnterAppMainCallbacks /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:207
    #22 0x7f0424035d45 in mortar_sdl3_main /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:70
    #23 0x7f0422c87cde in SDL_CallMainFunction /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:164
    #24 0x7f0422c87d0c in SDL_RunApp_REAL /home/maarten/projects/SDL/src/main/SDL_runapp.c:37
    #25 0x7f0422c3e71b in SDL_RunApp /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:804
    #26 0x7f0424035dc8 in MORTAR_SDL3_main(int, char**, MORTAR_AppResult (*)(void**, int, char**), MORTAR_AppResult (*)(void*), MORTAR_AppResult (*)(void*, MORTAR_Event*), void (*)(void*, MORTAR_AppResult)) /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:93
    #27 0x7f04240292fd in MORTAR_main /home/maarten/projects/isle-portable/mortar/src/mortar.cpp:95
    #28 0x00000041959f in main /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:1609
    #29 0x7f0423212574 in __libc_start_call_main (/lib64/libc.so.6+0x3574) (BuildId: 8569a90e9859345324d8d0374c16836929c0761a)

Indirect leak of 9045264 byte(s) in 18 object(s) allocated from:
    #0 0x7f042aee6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 4386f3fdd17c14d95efd91d6e6589d3e48629889)
    #1 0x7f0422d0dbcc in real_malloc /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6334
    #2 0x7f0422d0de33 in SDL_malloc_REAL /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6459
    #3 0x7f0422d10a13 in SDL_aligned_alloc_REAL /home/maarten/projects/SDL/src/stdlib/SDL_stdlib.c:540
    #4 0x7f0422db5ef0 in SDL_CreateSurface_REAL /home/maarten/projects/SDL/src/video/SDL_surface.c:232
    #5 0x7f0422c38ed7 in SDL_CreateSurface /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:153
    #6 0x7f04240411ab in MORTAR_CreateSurface /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_surface.cpp:74
    #7 0x7f0424eecb4f in DirectDrawSurfaceImpl::DirectDrawSurfaceImpl(int, int, MORTAR_PixelFormat) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddsurface.cpp:12
    #8 0x7f0424ee38bd in DirectDrawImpl::CreateSurface(DDSURFACEDESC*, IDirectDrawSurface**, IUnknown*) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddraw.cpp:126
    #9 0x7f0424dcb96d in Extensions::TextureLoader::PatchTexture(LegoTextureInfo*) /home/maarten/projects/isle-portable/extensions/src/textureloader.cpp:48
    #10 0x7f04247ea7b5 in bool std::__invoke_impl<bool, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(std::__invoke_other, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:63
    #11 0x7f04247ea460 in std::__invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::__invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:98
    #12 0x7f04247ea059 in std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/functional:122
    #13 0x7f04247e9ca6 in std::optional<std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type> Extensions::Extension<Extensions::TextureLoader>::Call<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /home/maarten/projects/isle-portable/extensions/include/extensions/extensions.h:23
    #14 0x7f04247e322a in LegoTextureInfo::Create(char const*, LegoTexture*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp:62
    #15 0x7f0424b87641 in LegoModelPresenter::CreateROI(MxDSChunk*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp:137
    #16 0x7f0424b8ba4d in LegoModelPresenter::CreateROI(MxDSChunk&, LegoEntity*, unsigned char, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp:211
    #17 0x7f0424916a83 in LegoWorldPresenter::LoadWorldModel(ModelDbModel&, MORTAR_IOStream*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:400
    #18 0x7f0424912e44 in LegoWorldPresenter::LoadWorld(char*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:310
    #19 0x7f0424919010 in LegoWorldPresenter::ParseExtra() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:444
    #20 0x7f042490e894 in LegoWorldPresenter::ReadyTickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:140
    #21 0x7f04242ac53b in MxPresenter::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxpresenter.cpp:130
    #22 0x7f0424bd78ff in LegoVideoManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legovideomanager.cpp:336
    #23 0x7f04242b9d68 in MxTickleManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxticklemanager.cpp:56
    #24 0x00000041ee82 in IsleApp::Tick() /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:1299
    #25 0x000000406242 in MORTAR_AppIterate(void*) /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:403
    #26 0x7f0424035b83 in sdl3_AppIterate /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:50
    #27 0x7f0422c87bea in SDL_IterateMainCallbacks /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:130
    #28 0x7f0422f42e7d in GenericIterateMainCallbacks /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:51
    #29 0x7f0422f42f6b in SDL_EnterAppMainCallbacks_REAL /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:62

Indirect leak of 786648 byte(s) in 3 object(s) allocated from:
    #0 0x7f042aee6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 4386f3fdd17c14d95efd91d6e6589d3e48629889)
    #1 0x7f0422d0dbcc in real_malloc /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6334
    #2 0x7f0422d0de33 in SDL_malloc_REAL /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6459
    #3 0x7f0422d10a13 in SDL_aligned_alloc_REAL /home/maarten/projects/SDL/src/stdlib/SDL_stdlib.c:540
    #4 0x7f0422db5ef0 in SDL_CreateSurface_REAL /home/maarten/projects/SDL/src/video/SDL_surface.c:232
    #5 0x7f0422c38ed7 in SDL_CreateSurface /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:153
    #6 0x7f04240411ab in MORTAR_CreateSurface /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_surface.cpp:74
    #7 0x7f0424eecb4f in DirectDrawSurfaceImpl::DirectDrawSurfaceImpl(int, int, MORTAR_PixelFormat) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddsurface.cpp:12
    #8 0x7f0424ee38bd in DirectDrawImpl::CreateSurface(DDSURFACEDESC*, IDirectDrawSurface**, IUnknown*) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddraw.cpp:126
    #9 0x7f0424dcb96d in Extensions::TextureLoader::PatchTexture(LegoTextureInfo*) /home/maarten/projects/isle-portable/extensions/src/textureloader.cpp:48
    #10 0x7f04247ea7b5 in bool std::__invoke_impl<bool, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(std::__invoke_other, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:63
    #11 0x7f04247ea460 in std::__invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::__invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:98
    #12 0x7f04247ea059 in std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/functional:122
    #13 0x7f04247e9ca6 in std::optional<std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type> Extensions::Extension<Extensions::TextureLoader>::Call<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /home/maarten/projects/isle-portable/extensions/include/extensions/extensions.h:23
    #14 0x7f04247e322a in LegoTextureInfo::Create(char const*, LegoTexture*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp:62
    #15 0x7f0424bc1d62 in LegoTexturePresenter::Store() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legotexturepresenter.cpp:102
    #16 0x7f0424910b18 in LegoWorldPresenter::LoadWorld(char*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:227
    #17 0x7f0424919010 in LegoWorldPresenter::ParseExtra() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:444
    #18 0x7f042490e894 in LegoWorldPresenter::ReadyTickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:140
    #19 0x7f04242ac53b in MxPresenter::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxpresenter.cpp:130
    #20 0x7f0424bd78ff in LegoVideoManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legovideomanager.cpp:336
    #21 0x7f04242b9d68 in MxTickleManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxticklemanager.cpp:56
    #22 0x00000041ee82 in IsleApp::Tick() /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:1299
    #23 0x000000406242 in MORTAR_AppIterate(void*) /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:403
    #24 0x7f0424035b83 in sdl3_AppIterate /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:50
    #25 0x7f0422c87bea in SDL_IterateMainCallbacks /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:130
    #26 0x7f0422f42e7d in GenericIterateMainCallbacks /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:51
    #27 0x7f0422f42f6b in SDL_EnterAppMainCallbacks_REAL /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:62
    #28 0x7f0422c396a6 in SDL_EnterAppMainCallbacks /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:207
    #29 0x7f0424035d45 in mortar_sdl3_main /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:70

Indirect leak of 5328 byte(s) in 18 object(s) allocated from:
    #0 0x7f042aee6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 4386f3fdd17c14d95efd91d6e6589d3e48629889)
    #1 0x7f0422d0dbcc in real_malloc /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6334
    #2 0x7f0422d0de33 in SDL_malloc_REAL /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6459
    #3 0x7f0422db5e4a in SDL_CreateSurface_REAL /home/maarten/projects/SDL/src/video/SDL_surface.c:221
    #4 0x7f0422c38ed7 in SDL_CreateSurface /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:153
    #5 0x7f04240411ab in MORTAR_CreateSurface /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_surface.cpp:74
    #6 0x7f0424eecb4f in DirectDrawSurfaceImpl::DirectDrawSurfaceImpl(int, int, MORTAR_PixelFormat) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddsurface.cpp:12
    #7 0x7f0424ee38bd in DirectDrawImpl::CreateSurface(DDSURFACEDESC*, IDirectDrawSurface**, IUnknown*) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddraw.cpp:126
    #8 0x7f0424dcb96d in Extensions::TextureLoader::PatchTexture(LegoTextureInfo*) /home/maarten/projects/isle-portable/extensions/src/textureloader.cpp:48
    #9 0x7f04247ea7b5 in bool std::__invoke_impl<bool, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(std::__invoke_other, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:63
    #10 0x7f04247ea460 in std::__invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::__invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:98
    #11 0x7f04247ea059 in std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/functional:122
    #12 0x7f04247e9ca6 in std::optional<std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type> Extensions::Extension<Extensions::TextureLoader>::Call<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /home/maarten/projects/isle-portable/extensions/include/extensions/extensions.h:23
    #13 0x7f04247e322a in LegoTextureInfo::Create(char const*, LegoTexture*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp:62
    #14 0x7f0424b87641 in LegoModelPresenter::CreateROI(MxDSChunk*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp:137
    #15 0x7f0424b8ba4d in LegoModelPresenter::CreateROI(MxDSChunk&, LegoEntity*, unsigned char, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp:211
    #16 0x7f0424916a83 in LegoWorldPresenter::LoadWorldModel(ModelDbModel&, MORTAR_IOStream*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:400
    #17 0x7f0424912e44 in LegoWorldPresenter::LoadWorld(char*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:310
    #18 0x7f0424919010 in LegoWorldPresenter::ParseExtra() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:444
    #19 0x7f042490e894 in LegoWorldPresenter::ReadyTickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:140
    #20 0x7f04242ac53b in MxPresenter::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxpresenter.cpp:130
    #21 0x7f0424bd78ff in LegoVideoManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legovideomanager.cpp:336
    #22 0x7f04242b9d68 in MxTickleManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxticklemanager.cpp:56
    #23 0x00000041ee82 in IsleApp::Tick() /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:1299
    #24 0x000000406242 in MORTAR_AppIterate(void*) /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:403
    #25 0x7f0424035b83 in sdl3_AppIterate /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:50
    #26 0x7f0422c87bea in SDL_IterateMainCallbacks /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:130
    #27 0x7f0422f42e7d in GenericIterateMainCallbacks /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:51
    #28 0x7f0422f42f6b in SDL_EnterAppMainCallbacks_REAL /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:62
    #29 0x7f0422c396a6 in SDL_EnterAppMainCallbacks /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:207

Indirect leak of 888 byte(s) in 3 object(s) allocated from:
    #0 0x7f042aee6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: 4386f3fdd17c14d95efd91d6e6589d3e48629889)
    #1 0x7f0422d0dbcc in real_malloc /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6334
    #2 0x7f0422d0de33 in SDL_malloc_REAL /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6459
    #3 0x7f0422db5e4a in SDL_CreateSurface_REAL /home/maarten/projects/SDL/src/video/SDL_surface.c:221
    #4 0x7f0422c38ed7 in SDL_CreateSurface /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:153
    #5 0x7f04240411ab in MORTAR_CreateSurface /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_surface.cpp:74
    #6 0x7f0424eecb4f in DirectDrawSurfaceImpl::DirectDrawSurfaceImpl(int, int, MORTAR_PixelFormat) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddsurface.cpp:12
    #7 0x7f0424ee38bd in DirectDrawImpl::CreateSurface(DDSURFACEDESC*, IDirectDrawSurface**, IUnknown*) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddraw.cpp:126
    #8 0x7f0424dcb96d in Extensions::TextureLoader::PatchTexture(LegoTextureInfo*) /home/maarten/projects/isle-portable/extensions/src/textureloader.cpp:48
    #9 0x7f04247ea7b5 in bool std::__invoke_impl<bool, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(std::__invoke_other, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:63
    #10 0x7f04247ea460 in std::__invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::__invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:98
    #11 0x7f04247ea059 in std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/functional:122
    #12 0x7f04247e9ca6 in std::optional<std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type> Extensions::Extension<Extensions::TextureLoader>::Call<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /home/maarten/projects/isle-portable/extensions/include/extensions/extensions.h:23
    #13 0x7f04247e322a in LegoTextureInfo::Create(char const*, LegoTexture*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp:62
    #14 0x7f0424bc1d62 in LegoTexturePresenter::Store() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legotexturepresenter.cpp:102
    #15 0x7f0424910b18 in LegoWorldPresenter::LoadWorld(char*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:227
    #16 0x7f0424919010 in LegoWorldPresenter::ParseExtra() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:444
    #17 0x7f042490e894 in LegoWorldPresenter::ReadyTickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:140
    #18 0x7f04242ac53b in MxPresenter::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxpresenter.cpp:130
    #19 0x7f0424bd78ff in LegoVideoManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legovideomanager.cpp:336
    #20 0x7f04242b9d68 in MxTickleManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxticklemanager.cpp:56
    #21 0x00000041ee82 in IsleApp::Tick() /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:1299
    #22 0x000000406242 in MORTAR_AppIterate(void*) /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:403
    #23 0x7f0424035b83 in sdl3_AppIterate /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:50
    #24 0x7f0422c87bea in SDL_IterateMainCallbacks /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:130
    #25 0x7f0422f42e7d in GenericIterateMainCallbacks /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:51
    #26 0x7f0422f42f6b in SDL_EnterAppMainCallbacks_REAL /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:62
    #27 0x7f0422c396a6 in SDL_EnterAppMainCallbacks /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:207
    #28 0x7f0424035d45 in mortar_sdl3_main /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:70
    #29 0x7f0422c87cde in SDL_CallMainFunction /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:164

Indirect leak of 720 byte(s) in 18 object(s) allocated from:
    #0 0x7f042aee68a3 in calloc (/lib64/libasan.so.8+0xe68a3) (BuildId: 4386f3fdd17c14d95efd91d6e6589d3e48629889)
    #1 0x7f0422d0dbf1 in real_calloc /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6335
    #2 0x7f0422d0dea4 in SDL_calloc_REAL /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6478
    #3 0x7f0422c4100e in SDL_calloc /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:1055
    #4 0x7f0424040b8e in create_mortar_surface_from_sdl3 /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_surface.cpp:58
    #5 0x7f04240411b3 in MORTAR_CreateSurface /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_surface.cpp:74
    #6 0x7f0424eecb4f in DirectDrawSurfaceImpl::DirectDrawSurfaceImpl(int, int, MORTAR_PixelFormat) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddsurface.cpp:12
    #7 0x7f0424ee38bd in DirectDrawImpl::CreateSurface(DDSURFACEDESC*, IDirectDrawSurface**, IUnknown*) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddraw.cpp:126
    #8 0x7f0424dcb96d in Extensions::TextureLoader::PatchTexture(LegoTextureInfo*) /home/maarten/projects/isle-portable/extensions/src/textureloader.cpp:48
    #9 0x7f04247ea7b5 in bool std::__invoke_impl<bool, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(std::__invoke_other, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:63
    #10 0x7f04247ea460 in std::__invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::__invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:98
    #11 0x7f04247ea059 in std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/functional:122
    #12 0x7f04247e9ca6 in std::optional<std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type> Extensions::Extension<Extensions::TextureLoader>::Call<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /home/maarten/projects/isle-portable/extensions/include/extensions/extensions.h:23
    #13 0x7f04247e322a in LegoTextureInfo::Create(char const*, LegoTexture*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp:62
    #14 0x7f0424b87641 in LegoModelPresenter::CreateROI(MxDSChunk*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp:137
    #15 0x7f0424b8ba4d in LegoModelPresenter::CreateROI(MxDSChunk&, LegoEntity*, unsigned char, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legomodelpresenter.cpp:211
    #16 0x7f0424916a83 in LegoWorldPresenter::LoadWorldModel(ModelDbModel&, MORTAR_IOStream*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:400
    #17 0x7f0424912e44 in LegoWorldPresenter::LoadWorld(char*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:310
    #18 0x7f0424919010 in LegoWorldPresenter::ParseExtra() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:444
    #19 0x7f042490e894 in LegoWorldPresenter::ReadyTickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:140
    #20 0x7f04242ac53b in MxPresenter::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxpresenter.cpp:130
    #21 0x7f0424bd78ff in LegoVideoManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legovideomanager.cpp:336
    #22 0x7f04242b9d68 in MxTickleManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxticklemanager.cpp:56
    #23 0x00000041ee82 in IsleApp::Tick() /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:1299
    #24 0x000000406242 in MORTAR_AppIterate(void*) /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:403
    #25 0x7f0424035b83 in sdl3_AppIterate /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:50
    #26 0x7f0422c87bea in SDL_IterateMainCallbacks /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:130
    #27 0x7f0422f42e7d in GenericIterateMainCallbacks /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:51
    #28 0x7f0422f42f6b in SDL_EnterAppMainCallbacks_REAL /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:62
    #29 0x7f0422c396a6 in SDL_EnterAppMainCallbacks /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:207

Indirect leak of 120 byte(s) in 3 object(s) allocated from:
    #0 0x7f042aee68a3 in calloc (/lib64/libasan.so.8+0xe68a3) (BuildId: 4386f3fdd17c14d95efd91d6e6589d3e48629889)
    #1 0x7f0422d0dbf1 in real_calloc /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6335
    #2 0x7f0422d0dea4 in SDL_calloc_REAL /home/maarten/projects/SDL/src/stdlib/SDL_malloc.c:6478
    #3 0x7f0422c4100e in SDL_calloc /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:1055
    #4 0x7f0424040b8e in create_mortar_surface_from_sdl3 /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_surface.cpp:58
    #5 0x7f04240411b3 in MORTAR_CreateSurface /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_surface.cpp:74
    #6 0x7f0424eecb4f in DirectDrawSurfaceImpl::DirectDrawSurfaceImpl(int, int, MORTAR_PixelFormat) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddsurface.cpp:12
    #7 0x7f0424ee38bd in DirectDrawImpl::CreateSurface(DDSURFACEDESC*, IDirectDrawSurface**, IUnknown*) /home/maarten/projects/isle-portable/miniwin/src/ddraw/ddraw.cpp:126
    #8 0x7f0424dcb96d in Extensions::TextureLoader::PatchTexture(LegoTextureInfo*) /home/maarten/projects/isle-portable/extensions/src/textureloader.cpp:48
    #9 0x7f04247ea7b5 in bool std::__invoke_impl<bool, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(std::__invoke_other, bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:63
    #10 0x7f04247ea460 in std::__invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::__invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/bits/invoke.h:98
    #11 0x7f04247ea059 in std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type std::invoke<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /usr/include/c++/15/functional:122
    #12 0x7f04247e9ca6 in std::optional<std::invoke_result<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>::type> Extensions::Extension<Extensions::TextureLoader>::Call<bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&>(bool (* const&)(LegoTextureInfo*), LegoTextureInfo*&) /home/maarten/projects/isle-portable/extensions/include/extensions/extensions.h:23
    #13 0x7f04247e322a in LegoTextureInfo::Create(char const*, LegoTexture*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/common/legotextureinfo.cpp:62
    #14 0x7f0424bc1d62 in LegoTexturePresenter::Store() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legotexturepresenter.cpp:102
    #15 0x7f0424910b18 in LegoWorldPresenter::LoadWorld(char*, LegoWorld*) /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:227
    #16 0x7f0424919010 in LegoWorldPresenter::ParseExtra() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:444
    #17 0x7f042490e894 in LegoWorldPresenter::ReadyTickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/entity/legoworldpresenter.cpp:140
    #18 0x7f04242ac53b in MxPresenter::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxpresenter.cpp:130
    #19 0x7f0424bd78ff in LegoVideoManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/lego/legoomni/src/video/legovideomanager.cpp:336
    #20 0x7f04242b9d68 in MxTickleManager::Tickle() /home/maarten/projects/isle-portable/LEGO1/omni/src/common/mxticklemanager.cpp:56
    #21 0x00000041ee82 in IsleApp::Tick() /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:1299
    #22 0x000000406242 in MORTAR_AppIterate(void*) /home/maarten/projects/isle-portable/ISLE/isleapp.cpp:403
    #23 0x7f0424035b83 in sdl3_AppIterate /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:50
    #24 0x7f0422c87bea in SDL_IterateMainCallbacks /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:130
    #25 0x7f0422f42e7d in GenericIterateMainCallbacks /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:51
    #26 0x7f0422f42f6b in SDL_EnterAppMainCallbacks_REAL /home/maarten/projects/SDL/src/main/generic/SDL_sysmain_callbacks.c:62
    #27 0x7f0422c396a6 in SDL_EnterAppMainCallbacks /home/maarten/projects/SDL/src/dynapi/SDL_dynapi_procs.h:207
    #28 0x7f0424035d45 in mortar_sdl3_main /home/maarten/projects/isle-portable/mortar/src/sdl3/sdl3_main.cpp:70
    #29 0x7f0422c87cde in SDL_CallMainFunction /home/maarten/projects/SDL/src/main/SDL_main_callbacks.c:164
```

<details>