### PR TITLE
Remove the intro movie audio replacement from the HD audio pack

### DIFF
--- a/assets/hdaudio/index.txt
+++ b/assets/hdaudio/index.txt
@@ -322,7 +322,6 @@ Hospital/HOSPITAL.SI	118	wav/onscreen/en/hho012en.wav
 Hospital/HOSPITAL.SI	120	wav/onscreen/en/hho011en.wav
 Hospital/HOSPITAL.SI	122	wav/onscreen/re/hho011re.wav
 Hospital/HOSPITAL.SI	124	wav/onscreen/cl/hho008cl.wav
-INTRO.SI	11	wav/music/lawrence/theme2_s1.wav
 Infocntr/ELEVBOTT.SI	500	wav/onscreen/in/iica31in.wav
 Infocntr/INFODOOR.SI	500	wav/onscreen/in/iic037in.wav
 Infocntr/INFODOOR.SI	501	wav/onscreen/in/iic038in.wav

--- a/assets/hdaudio/orig/INTRO.SI
+++ b/assets/hdaudio/orig/INTRO.SI
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e40dd00596c7806667bfbb67c81fa6c71a13e3b4ba03c0335fbe8dfe690c4cb
-size 60882944

--- a/assets/hdaudio/wav/music/lawrence/theme2_s1.wav
+++ b/assets/hdaudio/wav/music/lawrence/theme2_s1.wav
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26e2e1fee49f1c0e5ef7ab59e0777d93db6c212a7a82f3ff6988110329509025
-size 3621624


### PR DESCRIPTION
Fixes a regression from #816: the intro movie (`Intro_Smk`) lost all of its sound effects.

`Intro_Wave` — the sole audio track interleaved with the intro smacker — turned out not to be a music track but the movie's complete soundtrack **mixdown**: the theme music bed plus all the foley synced to the video (brick snaps at ~28–33s, ~40–44s, ~66–72s, etc.). The pack replaced it with the clean 2-12-97 `THEME2` master trimmed to the movie runtime, which is music-only, so every sound effect in the intro went silent. The dump has no separate SFX stems for the movie, so the retail mixdown is the only faithful option — same category as the other foley mixdowns the pack deliberately leaves untouched.

This drops the only `INTRO.SI` entry from the index, so the file leaves the pack entirely (the engine falls back to the retail original) and the now-unreferenced LFS objects (`orig/INTRO.SI`, `wav/music/lawrence/theme2_s1.wav`) are removed.

### Verification
Regenerated the pack from a clean stamp: the output contains exactly the 18 remaining SIs, each **byte-identical** to the previously verified build — the only change is `INTRO.SI`'s absence. An envelope comparison of retail `intro.wav` vs. the replacement confirms 35 windows of retail-only energy at the SFX timestamps (music-only elsewhere), plus a mismatched ending fade.