### PR TITLE
Fix Emscripten rendering after SDL3 window size change

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -948,6 +948,12 @@ MxResult IsleApp::SetupWindow()
 #endif
 
 	window = SDL_CreateWindowWithProperties(props);
+
+#ifdef __EMSCRIPTEN__
+	// Force correct window size since SDL3 may have picked up CSS dimensions
+	SDL_SetWindowSize(window, g_targetWidth, g_targetHeight);
+#endif
+
 	SDL_SetPointerProperty(SDL_GetWindowProperties(window), ISLE_PROP_WINDOW_CREATE_VIDEO_PARAM, &m_videoParam);
 
 	if (m_exclusiveFullScreen && m_fullScreen) {


### PR DESCRIPTION
SDL3 commit [1a27b5b838f](https://github.com/libsdl-org/SDL/commit/1a27b5b838f33ca437b9c2fbb97bc5b9096b158b)  added code that overwrites window dimensions with CSS values when external_size is detected. This broke rendering because the window was created with browser dimensions instead of the requested 640x480.

Force the correct window size immediately after creation to ensure the renderer initializes with the proper dimensions.

Emscripten build works fine now with SDL3 master.