### PR TITLE
Install the Vita SDK into a user-writable prefix in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           - { name: 'Nintendo Switch',     os: 'ubuntu-latest',  generator: 'Ninja',                 dx5: false, config: false, nx: true,    werror: true,   clang-tidy: false,  container: 'devkitpro/devkita64:latest', cmake-args: '-DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/Switch.cmake' }
           - { name: 'Xbox One',            os: 'windows-latest', generator: 'Visual Studio 18 2026', dx5: false, config: false, msvc: true,  werror: false,  clang-tidy: false,  vc-arch: 'amd64', cmake-args: '-DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0.26100.0', xbox-one: true}
           - { name: 'Android',             os: 'ubuntu-latest',  generator: 'Ninja',                 dx5: false, config: false, android: true, werror: true, clang-tidy: false,}
-          - { name: 'Vita',                os: 'ubuntu-latest',  generator: 'Ninja',                 dx5: false, config: false, vita: true,  werror: true,   clang-tidy: false, cmake-args: '--toolchain /usr/local/vitasdk/share/vita.toolchain.cmake'}
+          - { name: 'Vita',                os: 'ubuntu-latest',  generator: 'Ninja',                 dx5: false, config: false, vita: true,  werror: true,   clang-tidy: false, cmake-args: '--toolchain $HOME/vitasdk/share/vita.toolchain.cmake'}
           - { name: 'DOS',                 os: 'ubuntu-latest',  generator: 'Ninja',                 dx5: false, config: false, dos: true,   werror: true,   clang-tidy: false, cmake-args: '--toolchain $GITHUB_WORKSPACE/CMake/i586-pc-msdosdjgpp.cmake'}
     steps:
       - name: Setup vcvars
@@ -126,12 +126,12 @@ jobs:
         run: |
           git clone https://github.com/vitasdk/vdpm
           cd vdpm
+          export VITASDK=$HOME/vitasdk
+          export VDPM_NONINTERACTIVE=1
           ./bootstrap-vitasdk.sh
-          export VITASDK=/usr/local/vitasdk
-          export PATH=$VITASDK/bin:$PATH
-          echo "VITASDK=/usr/local/vitasdk" >> $GITHUB_ENV
+          ./vdpm install taihen
+          echo "VITASDK=$VITASDK" >> $GITHUB_ENV
           echo "$VITASDK/bin" >> $GITHUB_PATH
-          ./install-all.sh
 
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
The Vita job has failed deterministically on every run since 2026-08-15 (e.g. #826). vitasdk reworked its tooling in [vdpm on 2026-08-14/15](https://github.com/vitasdk/vdpm/commits/master) — vdpm is now a pacman-based package manager — which broke the job several ways:

1. `bootstrap-vitasdk.sh` now stages its download via `mktemp` in the install prefix's **parent** directory, and `/usr/local` is not writable by the unprivileged runner user:
   ```
   mktemp: failed to create directory via template '/usr/local/.vitasdk-bootstrap.XXXXXXXX': Permission denied
   ```
2. With that fixed, `install-all.sh` stops at pacman's `:: Proceed with installation? [Y/n]` prompt and aborts on the runner's non-interactive stdin (fixable with `VDPM_NONINTERACTIVE=1`).
3. With *that* fixed, `install-all.sh` still fails: its package list references packages missing from the new repository (`error: target not found: Box2D`) — upstream's own script is currently broken against upstream's own repo.

The repo's last green CI predates the rework (2026-08-11).

Fix: install into `$HOME/vitasdk` (the new bootstrap honors `VITASDK` for the prefix — fully user-writable, no sudo) and replace `install-all.sh` with `vdpm install taihen` — the one package the build actually links (`taihen_stub` in miniwin). SDL3 and iniparser are fetched from source via FetchContent, so nothing else from the ~100-package set is used, and the job gets faster to boot. The toolchain path in the matrix moves accordingly; it is expanded in the Configure shell step like the DOS entry's `$GITHUB_WORKSPACE`.

This PR's own Vita job validates the fix.