### PR TITLE
Don't enumerate the SDL3 GPU device on Android (#813)

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -409,7 +409,8 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char** argv)
 		Any_ShowSimpleMessageBox(
 			SDL_MESSAGEBOX_ERROR,
 			"LEGO® Island Error",
-			"\"LEGO® Island\" failed to start.\nPlease quit all other applications and try again.",
+			"\"LEGO® Island\" failed to start.\nPlease quit all other applications and try again."
+			"\nFailed to initialize; see logs for details",
 			window
 		);
 		return SDL_APP_FAILURE;

--- a/miniwin/src/d3drm/d3drm.cpp
+++ b/miniwin/src/d3drm/d3drm.cpp
@@ -138,7 +138,7 @@ HRESULT Direct3DRMImpl::CreateDeviceFromSurface(
 
 	DDRenderer = CreateDirect3DRMRenderer(miniwind3d, DDSDesc, guid);
 	if (!DDRenderer) {
-		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Device GUID not recognized");
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create a renderer for the selected device GUID");
 		return E_NOINTERFACE;
 	}
 	*outDevice =

--- a/miniwin/src/ddraw/ddraw.cpp
+++ b/miniwin/src/ddraw/ddraw.cpp
@@ -330,7 +330,7 @@ HRESULT DirectDrawImpl::CreateDevice(
 
 	DDRenderer = CreateDirect3DRMRenderer(this, DDSDesc, &guid);
 	if (!DDRenderer) {
-		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Device GUID not recognized");
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create a renderer for the selected device GUID");
 		return E_NOINTERFACE;
 	}
 	*ppDirect3DDevice = static_cast<IDirect3DDevice2*>(DDRenderer);

--- a/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
+++ b/miniwin/src/internal/d3drmrenderer_sdl3gpu.h
@@ -120,6 +120,18 @@ private:
 
 inline static void Direct3DRMSDL3GPU_EnumDevice(LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
+#ifdef SDL_PLATFORM_ANDROID
+	// [library:3d]
+	// On Android, SDL binds an EGLSurface to the window's ANativeWindow as soon as the window is
+	// created with SDL_WINDOW_OPENGL. vkCreateAndroidSurfaceKHR then fails with
+	// VK_ERROR_NATIVE_WINDOW_IN_USE_KHR for that same window, so SDL_ClaimWindowForGPUDevice() can
+	// never succeed. Do not advertise a device we would not be able to render into: the game picks
+	// the first enumerated device it considers usable and does not fall back to another one.
+	if (!DDWindow || (SDL_GetWindowFlags(DDWindow) & SDL_WINDOW_OPENGL)) {
+		return;
+	}
+#endif
+
 	SDL_GPUDevice* device = SDL_CreateGPUDevice(
 		SDL_GPU_SHADERFORMAT_SPIRV | SDL_GPU_SHADERFORMAT_DXBC | SDL_GPU_SHADERFORMAT_DXIL | SDL_GPU_SHADERFORMAT_MSL,
 		false,


### PR DESCRIPTION
On Android the game window is always created with SDL_WINDOW_OPENGL, and SDL binds an EGLSurface to the window's ANativeWindow as soon as that flag is present. vkCreateAndroidSurfaceKHR then fails with VK_ERROR_NATIVE_WINDOW_IN_USE_KHR for the same window, so SDL_ClaimWindowForGPUDevice() inside Direct3DRMSDL3GPURenderer::Create() can never succeed there.

Direct3DRMSDL3GPU_EnumDevice() probes with a windowless SDL_CreateGPUDevice() call, which happily succeeds on any Vulkan-capable device, so "SDL3 GPU HAL" was still advertised. Being the first entry of Direct3DRMRenderer_EnumDevices(), LegoDeviceEnumerate::GetBestDevice() always picked it, and since the device is selected once with no fallback, the failure cascaded:

  Direct3DRMSDL3GPURenderer::Create -> CreateDevice (E_NOINTERFACE)
  -> MxDirect3D::Create -> LegoVideoManager::Create -> LegoOmni::Create
  -> IsleApp::SetupLegoOmni -> IsleApp::SetupWindow

The user only saw "failed to start / quit all other applications", raised before VerifyFilesystem() runs, which is why moving the game files around never helped.

Skip advertising the SDL3 GPU device on Android when the window it would have to render into is OpenGL-backed, so the OpenGL ES 3.0 renderer is chosen instead. Also mention the log in the message box for this failure path, and correct the misleading "Device GUID not recognized" error emitted when a renderer fails to initialize.