### PR TITLE
Replicate DirectX 5 and DirectX 8 era lighting in the GLES renderers

### DIFF
--- a/CONFIG/qt/MainDlg.cpp
+++ b/CONFIG/qt/MainDlg.cpp
@@ -95,6 +95,7 @@ CMainDialog::CMainDialog(QWidget* pParent) : QDialog(pParent)
 
 	connect(m_ui->msaaSlider, &QSlider::valueChanged, this, &CMainDialog::MSAAChanged);
 	connect(m_ui->msaaSlider, &QSlider::sliderMoved, this, &CMainDialog::MSAAChanged);
+	connect(m_ui->lightingModelComboBox, &QComboBox::currentIndexChanged, this, &CMainDialog::LightingModelChanged);
 	connect(m_ui->AFSlider, &QSlider::valueChanged, this, &CMainDialog::AFChanged);
 	connect(m_ui->AFSlider, &QSlider::sliderMoved, this, &CMainDialog::AFChanged);
 
@@ -350,6 +351,7 @@ void CMainDialog::UpdateInterface()
 	m_ui->msaaNum->setNum(currentConfigApp->m_msaa);
 	m_ui->AFSlider->setValue(log2(currentConfigApp->m_anisotropy));
 	m_ui->AFNum->setNum(currentConfigApp->m_anisotropy);
+	m_ui->lightingModelComboBox->setCurrentIndex(currentConfigApp->m_lighting_model);
 }
 
 // FUNCTION: CONFIG 0x004045e0
@@ -589,6 +591,13 @@ void CMainDialog::MaxActorsChanged(int value)
 void CMainDialog::MSAAChanged(int value)
 {
 	currentConfigApp->m_msaa = exp2(value);
+	m_modified = true;
+	UpdateInterface();
+}
+
+void CMainDialog::LightingModelChanged(int index)
+{
+	currentConfigApp->m_lighting_model = index;
 	m_modified = true;
 	UpdateInterface();
 }

--- a/CONFIG/qt/MainDlg.h
+++ b/CONFIG/qt/MainDlg.h
@@ -65,6 +65,7 @@ private slots:
 	void MaxActorsChanged(int value);
 	void MSAAChanged(int value);
 	void AFChanged(int value);
+	void LightingModelChanged(int index);
 	void SelectTexturePathDialog();
 	void TexturePathEdited();
 	void AddCustomAssetPath();

--- a/CONFIG/qt/config.cpp
+++ b/CONFIG/qt/config.cpp
@@ -86,6 +86,7 @@ bool CConfigApp::InitInstance()
 	m_display_bit_depth = 16;
 	m_msaa = 1;
 	m_anisotropy = 1;
+	m_lighting_model = 0;
 	m_haptic = TRUE;
 	m_wasd = FALSE;
 	m_touch_scheme = 2;
@@ -189,6 +190,7 @@ bool CConfigApp::ReadRegisterSettings()
 	m_max_lod = iniparser_getdouble(dict, "isle:Max LOD", m_max_lod);
 	m_max_actors = iniparser_getint(dict, "isle:Max Allowed Extras", m_max_actors);
 	m_msaa = iniparser_getint(dict, "isle:MSAA", m_msaa);
+	m_lighting_model = iniparser_getint(dict, "isle:Lighting Model", m_lighting_model);
 	m_anisotropy = iniparser_getint(dict, "isle:Anisotropic", m_anisotropy);
 	m_texture_load = iniparser_getboolean(dict, "extensions:texture loader", m_texture_load);
 	m_texture_path = iniparser_getstring(dict, "texture loader:texture path", m_texture_path.c_str());
@@ -275,6 +277,10 @@ bool CConfigApp::ValidateSettings()
 	}
 	if (m_exclusive_full_screen && !m_full_screen) {
 		m_full_screen = TRUE;
+		is_modified = TRUE;
+	}
+	if (m_lighting_model < 0 || m_lighting_model > 1) {
+		m_lighting_model = 0;
 		is_modified = TRUE;
 	}
 	if (!(m_msaa & (m_msaa - 1))) {         // Check if MSAA is power of 2 (1, 2, 4, 8, etc)
@@ -382,6 +388,7 @@ void CConfigApp::WriteRegisterSettings() const
 
 	SetIniInt(dict, "isle:Display Bit Depth", m_display_bit_depth);
 	SetIniInt(dict, "isle:MSAA", m_msaa);
+	SetIniInt(dict, "isle:Lighting Model", m_lighting_model);
 	SetIniInt(dict, "isle:Anisotropic", m_anisotropy);
 	SetIniBool(dict, "isle:Flip Surfaces", m_flip_surfaces);
 	SetIniBool(dict, "isle:Full Screen", m_full_screen);

--- a/CONFIG/qt/config.h
+++ b/CONFIG/qt/config.h
@@ -72,6 +72,7 @@ public:
 	int m_display_bit_depth;
 	int m_msaa;
 	int m_anisotropy;
+	int m_lighting_model;
 	bool m_flip_surfaces;
 	bool m_full_screen;
 	bool m_exclusive_full_screen;

--- a/CONFIG/qt/res/maindialog.ui
+++ b/CONFIG/qt/res/maindialog.ui
@@ -948,6 +948,35 @@ The game will gradually increase the number of actors until this maximum is reac
             </layout>
            </widget>
           </item>
+          <item>
+           <widget class="QGroupBox" name="lightingModelBox">
+            <property name="toolTip">
+             <string>Selects which DirectX runtime's lighting the renderer reproduces.</string>
+            </property>
+            <property name="title">
+             <string>Lighting Model</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_lighting">
+             <item>
+              <widget class="QComboBox" name="lightingModelComboBox">
+               <property name="currentIndex">
+                <number>0</number>
+               </property>
+               <item>
+                <property name="text">
+                 <string>DirectX 5</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>DirectX 8</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
          </layout>
         </widget>
         <widget class="QWidget" name="controlsTab">

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -222,6 +222,7 @@ IsleApp::IsleApp()
 	m_exclusiveFullScreen = FALSE;
 	m_msaaSamples = 0;
 	m_anisotropic = 16.0f;
+	m_lightingModel = 0;
 	m_activeInBackground = FALSE;
 }
 
@@ -1232,6 +1233,7 @@ bool IsleApp::LoadConfig()
 		iniparser_set(dict, "isle:Frame Delta", SDL_itoa(m_frameDelta, buf, 10));
 		iniparser_set(dict, "isle:MSAA", SDL_itoa(m_msaaSamples, buf, 10));
 		iniparser_set(dict, "isle:Anisotropic", SDL_itoa(m_anisotropic, buf, 10));
+		iniparser_set(dict, "isle:Lighting Model", SDL_itoa(m_lightingModel, buf, 10));
 		iniparser_set(dict, "isle:Active in background", m_activeInBackground ? "true" : "false");
 
 #ifdef EXTENSIONS
@@ -1317,6 +1319,7 @@ bool IsleApp::LoadConfig()
 	m_frameDelta = static_cast<int>(iniparser_getdouble(dict, "isle:Frame Delta", m_frameDelta));
 	m_videoParam.SetMSAASamples((m_msaaSamples = iniparser_getint(dict, "isle:MSAA", m_msaaSamples)));
 	m_videoParam.SetAnisotropic((m_anisotropic = iniparser_getdouble(dict, "isle:Anisotropic", m_anisotropic)));
+	m_videoParam.SetLightingModel((m_lightingModel = iniparser_getint(dict, "isle:Lighting Model", m_lightingModel)));
 	m_activeInBackground = iniparser_getboolean(dict, "isle:Active in Background", m_activeInBackground);
 
 	const char* deviceId = iniparser_getstring(dict, "isle:3D Device ID", NULL);

--- a/ISLE/isleapp.h
+++ b/ISLE/isleapp.h
@@ -118,6 +118,7 @@ private:
 	MxBool m_exclusiveFullScreen;
 	MxU32 m_msaaSamples;
 	MxFloat m_anisotropic;
+	MxU32 m_lightingModel;
 	MxBool m_activeInBackground;
 };
 

--- a/LEGO1/mxdirectx/mxdirect3d.cpp
+++ b/LEGO1/mxdirectx/mxdirect3d.cpp
@@ -83,6 +83,7 @@ BOOL MxDirect3D::Create(
 		if (videoParam) {
 			miniwind3d->RequestMSAA(videoParam->GetMSAASamples());
 			miniwind3d->RequestAnisotropic(videoParam->GetAnisotropic());
+			miniwind3d->RequestLightingModel(static_cast<D3DLightingModel>(videoParam->GetLightingModel()));
 		}
 	}
 

--- a/LEGO1/mxdirectx/mxdirectxinfo.cpp
+++ b/LEGO1/mxdirectx/mxdirectxinfo.cpp
@@ -239,6 +239,7 @@ BOOL MxDeviceEnumerate::EnumDirectDrawCallback(LPGUID p_guid, LPSTR p_driverDesc
 		if (videoParam) {
 			miniwind3d->RequestMSAA(videoParam->GetMSAASamples());
 			miniwind3d->RequestAnisotropic(videoParam->GetAnisotropic());
+			miniwind3d->RequestLightingModel(static_cast<D3DLightingModel>(videoParam->GetLightingModel()));
 		}
 	}
 

--- a/LEGO1/omni/include/mxvideoparam.h
+++ b/LEGO1/omni/include/mxvideoparam.h
@@ -59,6 +59,9 @@ public:
 	void SetAnisotropic(MxFloat p_anisotropic) { m_anisotropic = p_anisotropic; }
 	MxFloat GetAnisotropic() { return m_anisotropic; }
 
+	void SetLightingModel(MxU32 p_lightingModel) { m_lightingModel = p_lightingModel; }
+	MxU32 GetLightingModel() { return m_lightingModel; }
+
 private:
 	MxRect32 m_rect;           // 0x00
 	MxPalette* m_palette;      // 0x10
@@ -68,6 +71,7 @@ private:
 	char* m_deviceId;          // 0x20
 	MxU32 m_msaaSamples;
 	MxFloat m_anisotropic;
+	MxU32 m_lightingModel;
 };
 
 #endif // MXVIDEOPARAM_H

--- a/LEGO1/omni/src/video/mxvideoparam.cpp
+++ b/LEGO1/omni/src/video/mxvideoparam.cpp
@@ -30,6 +30,7 @@ MxVideoParam::MxVideoParam(MxRect32& p_rect, MxPalette* p_palette, MxULong p_bac
 	m_deviceId = NULL;
 	m_msaaSamples = 0;
 	m_anisotropic = 0.0f;
+	m_lightingModel = 0;
 }
 
 // FUNCTION: LEGO1 0x100becf0
@@ -45,6 +46,7 @@ MxVideoParam::MxVideoParam(MxVideoParam& p_videoParam)
 	SetDeviceName(p_videoParam.m_deviceId);
 	m_msaaSamples = p_videoParam.m_msaaSamples;
 	m_anisotropic = p_videoParam.m_anisotropic;
+	m_lightingModel = p_videoParam.m_lightingModel;
 }
 
 // FUNCTION: LEGO1 0x100bed50
@@ -88,6 +90,7 @@ MxVideoParam& MxVideoParam::operator=(const MxVideoParam& p_videoParam)
 	SetDeviceName(p_videoParam.m_deviceId);
 	m_msaaSamples = p_videoParam.m_msaaSamples;
 	m_anisotropic = p_videoParam.m_anisotropic;
+	m_lightingModel = p_videoParam.m_lightingModel;
 
 	return *this;
 }

--- a/miniwin/include/miniwin/miniwind3d.h
+++ b/miniwin/include/miniwin/miniwind3d.h
@@ -2,9 +2,16 @@
 
 DEFINE_GUID(IID_IDirect3DMiniwin, 0xf8a97f2d, 0x9b3a, 0x4f1c, 0x9e, 0x8d, 0x6a, 0x5b, 0x4c, 0x3d, 0x2e, 0x1f);
 
+enum class D3DLightingModel : DWORD {
+	DirectX5 = 0,
+	DirectX8 = 1,
+};
+
 struct IDirect3DMiniwin : virtual public IUnknown {
 	virtual HRESULT RequestMSAA(DWORD msaaSamples) = 0;
 	virtual DWORD GetMSAASamples() const = 0;
 	virtual HRESULT RequestAnisotropic(float anisotropic) = 0;
 	virtual float GetAnisotropic() const = 0;
+	virtual HRESULT RequestLightingModel(D3DLightingModel lightingModel) = 0;
+	virtual D3DLightingModel GetLightingModel() const = 0;
 };

--- a/miniwin/src/d3drm/backends/opengles2/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengles2/renderer.cpp
@@ -50,7 +50,12 @@ struct SceneLightGLES2 {
 	float direction[4];
 };
 
-Direct3DRMRenderer* OpenGLES2Renderer::Create(DWORD width, DWORD height, float anisotropic)
+Direct3DRMRenderer* OpenGLES2Renderer::Create(
+	DWORD width,
+	DWORD height,
+	float anisotropic,
+	D3DLightingModel lightingModel
+)
 {
 	// We have to reset the attributes here after having enumerated the
 	// OpenGL ES 2.0 renderer, or else SDL gets very confused by SDL_GL_DEPTH_SIZE
@@ -84,6 +89,12 @@ Direct3DRMRenderer* OpenGLES2Renderer::Create(DWORD width, DWORD height, float a
 	glFrontFace(GL_CW);
 
 	const char* vertexShaderSource = R"(
+		struct SceneLight {
+			vec4 color;
+			vec4 position;
+			vec4 direction;
+		};
+
 		attribute vec3 a_position;
 		attribute vec3 a_normal;
 		attribute vec2 a_texCoord;
@@ -91,47 +102,35 @@ Direct3DRMRenderer* OpenGLES2Renderer::Create(DWORD width, DWORD height, float a
 		uniform mat4 u_modelViewMatrix;
 		uniform mat3 u_normalMatrix;
 		uniform mat4 u_projectionMatrix;
+		uniform mat4 u_worldMatrix;
+		uniform vec3 u_cameraPos;
+		uniform SceneLight u_lights[3];
+		uniform int u_lightCount;
+		uniform int u_lightingModel;
+		uniform float u_shininess;
+		uniform vec4 u_color;
 
-		varying vec3 v_viewPos;
-		varying vec3 v_normal;
+		varying vec4 v_color;
+		varying vec3 v_specular;
 		varying vec2 v_texCoord;
 
 		void main() {
 			vec4 viewPos = u_modelViewMatrix * vec4(a_position, 1.0);
 			gl_Position = u_projectionMatrix * viewPos;
-			v_viewPos = viewPos.xyz;
-			v_normal = normalize(u_normalMatrix * a_normal);
-			v_texCoord = a_texCoord;
-		}
-	)";
 
-	const char* fragmentShaderSource = R"(
-		precision mediump float;
+			vec3 worldPos = (u_worldMatrix * vec4(a_position, 1.0)).xyz;
+			vec3 normal = normalize(u_normalMatrix * a_normal);
 
-		struct SceneLight {
-			vec4 color;
-			vec4 position;
-			vec4 direction;
-		};
+			vec3 modelOrigin = u_worldMatrix[3].xyz;
+			vec3 camDir = normalize(u_cameraPos - modelOrigin);
 
-		uniform SceneLight u_lights[3];
-		uniform int u_lightCount;
-
-		varying vec3 v_viewPos;
-		varying vec3 v_normal;
-		varying vec2 v_texCoord;
-
-		uniform float u_shininess;
-		uniform vec4 u_color;
-		uniform int u_useTexture;
-		uniform sampler2D u_texture;
-
-		void main() {
 			vec3 diffuse = vec3(0.0);
 			vec3 specular = vec3(0.0);
 
 			for (int i = 0; i < 3; ++i) {
-				if (i >= u_lightCount) break;
+				if (i >= u_lightCount) {
+					break;
+				}
 
 				vec3 lightColor = u_lights[i].color.rgb;
 
@@ -145,33 +144,54 @@ Direct3DRMRenderer* OpenGLES2Renderer::Create(DWORD width, DWORD height, float a
 					lightVec = -normalize(u_lights[i].direction.xyz);
 				}
 				else {
-					lightVec = u_lights[i].position.xyz - v_viewPos;
+					lightVec = normalize(u_lights[i].position.xyz - worldPos);
 				}
-				lightVec = normalize(lightVec);
 
-				float dotNL = max(dot(v_normal, lightVec), 0.0);
+				float dotNL = dot(normal, lightVec);
 				if (dotNL > 0.0) {
-					// Diffuse contribution
 					diffuse += dotNL * lightColor;
 
-					// Specular
-					if (u_shininess > 0.0 && u_lights[i].direction.w == 1.0) {
-						vec3 viewVec = normalize(-v_viewPos);
-						vec3 H = normalize(lightVec + viewVec);
-						float dotNH = max(dot(v_normal, H), 0.0);
-						float spec = pow(dotNH, u_shininess);
-						specular += spec * lightColor;
+					if (u_lightingModel == 0 && u_shininess > 0.0) {
+						vec3 towardLight;
+						if (u_lights[i].direction.w == 1.0) {
+							towardLight = lightVec;
+						}
+						else {
+							towardLight = normalize(u_lights[i].position.xyz - modelOrigin);
+						}
+						vec3 H = normalize(camDir + towardLight);
+						float dotNH = dot(normal, H);
+						if (dotNH > 0.0) {
+							specular += pow(dotNH, u_shininess) * lightColor;
+						}
 					}
 				}
 			}
 
-			vec4 finalColor = u_color;
-			finalColor.rgb = clamp(diffuse * u_color.rgb + specular, 0.0, 1.0);
+			v_color = vec4(clamp(diffuse * u_color.rgb, 0.0, 1.0), u_color.a);
+			v_specular = clamp(specular, 0.0, 1.0);
+			v_texCoord = a_texCoord;
+		}
+	)";
+
+	const char* fragmentShaderSource = R"(
+		precision mediump float;
+
+		varying vec4 v_color;
+		varying vec3 v_specular;
+		varying vec2 v_texCoord;
+
+		uniform int u_useTexture;
+		uniform sampler2D u_texture;
+
+		void main() {
+			vec4 finalColor = v_color;
 			if (u_useTexture != 0) {
 				vec4 texel = texture2D(u_texture, v_texCoord);
-				finalColor.rgb = clamp(texel.rgb * finalColor.rgb, 0.0, 1.0);
+				finalColor.rgb = texel.rgb * finalColor.rgb;
 				finalColor.a = texel.a;
 			}
+			finalColor.rgb = clamp(finalColor.rgb + v_specular, 0.0, 1.0);
 
 			gl_FragColor = finalColor;
 		}
@@ -190,7 +210,7 @@ Direct3DRMRenderer* OpenGLES2Renderer::Create(DWORD width, DWORD height, float a
 	glDeleteShader(vs);
 	glDeleteShader(fs);
 
-	return new OpenGLES2Renderer(width, height, anisotropic, context, shaderProgram);
+	return new OpenGLES2Renderer(width, height, anisotropic, lightingModel, context, shaderProgram);
 }
 
 GLES2MeshCacheEntry GLES2UploadMesh(const MeshGroup& meshGroup, bool forceUV = false)
@@ -301,10 +321,11 @@ OpenGLES2Renderer::OpenGLES2Renderer(
 	DWORD width,
 	DWORD height,
 	float anisotropic,
+	D3DLightingModel lightingModel,
 	SDL_GLContext context,
 	GLuint shaderProgram
 )
-	: m_context(context), m_shaderProgram(shaderProgram), m_anisotropic(anisotropic)
+	: m_context(context), m_shaderProgram(shaderProgram), m_anisotropic(anisotropic), m_lightingModel(lightingModel)
 {
 	glGenFramebuffers(1, &m_fbo);
 	glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
@@ -324,6 +345,8 @@ OpenGLES2Renderer::OpenGLES2Renderer(
 		m_anisotropic,
 		maxAniso
 	);
+
+	SDL_Log("Lighting model: %s", m_lightingModel == D3DLightingModel::DirectX8 ? "DirectX 8" : "DirectX 5");
 
 	m_virtualWidth = width;
 	m_virtualHeight = height;
@@ -368,6 +391,9 @@ OpenGLES2Renderer::OpenGLES2Renderer(
 	m_modelViewMatrixLoc = glGetUniformLocation(m_shaderProgram, "u_modelViewMatrix");
 	m_normalMatrixLoc = glGetUniformLocation(m_shaderProgram, "u_normalMatrix");
 	m_projectionMatrixLoc = glGetUniformLocation(m_shaderProgram, "u_projectionMatrix");
+	m_worldMatrixLoc = glGetUniformLocation(m_shaderProgram, "u_worldMatrix");
+	m_cameraPosLoc = glGetUniformLocation(m_shaderProgram, "u_cameraPos");
+	m_lightingModelLoc = glGetUniformLocation(m_shaderProgram, "u_lightingModel");
 
 	m_uiMesh.vertices = {
 		{{0.0f, 0.0f, 0.0f}, {0, 0, -1}, {0.0f, 0.0f}},
@@ -379,6 +405,7 @@ OpenGLES2Renderer::OpenGLES2Renderer(
 	m_uiMeshCache = GLES2UploadMesh(m_uiMesh, true);
 
 	glUseProgram(m_shaderProgram);
+	glUniform1i(m_lightingModelLoc, static_cast<GLint>(m_lightingModel));
 }
 
 OpenGLES2Renderer::~OpenGLES2Renderer()
@@ -568,6 +595,7 @@ HRESULT OpenGLES2Renderer::BeginFrame()
 		glUniform4fv(u_lightLocs[i][2], 1, lightData[i].direction);
 	}
 	glUniform1i(m_lightCountLoc, lightCount);
+	glUniform1i(m_lightingModelLoc, static_cast<GLint>(m_lightingModel));
 	return DD_OK;
 }
 
@@ -592,6 +620,17 @@ void OpenGLES2Renderer::SubmitDraw(
 	glUniformMatrix4fv(m_modelViewMatrixLoc, 1, GL_FALSE, &modelViewMatrix[0][0]);
 	glUniformMatrix3fv(m_normalMatrixLoc, 1, GL_FALSE, &normalMatrix[0][0]);
 	glUniformMatrix4fv(m_projectionMatrixLoc, 1, GL_FALSE, &m_projection[0][0]);
+	glUniformMatrix4fv(m_worldMatrixLoc, 1, GL_FALSE, &worldMatrix[0][0]);
+
+	float cameraPos[3] = {
+		-(viewMatrix[3][0] * viewMatrix[0][0] + viewMatrix[3][1] * viewMatrix[0][1] +
+		  viewMatrix[3][2] * viewMatrix[0][2]),
+		-(viewMatrix[3][0] * viewMatrix[1][0] + viewMatrix[3][1] * viewMatrix[1][1] +
+		  viewMatrix[3][2] * viewMatrix[1][2]),
+		-(viewMatrix[3][0] * viewMatrix[2][0] + viewMatrix[3][1] * viewMatrix[2][1] +
+		  viewMatrix[3][2] * viewMatrix[2][2])
+	};
+	glUniform3fv(m_cameraPosLoc, 1, cameraPos);
 
 	glUniform4f(
 		m_colorLoc,
@@ -750,6 +789,9 @@ void OpenGLES2Renderer::Flip()
 		{0.0f, (float) m_height, 0.0f, 1.0f}
 	};
 	glUniformMatrix4fv(m_modelViewMatrixLoc, 1, GL_FALSE, &modelViewMatrix[0][0]);
+	glUniformMatrix4fv(m_worldMatrixLoc, 1, GL_FALSE, &modelViewMatrix[0][0]);
+	float cameraPos[3] = {0.f, 0.f, 0.f};
+	glUniform3fv(m_cameraPosLoc, 1, cameraPos);
 	Matrix3x3 identity = {{1.f, 0.f, 0.f}, {0.f, 1.f, 0.f}, {0.f, 0.f, 1.f}};
 	glUniformMatrix3fv(m_normalMatrixLoc, 1, GL_FALSE, &identity[0][0]);
 	CreateOrthographicProjection((float) m_width, (float) m_height, projection);
@@ -833,6 +875,9 @@ void OpenGLES2Renderer::Draw2DImage(Uint32 textureId, const SDL_Rect& srcRect, c
 	);
 
 	glUniformMatrix4fv(m_modelViewMatrixLoc, 1, GL_FALSE, &modelView[0][0]);
+	glUniformMatrix4fv(m_worldMatrixLoc, 1, GL_FALSE, &modelView[0][0]);
+	float cameraPos[3] = {0.f, 0.f, 0.f};
+	glUniform3fv(m_cameraPosLoc, 1, cameraPos);
 	Matrix3x3 identity = {{1.f, 0.f, 0.f}, {0.f, 1.f, 0.f}, {0.f, 0.f, 1.f}};
 	glUniformMatrix3fv(m_normalMatrixLoc, 1, GL_FALSE, &identity[0][0]);
 	CreateOrthographicProjection((float) m_width, (float) m_height, projection);

--- a/miniwin/src/d3drm/backends/opengles3/renderer.cpp
+++ b/miniwin/src/d3drm/backends/opengles3/renderer.cpp
@@ -51,7 +51,13 @@ struct SceneLightGLES3 {
 	float direction[4];
 };
 
-Direct3DRMRenderer* OpenGLES3Renderer::Create(DWORD width, DWORD height, DWORD msaaSamples, float anisotropic)
+Direct3DRMRenderer* OpenGLES3Renderer::Create(
+	DWORD width,
+	DWORD height,
+	DWORD msaaSamples,
+	float anisotropic,
+	D3DLightingModel lightingModel
+)
 {
 	// We have to reset the attributes here after having enumerated the
 	// OpenGL ES 2.0 renderer, or else SDL gets very confused by SDL_GL_DEPTH_SIZE
@@ -87,6 +93,12 @@ Direct3DRMRenderer* OpenGLES3Renderer::Create(DWORD width, DWORD height, DWORD m
 	const char* vertexShaderSource = R"(#version 300 es
 		precision highp float;
 
+		struct SceneLight {
+			vec4 color;
+			vec4 position;
+			vec4 direction;
+		};
+
 		in vec3 a_position;
 		in vec3 a_normal;
 		in vec2 a_texCoord;
@@ -94,44 +106,28 @@ Direct3DRMRenderer* OpenGLES3Renderer::Create(DWORD width, DWORD height, DWORD m
 		uniform mat4 u_modelViewMatrix;
 		uniform mat3 u_normalMatrix;
 		uniform mat4 u_projectionMatrix;
+		uniform mat4 u_worldMatrix;
+		uniform vec3 u_cameraPos;
+		uniform SceneLight u_lights[3];
+		uniform int u_lightCount;
+		uniform int u_lightingModel;
+		uniform float u_shininess;
+		uniform vec4 u_color;
 
-		out vec3 v_viewPos;
-		out vec3 v_normal;
+		out vec4 v_color;
+		out vec3 v_specular;
 		out vec2 v_texCoord;
 
 		void main() {
 			vec4 viewPos = u_modelViewMatrix * vec4(a_position, 1.0);
 			gl_Position = u_projectionMatrix * viewPos;
-			v_viewPos = viewPos.xyz;
-			v_normal = normalize(u_normalMatrix * a_normal);
-			v_texCoord = a_texCoord;
-		}
-	)";
 
-	const char* fragmentShaderSource = R"(#version 300 es
-		precision mediump float;
+			vec3 worldPos = (u_worldMatrix * vec4(a_position, 1.0)).xyz;
+			vec3 normal = normalize(u_normalMatrix * a_normal);
 
-		struct SceneLight {
-			vec4 color;
-			vec4 position;
-			vec4 direction;
-		};
+			vec3 modelOrigin = u_worldMatrix[3].xyz;
+			vec3 camDir = normalize(u_cameraPos - modelOrigin);
 
-		uniform SceneLight u_lights[3];
-		uniform int u_lightCount;
-
-		in vec3 v_viewPos;
-		in vec3 v_normal;
-		in vec2 v_texCoord;
-
-		uniform float u_shininess;
-		uniform vec4 u_color;
-		uniform bool u_useTexture;
-		uniform sampler2D u_texture;
-
-		out vec4 fragColor;
-
-		void main() {
 			vec3 diffuse = vec3(0.0);
 			vec3 specular = vec3(0.0);
 
@@ -148,33 +144,56 @@ Direct3DRMRenderer* OpenGLES3Renderer::Create(DWORD width, DWORD height, DWORD m
 					lightVec = -normalize(u_lights[i].direction.xyz);
 				}
 				else {
-					lightVec = u_lights[i].position.xyz - v_viewPos;
+					lightVec = normalize(u_lights[i].position.xyz - worldPos);
 				}
-				lightVec = normalize(lightVec);
 
-				float dotNL = max(dot(v_normal, lightVec), 0.0);
+				float dotNL = dot(normal, lightVec);
 				if (dotNL > 0.0) {
-					// Diffuse contribution
 					diffuse += dotNL * lightColor;
 
-					// Specular
-					if (u_shininess > 0.0 && u_lights[i].direction.w == 1.0) {
-						vec3 viewVec = normalize(-v_viewPos);
-						vec3 H = normalize(lightVec + viewVec);
-						float dotNH = max(dot(v_normal, H), 0.0);
-						float spec = pow(dotNH, u_shininess);
-						specular += spec * lightColor;
+					if (u_lightingModel == 0 && u_shininess > 0.0) {
+						vec3 towardLight;
+						if (u_lights[i].direction.w == 1.0) {
+							towardLight = lightVec;
+						}
+						else {
+							towardLight = normalize(u_lights[i].position.xyz - modelOrigin);
+						}
+						vec3 H = normalize(camDir + towardLight);
+						float dotNH = dot(normal, H);
+						if (dotNH > 0.0) {
+							specular += pow(dotNH, u_shininess) * lightColor;
+						}
 					}
 				}
 			}
 
-			vec4 finalColor = u_color;
-			finalColor.rgb = clamp(diffuse * u_color.rgb + specular, 0.0, 1.0);
+			v_color = vec4(clamp(diffuse * u_color.rgb, 0.0, 1.0), u_color.a);
+			v_specular = clamp(specular, 0.0, 1.0);
+			v_texCoord = a_texCoord;
+		}
+	)";
+
+	const char* fragmentShaderSource = R"(#version 300 es
+		precision mediump float;
+
+		in vec4 v_color;
+		in vec3 v_specular;
+		in vec2 v_texCoord;
+
+		uniform bool u_useTexture;
+		uniform sampler2D u_texture;
+
+		out vec4 fragColor;
+
+		void main() {
+			vec4 finalColor = v_color;
 			if (u_useTexture) {
 				vec4 texel = texture(u_texture, v_texCoord);
-				finalColor.rgb = clamp(texel.rgb * finalColor.rgb, 0.0, 1.0);
+				finalColor.rgb = texel.rgb * finalColor.rgb;
 				finalColor.a = texel.a;
 			}
+			finalColor.rgb = clamp(finalColor.rgb + v_specular, 0.0, 1.0);
 
 			fragColor = finalColor;
 		}
@@ -193,7 +212,7 @@ Direct3DRMRenderer* OpenGLES3Renderer::Create(DWORD width, DWORD height, DWORD m
 	glDeleteShader(vs);
 	glDeleteShader(fs);
 
-	return new OpenGLES3Renderer(width, height, msaaSamples, anisotropic, context, shaderProgram);
+	return new OpenGLES3Renderer(width, height, msaaSamples, anisotropic, lightingModel, context, shaderProgram);
 }
 
 GLES3MeshCacheEntry OpenGLES3Renderer::GLES3UploadMesh(const MeshGroup& meshGroup, bool forceUV)
@@ -316,10 +335,12 @@ OpenGLES3Renderer::OpenGLES3Renderer(
 	DWORD height,
 	DWORD msaaSamples,
 	float anisotropic,
+	D3DLightingModel lightingModel,
 	SDL_GLContext context,
 	GLuint shaderProgram
 )
-	: m_context(context), m_shaderProgram(shaderProgram), m_msaa(msaaSamples), m_anisotropic(anisotropic)
+	: m_context(context), m_shaderProgram(shaderProgram), m_msaa(msaaSamples), m_anisotropic(anisotropic),
+	  m_lightingModel(lightingModel)
 {
 	glGenFramebuffers(1, &m_fbo);
 	glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
@@ -356,6 +377,8 @@ OpenGLES3Renderer::OpenGLES3Renderer(
 		m_anisotropic,
 		maxAniso
 	);
+
+	SDL_Log("Lighting model: %s", m_lightingModel == D3DLightingModel::DirectX8 ? "DirectX 8" : "DirectX 5");
 
 	m_virtualWidth = width;
 	m_virtualHeight = height;
@@ -400,6 +423,9 @@ OpenGLES3Renderer::OpenGLES3Renderer(
 	m_modelViewMatrixLoc = glGetUniformLocation(m_shaderProgram, "u_modelViewMatrix");
 	m_normalMatrixLoc = glGetUniformLocation(m_shaderProgram, "u_normalMatrix");
 	m_projectionMatrixLoc = glGetUniformLocation(m_shaderProgram, "u_projectionMatrix");
+	m_worldMatrixLoc = glGetUniformLocation(m_shaderProgram, "u_worldMatrix");
+	m_cameraPosLoc = glGetUniformLocation(m_shaderProgram, "u_cameraPos");
+	m_lightingModelLoc = glGetUniformLocation(m_shaderProgram, "u_lightingModel");
 
 	m_uiMesh.vertices = {
 		{{0.0f, 0.0f, 0.0f}, {0, 0, -1}, {0.0f, 0.0f}},
@@ -411,6 +437,7 @@ OpenGLES3Renderer::OpenGLES3Renderer(
 	m_uiMeshCache = GLES3UploadMesh(m_uiMesh, true);
 
 	glUseProgram(m_shaderProgram);
+	glUniform1i(m_lightingModelLoc, static_cast<GLint>(m_lightingModel));
 }
 
 OpenGLES3Renderer::~OpenGLES3Renderer()
@@ -606,6 +633,7 @@ HRESULT OpenGLES3Renderer::BeginFrame()
 		glUniform4fv(u_lightLocs[i][2], 1, lightData[i].direction);
 	}
 	glUniform1i(m_lightCountLoc, lightCount);
+	glUniform1i(m_lightingModelLoc, static_cast<GLint>(m_lightingModel));
 	return DD_OK;
 }
 
@@ -630,6 +658,17 @@ void OpenGLES3Renderer::SubmitDraw(
 	glUniformMatrix4fv(m_modelViewMatrixLoc, 1, GL_FALSE, &modelViewMatrix[0][0]);
 	glUniformMatrix3fv(m_normalMatrixLoc, 1, GL_FALSE, &normalMatrix[0][0]);
 	glUniformMatrix4fv(m_projectionMatrixLoc, 1, GL_FALSE, &m_projection[0][0]);
+	glUniformMatrix4fv(m_worldMatrixLoc, 1, GL_FALSE, &worldMatrix[0][0]);
+
+	float cameraPos[3] = {
+		-(viewMatrix[3][0] * viewMatrix[0][0] + viewMatrix[3][1] * viewMatrix[0][1] +
+		  viewMatrix[3][2] * viewMatrix[0][2]),
+		-(viewMatrix[3][0] * viewMatrix[1][0] + viewMatrix[3][1] * viewMatrix[1][1] +
+		  viewMatrix[3][2] * viewMatrix[1][2]),
+		-(viewMatrix[3][0] * viewMatrix[2][0] + viewMatrix[3][1] * viewMatrix[2][1] +
+		  viewMatrix[3][2] * viewMatrix[2][2])
+	};
+	glUniform3fv(m_cameraPosLoc, 1, cameraPos);
 
 	glUniform4f(
 		m_colorLoc,
@@ -830,6 +869,9 @@ void OpenGLES3Renderer::Draw2DImage(Uint32 textureId, const SDL_Rect& srcRect, c
 	);
 
 	glUniformMatrix4fv(m_modelViewMatrixLoc, 1, GL_FALSE, &modelView[0][0]);
+	glUniformMatrix4fv(m_worldMatrixLoc, 1, GL_FALSE, &modelView[0][0]);
+	float cameraPos[3] = {0.f, 0.f, 0.f};
+	glUniform3fv(m_cameraPosLoc, 1, cameraPos);
 	Matrix3x3 identity = {{1.f, 0.f, 0.f}, {0.f, 1.f, 0.f}, {0.f, 0.f, 1.f}};
 	glUniformMatrix3fv(m_normalMatrixLoc, 1, GL_FALSE, &identity[0][0]);
 	CreateOrthographicProjection((float) m_width, (float) m_height, projection);

--- a/miniwin/src/d3drm/d3drmrenderer.cpp
+++ b/miniwin/src/d3drm/d3drmrenderer.cpp
@@ -52,13 +52,19 @@ Direct3DRMRenderer* CreateDirect3DRMRenderer(
 			DDSDesc.dwWidth,
 			DDSDesc.dwHeight,
 			d3d->GetMSAASamples(),
-			d3d->GetAnisotropic()
+			d3d->GetAnisotropic(),
+			d3d->GetLightingModel()
 		);
 	}
 #endif
 #ifdef USE_OPENGLES2
 	if (SDL_memcmp(guid, &OpenGLES2_GUID, sizeof(GUID)) == 0) {
-		return OpenGLES2Renderer::Create(DDSDesc.dwWidth, DDSDesc.dwHeight, d3d->GetAnisotropic());
+		return OpenGLES2Renderer::Create(
+			DDSDesc.dwWidth,
+			DDSDesc.dwHeight,
+			d3d->GetAnisotropic(),
+			d3d->GetLightingModel()
+		);
 	}
 #endif
 #ifdef USE_OPENGL1

--- a/miniwin/src/internal/d3drmrenderer_opengles2.h
+++ b/miniwin/src/internal/d3drmrenderer_opengles2.h
@@ -41,8 +41,15 @@ struct GLES2MeshCacheEntry {
 
 class OpenGLES2Renderer : public Direct3DRMRenderer {
 public:
-	static Direct3DRMRenderer* Create(DWORD width, DWORD height, float anisotropic);
-	OpenGLES2Renderer(DWORD width, DWORD height, float anisotropic, SDL_GLContext context, GLuint shaderProgram);
+	static Direct3DRMRenderer* Create(DWORD width, DWORD height, float anisotropic, D3DLightingModel lightingModel);
+	OpenGLES2Renderer(
+		DWORD width,
+		DWORD height,
+		float anisotropic,
+		D3DLightingModel lightingModel,
+		SDL_GLContext context,
+		GLuint shaderProgram
+	);
 	~OpenGLES2Renderer() override;
 
 	void PushLights(const SceneLight* lightsArray, size_t count) override;
@@ -83,6 +90,7 @@ private:
 	std::vector<SceneLight> m_lights;
 	SDL_GLContext m_context;
 	float m_anisotropic;
+	D3DLightingModel m_lightingModel;
 	GLuint m_fbo;
 	GLuint m_colorTarget = 0;
 	GLuint m_depthTarget = 0;
@@ -100,12 +108,15 @@ private:
 	GLint m_modelViewMatrixLoc;
 	GLint m_normalMatrixLoc;
 	GLint m_projectionMatrixLoc;
+	GLint m_worldMatrixLoc;
+	GLint m_cameraPosLoc;
+	GLint m_lightingModelLoc;
 	ViewportTransform m_viewportTransform;
 };
 
 inline static void OpenGLES2Renderer_EnumDevice(const IDirect3DMiniwin* d3d, LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
-	Direct3DRMRenderer* device = OpenGLES2Renderer::Create(640, 480, d3d->GetAnisotropic());
+	Direct3DRMRenderer* device = OpenGLES2Renderer::Create(640, 480, d3d->GetAnisotropic(), d3d->GetLightingModel());
 	if (!device) {
 		return;
 	}

--- a/miniwin/src/internal/d3drmrenderer_opengles3.h
+++ b/miniwin/src/internal/d3drmrenderer_opengles3.h
@@ -42,12 +42,19 @@ struct GLES3MeshCacheEntry {
 
 class OpenGLES3Renderer : public Direct3DRMRenderer {
 public:
-	static Direct3DRMRenderer* Create(DWORD width, DWORD height, DWORD msaaSamples, float anisotropic);
+	static Direct3DRMRenderer* Create(
+		DWORD width,
+		DWORD height,
+		DWORD msaaSamples,
+		float anisotropic,
+		D3DLightingModel lightingModel
+	);
 	OpenGLES3Renderer(
 		DWORD width,
 		DWORD height,
 		DWORD msaaSamples,
 		float anisotropic,
+		D3DLightingModel lightingModel,
 		SDL_GLContext context,
 		GLuint shaderProgram
 	);
@@ -93,6 +100,7 @@ private:
 	SDL_GLContext m_context;
 	uint32_t m_msaa;
 	float m_anisotropic;
+	D3DLightingModel m_lightingModel;
 	GLuint m_fbo = 0;
 	GLuint m_resolveFBO = 0;
 	GLuint m_colorTarget = 0;
@@ -112,12 +120,16 @@ private:
 	GLint m_modelViewMatrixLoc;
 	GLint m_normalMatrixLoc;
 	GLint m_projectionMatrixLoc;
+	GLint m_worldMatrixLoc;
+	GLint m_cameraPosLoc;
+	GLint m_lightingModelLoc;
 	ViewportTransform m_viewportTransform;
 };
 
 inline static void OpenGLES3Renderer_EnumDevice(const IDirect3DMiniwin* d3d, LPD3DENUMDEVICESCALLBACK cb, void* ctx)
 {
-	Direct3DRMRenderer* device = OpenGLES3Renderer::Create(640, 480, d3d->GetMSAASamples(), d3d->GetAnisotropic());
+	Direct3DRMRenderer* device =
+		OpenGLES3Renderer::Create(640, 480, d3d->GetMSAASamples(), d3d->GetAnisotropic(), d3d->GetLightingModel());
 	if (!device) {
 		return;
 	}

--- a/miniwin/src/internal/ddraw_impl.h
+++ b/miniwin/src/internal/ddraw_impl.h
@@ -59,6 +59,12 @@ struct DirectDrawImpl : public IDirectDraw2, public IDirect3D2, public IDirect3D
 		return DD_OK;
 	}
 	float GetAnisotropic() const override { return m_anisotropic; }
+	HRESULT RequestLightingModel(D3DLightingModel lightingModel) override
+	{
+		m_lightingModel = lightingModel;
+		return DD_OK;
+	}
+	D3DLightingModel GetLightingModel() const override { return m_lightingModel; }
 
 private:
 	FrameBufferImpl* m_frameBuffer = nullptr;
@@ -67,6 +73,7 @@ private:
 	int m_virtualBPP = 0;
 	DWORD m_msaaSamples = 0;
 	float m_anisotropic = 0.0f;
+	D3DLightingModel m_lightingModel = D3DLightingModel::DirectX5;
 };
 
 HRESULT DirectDrawEnumerate(LPDDENUMCALLBACKA cb, void* context);


### PR DESCRIPTION
Closes #247.

This replicates the original lighting of the game as rendered by the DirectX 5 runtime, and adds the look of DirectX 7+ era runtimes as a second selectable model. Both models were reverse-engineered from the original runtime binaries (D3DRM/D3DIM/D3DHALF from the DirectX 5 redistributable, d3dim/d3drm from DirectX 8.1) and verified against period captures from the issue thread.

**DirectX 5 model (default):** Retained Mode programs legacy `D3DLIGHT` structures, which the vertex pipeline lights per vertex in model space: point lights are unattenuated with no range limit, and specular uses one halfway vector per draw call, built from the camera and light directions anchored at the model origin (the software T&L's infinite-viewer/infinite-light approximation). Specular applies only to meshes carrying the WDB shininess flag (power 10, white specular via the shared `CreateMaterial(10.0)` material) and is added after texture modulation. This restores the characteristic broad sheen on LEGO plastic and the bright race track.

**DirectX 8 model:** On DirectX 6 and later runtimes, Retained Mode pre-lights mesh vertices itself and submits them as `D3DVT_LVERTEX` with the specular component hardwired to zero, so diffuse lighting is identical to DirectX 5 but specular never appears. This matches how the game looks on newer Windows systems (dark matte race track).

Implementation: both models live in the OpenGL ES 3.0 and 2.0 vertex shaders behind a `u_lightingModel` uniform, selectable through a new `Lighting Model` graphics option (`isle.ini` `Lighting Model`: 0 = DirectX 5, 1 = DirectX 8), plumbed through `MxVideoParam` and `IDirect3DMiniwin` and exposed in the Qt config dialog. The selected model is logged at renderer creation. Other backends keep their current lighting for now.

Differences between the lighting options can be observed here: https://github.com/isledecomp/isle-portable/issues/247#issuecomment-2972899213

<img width="829" height="626" alt="image" src="https://github.com/user-attachments/assets/83a0b1cd-d16b-4a9c-99fa-5691ab75c6ef" />
