### PR TITLE
Add alternate-take voice masters found by the final audit

### DIFF
--- a/assets/hdaudio/index.txt
+++ b/assets/hdaudio/index.txt
@@ -220,6 +220,7 @@ Act3/ACT3.SI	566	wav/offscreen/cl/sns63xcl.wav
 Act3/ACT3.SI	567	wav/offscreen/en/sns64xen.wav
 Act3/ACT3.SI	568	wav/offscreen/re/sns65xre.wav
 Act3/ACT3.SI	569	wav/offscreen/sl/sns66xsl.wav
+Act3/ACT3.SI	570	wav/offscreen/ml/sns67xml.wav
 Act3/ACT3.SI	571	wav/offscreen/bu/sns68xbu.wav
 Act3/ACT3.SI	572	wav/offscreen/sn/sns69xsn.wav
 Act3/ACT3.SI	573	wav/offscreen/ni/sns70xni.wav
@@ -235,12 +236,15 @@ Act3/ACT3.SI	582	wav/offscreen/js/sns77xjs.wav
 Act3/ACT3.SI	583	wav/offscreen/ni/tns069ni.wav
 Act3/ACT3.SI	584	wav/offscreen/br/tns070br.wav
 Act3/ACT3.SI	585	wav/offscreen/ni/tns071ni.wav
+Act3/ACT3.SI	586	wav/offscreen/br/tns072br.wav
 Act3/ACT3.SI	587	wav/offscreen/ni/tns073ni.wav
 Act3/ACT3.SI	588	wav/offscreen/ni/tns074ni.wav
+Act3/ACT3.SI	589	wav/offscreen/br/tns075br.wav
 Act3/ACT3.SI	590	wav/offscreen/la/tns076la.wav
 Act3/ACT3.SI	591	wav/offscreen/br/tns077br.wav
 Act3/ACT3.SI	593	wav/offscreen/la/tns079la.wav
 Act3/ACT3.SI	594	wav/offscreen/ni/tns081ni.wav
+Act3/ACT3.SI	595	wav/offscreen/br/tns082br.wav
 Act3/ACT3.SI	596	wav/offscreen/br/tns080br.wav
 Act3/ACT3.SI	597	wav/onscreen/br/tns007br_s1.wav
 Act3/ACT3.SI	599	wav/onscreen/br/snsx27br_s1.wav
@@ -256,16 +260,19 @@ Build/DUNECAR.SI	148	wav/onscreen/d3/igs002d3.wav
 Build/DUNECAR.SI	152	wav/onscreen/d3/igs003d3.wav
 Build/DUNECAR.SI	164	wav/onscreen/d3/igs004d3.wav
 Build/DUNECAR.SI	172	wav/onscreen/d3/igs005d3.wav
+Build/JETSKI.SI	153	wav/onscreen/d4/ijs001d4.wav
 Build/JETSKI.SI	155	wav/onscreen/d4/ijs002d4.wav
 Build/JETSKI.SI	184	wav/onscreen/d4/ijs003d4.wav
 Build/JETSKI.SI	189	wav/onscreen/d4/ijs004d4.wav
 Build/JETSKI.SI	198	wav/onscreen/d4/ijs005d4.wav
 Build/JETSKI.SI	214	wav/onscreen/d4/ijs006d4.wav
 Build/JETSKI.SI	234	wav/onscreen/d4/ijs007d4.wav
+Build/RACECAR.SI	149	wav/onscreen/d1/irt001d1.wav
 Build/RACECAR.SI	158	wav/onscreen/d1/irt002d1.wav
 Build/RACECAR.SI	164	wav/onscreen/d1/irt003d1.wav
 Build/RACECAR.SI	175	wav/onscreen/d1/irt004d1.wav
 Build/RACECAR.SI	193	wav/onscreen/d1/irt005d1.wav
+Garage/GARAGE.SI	21	wav/onscreen/nu/wgs002nu.wav
 Garage/GARAGE.SI	26	wav/onscreen/nu/wgs003nu.wav
 Garage/GARAGE.SI	32	wav/onscreen/nu/wgs004nu.wav
 Garage/GARAGE.SI	36	wav/onscreen/nu/wgs006nu.wav
@@ -324,8 +331,10 @@ Infocntr/INFODOOR.SI	503	wav/onscreen/in/iic007in.wav
 Infocntr/INFOMAIN.SI	132	wav/onscreen/in/iic005in.wav
 Infocntr/INFOMAIN.SI	134	wav/onscreen/in/iic004in_s1.wav
 Infocntr/INFOMAIN.SI	136	wav/onscreen/in/iic002in_s1.wav
+Infocntr/INFOMAIN.SI	162	wav/onscreen/in/iic017in_s2.wav
 Infocntr/INFOMAIN.SI	164	wav/onscreen/in/iic016in.wav
 Infocntr/INFOMAIN.SI	181	wav/onscreen/in/iic017in_s1.wav
+Infocntr/INFOMAIN.SI	185	wav/onscreen/in/iic018in.wav
 Infocntr/INFOMAIN.SI	206	wav/onscreen/in/iic019in.wav
 Infocntr/INFOMAIN.SI	214	wav/onscreen/in/iic020in.wav
 Infocntr/INFOMAIN.SI	223	wav/onscreen/in/iic021in.wav
@@ -353,6 +362,7 @@ Infocntr/INFOMAIN.SI	410	wav/onscreen/in/iic055in.wav
 Infocntr/INFOMAIN.SI	418	wav/onscreen/in/iic056in.wav
 Infocntr/INFOMAIN.SI	429	wav/onscreen/in/iic057in.wav
 Infocntr/INFOMAIN.SI	436	wav/onscreen/in/iic058in.wav
+Infocntr/INFOMAIN.SI	447	wav/onscreen/in/iicb28in_s1.wav
 Infocntr/INFOMAIN.SI	453	wav/onscreen/in/iicc28in.wav
 Infocntr/INFOMAIN.SI	461	wav/onscreen/in/tic089in.wav
 Infocntr/INFOMAIN.SI	467	wav/onscreen/in/tic092in.wav
@@ -385,6 +395,7 @@ Infocntr/REGBOOK.SI	143	wav/onscreen/in/iic014in.wav
 Infocntr/REGBOOK.SI	504	wav/onscreen/in/iic009in.wav
 Infocntr/REGBOOK.SI	505	wav/onscreen/in/iic007in.wav
 Infocntr/REGBOOK.SI	506	wav/onscreen/in/iic008in.wav
+Isle/ISLE.SI	347	wav/onscreen/bu/sba001bu.wav
 Isle/ISLE.SI	352	wav/onscreen/bu/sba002bu.wav
 Isle/ISLE.SI	357	wav/onscreen/bu/sba003bu.wav
 Isle/ISLE.SI	379	wav/onscreen/la/fns017la.wav
@@ -393,6 +404,7 @@ Isle/ISLE.SI	398	wav/onscreen/na/igs005na.wav
 Isle/ISLE.SI	430	wav/onscreen/na/igs001na.wav
 Isle/ISLE.SI	432	wav/onscreen/na/igs003na.wav
 Isle/ISLE.SI	453	wav/onscreen/nu/sns003nu.wav
+Isle/ISLE.SI	460	wav/onscreen/na/sgs001na_s1.wav
 Isle/ISLE.SI	466	wav/onscreen/nu/sns001nu.wav
 Isle/ISLE.SI	472	wav/onscreen/nu/sns002nu.wav
 Isle/ISLE.SI	479	wav/onscreen/na/sgs002na.wav
@@ -419,6 +431,7 @@ Isle/ISLE.SI	884	wav/offscreen/ra/sns013ra.wav
 Isle/ISLE.SI	885	wav/offscreen/js/snsa01js_s1.wav
 Isle/ISLE.SI	886	wav/offscreen/js/snsb01js_s1.wav
 Isle/ISLE.SI	887	wav/offscreen/js/snsc01js_s1.wav
+Isle/ISLE.SI	888	wav/offscreen/cl/ham033cl.wav
 Isle/ISLE.SI	889	wav/offscreen/ra/ham034ra.wav
 Isle/ISLE.SI	890	wav/offscreen/ra/ham035ra.wav
 Isle/ISLE.SI	891	wav/offscreen/ra/ham036ra.wav
@@ -428,6 +441,7 @@ Isle/ISLE.SI	894	wav/offscreen/cl/ham041cl.wav
 Isle/ISLE.SI	895	wav/offscreen/cl/ham042cl.wav
 Isle/ISLE.SI	896	wav/offscreen/cl/ham043cl.wav
 Isle/ISLE.SI	897	wav/offscreen/cl/ham044cl.wav
+Isle/ISLE.SI	898	wav/offscreen/cl/ham045cl.wav
 Isle/ISLE.SI	899	wav/offscreen/cl/ham046cl.wav
 Isle/ISLE.SI	900	wav/offscreen/cl/ham075cl.wav
 Isle/ISLE.SI	901	wav/offscreen/cl/ham076cl.wav
@@ -440,6 +454,7 @@ Isle/ISLE.SI	907	wav/offscreen/cl/ham115cl.wav
 Isle/ISLE.SI	908	wav/offscreen/ma/hpz037ma.wav
 Isle/ISLE.SI	909	wav/offscreen/pa/sns078pa.wav
 Isle/ISLE.SI	910	wav/offscreen/pa/sns079pa.wav
+Isle/ISLE.SI	911	wav/offscreen/nu/wgs032nu.wav
 Isle/ISLE.SI	912	wav/offscreen/na/wns033na.wav
 Isle/ISLE.SI	913	wav/offscreen/na/wns034na.wav
 Isle/ISLE.SI	914	wav/offscreen/na/wns035na.wav
@@ -641,6 +656,7 @@ Isle/ISLE.SI	2269	wav/onscreen/ni/sps003ni.wav
 Isle/ISLE.SI	2274	wav/onscreen/la/sns017la.wav
 Isle/ISLE.SI	2279	wav/onscreen/la/sps001la.wav
 Isle/ISLE.SI	2283	wav/onscreen/la/sps002la.wav
+Isle/ISLE.SI	2291	wav/onscreen/ml/sns001ml.wav
 Isle/ISLE.SI	2297	wav/onscreen/mg/sns002mg.wav
 Isle/ISLE.SI	2300	wav/onscreen/p1/wns050p1_s1.wav
 Isle/ISLE.SI	2301	wav/onscreen/p1/wns050p1_s1.wav
@@ -665,6 +681,7 @@ Isle/ISLE.SI	2379	wav/onscreen/rd/ppz029rd.wav
 Isle/ISLE.SI	2384	wav/onscreen/sy/sns007sy.wav
 Isle/ISLE.SI	2390	wav/onscreen/sn/ijs006sn.wav
 Isle/ISLE.SI	2403	wav/onscreen/na/igs008na.wav
+Isle/ISLE.SI	2408	wav/onscreen/in/irt007in_s1.wav
 Isle/ISLE.SI	2417	wav/onscreen/ro/ips002ro.wav
 Isle/ISLE.SI	2424	wav/onscreen/cl/hho142cl.wav
 Isle/ISLE.SI	2445	wav/onscreen/cl/hho143cl.wav
@@ -874,6 +891,10 @@ Isle/ISLE.SI	3479	wav/onscreen/jk/wrt081jk.wav
 Isle/ISLE.SI	3481	wav/onscreen/bm/wrt080bm.wav
 Isle/ISLE.SI	3490	wav/onscreen/jk/wrt081jk.wav
 Isle/ISLE.SI	3492	wav/onscreen/bm/wrt080bm.wav
+Isle/ISLE.SI	3583	wav/onscreen/in/sjs007in.wav
+Isle/ISLE.SI	3588	wav/onscreen/in/sns005in.wav
+Isle/ISLE.SI	3593	wav/onscreen/in/sns006in.wav
+Isle/ISLE.SI	3600	wav/onscreen/in/sns008in.wav
 Isle/ISLE.SI	3607	wav/onscreen/in/sjs012in.wav
 Isle/ISLE.SI	3615	wav/onscreen/in/sjs013in.wav
 Isle/ISLE.SI	3622	wav/onscreen/in/sjs014in.wav

--- a/assets/hdaudio/wav/offscreen/br/tns072br.wav
+++ b/assets/hdaudio/wav/offscreen/br/tns072br.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05003de51b8792d7592073b7a3f7becb65d98b4d3f3d9ddf5ecd91c0d1cc49d6
+size 23084

--- a/assets/hdaudio/wav/offscreen/br/tns075br.wav
+++ b/assets/hdaudio/wav/offscreen/br/tns075br.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:544be6709fac013e7019b18e3cba59ca33edbe80dc8621152fea8d517a16da32
+size 18860

--- a/assets/hdaudio/wav/offscreen/br/tns082br.wav
+++ b/assets/hdaudio/wav/offscreen/br/tns082br.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1ea44dea0837358b48a7e84d750aea4fd713c292d0985149e82fd7d900286e7
+size 88396

--- a/assets/hdaudio/wav/offscreen/cl/ham033cl.wav
+++ b/assets/hdaudio/wav/offscreen/cl/ham033cl.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:517792b0a07982a253b8e7b86af5248ad25286cc6e44350dc334cea1ac02fd28
+size 171564

--- a/assets/hdaudio/wav/offscreen/cl/ham045cl.wav
+++ b/assets/hdaudio/wav/offscreen/cl/ham045cl.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ef16ef154063782567d4b28125bf2f613c85bd8a23de8075a56f5c0641e36fd
+size 102064

--- a/assets/hdaudio/wav/offscreen/ml/sns67xml.wav
+++ b/assets/hdaudio/wav/offscreen/ml/sns67xml.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea3a976edf03f175de4c46d7e8e62df5bbf3788d591712334b644ec81dd3cbef
+size 377516

--- a/assets/hdaudio/wav/offscreen/nu/wgs032nu.wav
+++ b/assets/hdaudio/wav/offscreen/nu/wgs032nu.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22bd14387db3413f4fae6d08e18fc1085454d1e319eff135685dd652eacf9203
+size 352796

--- a/assets/hdaudio/wav/onscreen/bu/sba001bu.wav
+++ b/assets/hdaudio/wav/onscreen/bu/sba001bu.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a756afadddc916add1c04743d72595cf1c017f3cb26c16e156cc7627aa5df86
+size 336813

--- a/assets/hdaudio/wav/onscreen/d1/irt001d1.wav
+++ b/assets/hdaudio/wav/onscreen/d1/irt001d1.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38969d0728c4b004bfec53e332a8b3139fcc40547a4dfc186bb8e5d4c2dae327
+size 1102444

--- a/assets/hdaudio/wav/onscreen/d4/ijs001d4.wav
+++ b/assets/hdaudio/wav/onscreen/d4/ijs001d4.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c33198e1844b4a9043c4f1683f70a7a5c5305c9c553c3b1013fb9466f4662e4
+size 367092

--- a/assets/hdaudio/wav/onscreen/in/iic017in_s2.wav
+++ b/assets/hdaudio/wav/onscreen/in/iic017in_s2.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3b2ae125de662217b5bfc15ea07eb69bfbb2d7f4e2dd09ef0789a5bb539883c
+size 555436

--- a/assets/hdaudio/wav/onscreen/in/iic018in.wav
+++ b/assets/hdaudio/wav/onscreen/in/iic018in.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30cdee7da3d8d133fc21c43831f6670f9a0d7b562f2562eaf9a5e83ea6c25f18
+size 342124

--- a/assets/hdaudio/wav/onscreen/in/iicb28in_s1.wav
+++ b/assets/hdaudio/wav/onscreen/in/iicb28in_s1.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f76b9bacc02f2267947776904f145e92abb52b06fb73a5f78d00d4a44e9a32a5
+size 30755

--- a/assets/hdaudio/wav/onscreen/in/irt007in_s1.wav
+++ b/assets/hdaudio/wav/onscreen/in/irt007in_s1.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fa6314ec86cfe7b096c0920cca96ded0143161566a65e6d74a891abeda2c54d
+size 312420

--- a/assets/hdaudio/wav/onscreen/in/sjs007in.wav
+++ b/assets/hdaudio/wav/onscreen/in/sjs007in.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd44fc1d4de0a39e67532a013de1b01d7b345265a2ca2d82d36fe292ede3904f
+size 251916

--- a/assets/hdaudio/wav/onscreen/in/sns005in.wav
+++ b/assets/hdaudio/wav/onscreen/in/sns005in.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94caa4c9404686b919439da3d6fc97ff924b7279a9ce7954fda06c5f3d8a5ce4
+size 168172

--- a/assets/hdaudio/wav/onscreen/in/sns006in.wav
+++ b/assets/hdaudio/wav/onscreen/in/sns006in.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a3fe7eb186a6112ce33daf7e7d57935149ebc76cc51990cb14c804f16bef85b
+size 184236

--- a/assets/hdaudio/wav/onscreen/in/sns008in.wav
+++ b/assets/hdaudio/wav/onscreen/in/sns008in.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca7152a87010995d38a899b70e7ffde1631c06418b60e796d36ec824275f9b3e
+size 175596

--- a/assets/hdaudio/wav/onscreen/ml/sns001ml.wav
+++ b/assets/hdaudio/wav/onscreen/ml/sns001ml.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8e255ed983efdebe073d02a0083565888c9d441f8f6c0c0009ac8745ce5b8c3
+size 473988

--- a/assets/hdaudio/wav/onscreen/na/sgs001na_s1.wav
+++ b/assets/hdaudio/wav/onscreen/na/sgs001na_s1.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab8c80dbc0dde6afc73a31fba95dfc7428a2375ced66a9a21becbe06c578da87
+size 99000

--- a/assets/hdaudio/wav/onscreen/nu/wgs002nu.wav
+++ b/assets/hdaudio/wav/onscreen/nu/wgs002nu.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08e3fe4a8f0349ea5d849b1a1d7868afba3ce3cc76097c4f7425438e0269d72f
+size 349084


### PR DESCRIPTION
Follow-up to #816: a completeness audit that checks every unreplaced object whose embedded source filename exists in the dump at higher quality — independent of acoustic correlation, which is what let these slip past the original pipeline (different takes correlate poorly by waveform).

**21 alternate-take voice lines**: Act3 Brickster taunts, the build instructor introductions, and several Infomaniac/character lines where the 22kHz master is a different read of the same line. Masters that outrun the shipped scope are cut to it (e.g. the 54s IIC017IN master cut to the shipped 25.2s window) so paired animations stay in sync; standalone lines keep the master's full length.

**Evaluated and rejected — Papa's bio narration**: the only one of the five Infocenter bios that shipped below master quality (11kHz/8-bit; the other four ship the 22kHz masters byte-for-byte). The dump's `Papafin.wav` is 22kHz and exactly movie-length, but phrase-level analysis shows it is a different performance whose timing drifts up to 3.7s from the take the Papa_Smk animation was authored against — unfixable without voice/music separation, since both takes sit on a continuous music bed. Sync wins; the retail track stays.

Pack grows to 981 replacements; full parity, duration and boundary verification pass. Remaining unreplaced audio is confirmed to be per-cutscene Foley mixdowns with no dump master, same-quality matches with no gain, and the Build/Race UI sounds whose 22kHz dump versions are old-generation designs rather than quality upgrades (deliberately skipped).