### PR TITLE
Improve the Information Center HD music track

### DIFF
--- a/assets/hdmusic/InformationCenter_Music_HD.wav
+++ b/assets/hdmusic/InformationCenter_Music_HD.wav
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c1ade0044cef699f526898cd44c34f426f3f057312f8d457ebc4b454096bdb0
-size 27256398
+oid sha256:5a554adcbec935b22420a7167bf71a87f0bb5c1ec8b3984211d4f2955847ce95
+size 26570292

--- a/assets/main.cpp
+++ b/assets/main.cpp
@@ -167,7 +167,7 @@ void CreateHDMusic()
 		 MxDSAction::c_enabled | MxDSAction::c_bit3},
 		{"InformationCenter_Music_HD",
 		 "Replace:\\Lego\\Scripts\\Isle\\Jukebox;11",
-		 154510,
+		 150625,
 		 10000,
 		 MxDSAction::c_enabled | MxDSAction::c_bit3},
 		{"PoliceStation_Music_HD",


### PR DESCRIPTION
Replaces the Information Center jukebox track (`Jukebox;11`) in the hdmusic pack with a new transfer contributed by @toonjoey in isledecomp/isle#1758.

Quoting the contribution:

> This is an improved copy of the Information Center music, based on the Lorin Nelson tape rather than the older MP3 upload due to it's lossless quality.
>
> The process behind it began with fixing the EQ. The tape is actually higher quality than it seems [...] but the state of the tape butchered the EQ thus resulting in what seemed like a lossy sound. Afterwards it was slowed to match the in-game version of the track, the right channel volume was bumped up (the original volume was VERY low), and then given a denoise pass.

Format is unchanged (44100 Hz, 16-bit, stereo), but the new master runs 150.625 s instead of 154.514 s, so the encoded duration in `assets/main.cpp` is recomputed from the audio (`ceil(body * 1000 / byteRate)` = 150625 ms per loop) to match — same convention the rest of the table uses.

See isledecomp/isle#1758
