### PR TITLE
Fix AppRun script for AppImage execution

### DIFF
--- a/packaging/linux/appimage/AppRun
+++ b/packaging/linux/appimage/AppRun
@@ -7,14 +7,14 @@ MAIN=$(grep -r "^Exec=.*" "$HERE"/*.desktop | head -n 1 | cut -d "=" -f 2 | cut 
 # MAIN_BIN=$(find "$HERE/usr/bin" -name "$MAIN" | head -n 1)
 MAIN_BIN="$HERE/usr/bin/isle-config"
 
-export PATH="${HERE}/usr/bin/":$PATH # Prefer bundled binaries
+export PATH="${HERE}/usr/bin/:$PATH" # Prefer bundled binaries
 
 export QT_QPA_PLATFORMTHEME=xdgdesktopportal # Use XDG filepicker for forward compatability
 [ -z "$QT_PLUGIN_PATH" ] && export QT_PLUGIN_PATH=/usr/lib/qt6/plugins:/usr/lib64/qt6/plugins # Use system Qt theme, will fallback to the default one if unavailable
 
 
-if [ ! -z $APPIMAGE ]; then
-  BINARY_NAME=$(basename "$ARGV0")
+if [ ! -z "$APPIMAGE" ]; then
+  BINARY_NAME="$(basename "$ARGV0")"
   if [ -e "$HERE/usr/bin/$BINARY_NAME" ]; then
     exec "$HERE/usr/bin/$BINARY_NAME" "$@"
   else


### PR DESCRIPTION
Right now when path to AppImage has spaces in it (for example if it gets installed in ~/Applications by a manager I'll be named "Isle Portable") I'll fail to execute with an error:
```
/tmp/.mount_Isle PCAHbep/AppRun: line 16: [: /home/damglador/Applications/Isle: binary operator expected
/tmp/.mount_Isle PCAHbep/AppRun: line 24: /tmp/.mount_Isle PCAHbep/usr/bin/isle-config: Input/output error
```

This patch should fix it.