### PR TITLE
Vita: include <limits> for paf header transitive use

### DIFF
--- a/CONFIG/vita/src/app.cpp
+++ b/CONFIG/vita/src/app.cpp
@@ -1,6 +1,9 @@
+// clang-format off
+#include <limits> // must precede paf headers (paf/std/ngp/vector uses std::numeric_limits without including <limits>)
+// clang-format on
+
 #include <app_settings.h>
 #include <iniparser.h>
-#include <limits>
 #include <paf.h>
 #include <psp2/appmgr.h>
 #include <psp2/io/fcntl.h>

--- a/CONFIG/vita/src/app.cpp
+++ b/CONFIG/vita/src/app.cpp
@@ -1,5 +1,6 @@
 #include <app_settings.h>
 #include <iniparser.h>
+#include <limits>
 #include <paf.h>
 #include <psp2/appmgr.h>
 #include <psp2/io/fcntl.h>

--- a/CONFIG/vita/src/paf_runtime.cpp
+++ b/CONFIG/vita/src/paf_runtime.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <paf.h>
 #include <psp2/kernel/clib.h>
 #include <psp2/kernel/modulemgr.h>


### PR DESCRIPTION
working around a bug in external dependency