### PR TITLE
Preserve framebuffer contents across render passes in the SDL3 GPU renderer

### DIFF
--- a/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
+++ b/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
@@ -736,12 +736,12 @@ void Direct3DRMSDL3GPURenderer::StartRenderPass(float r, float g, float b, bool 
 	SDL_GPUColorTargetInfo colorTargetInfo = {};
 	colorTargetInfo.texture = m_transferTexture;
 	colorTargetInfo.clear_color = {r, g, b, 1.0f};
-	colorTargetInfo.load_op = clear ? SDL_GPU_LOADOP_CLEAR : SDL_GPU_LOADOP_DONT_CARE;
+	colorTargetInfo.load_op = clear ? SDL_GPU_LOADOP_CLEAR : SDL_GPU_LOADOP_LOAD;
 
 	SDL_GPUDepthStencilTargetInfo depthStencilTargetInfo = {};
 	depthStencilTargetInfo.texture = m_depthTexture;
 	depthStencilTargetInfo.clear_depth = 0.0f;
-	depthStencilTargetInfo.load_op = clear ? SDL_GPU_LOADOP_CLEAR : SDL_GPU_LOADOP_DONT_CARE;
+	depthStencilTargetInfo.load_op = clear ? SDL_GPU_LOADOP_CLEAR : SDL_GPU_LOADOP_LOAD;
 	depthStencilTargetInfo.store_op = SDL_GPU_STOREOP_STORE;
 
 	m_renderPass = SDL_BeginGPURenderPass(m_cmdbuf, &colorTargetInfo, 1, &depthStencilTargetInfo);


### PR DESCRIPTION
Fixes #553

The game's 2D compositing model assumes a persistent framebuffer: the mosaic transition draws only each tick's newly revealed blocks (a color-keyed 64×48 surface scaled fullscreen), the credits draw only the text quads with no per-frame clear, and both rely on everything else surviving from the previous frame. `Direct3DRMSDL3GPURenderer::StartRenderPass` used `SDL_GPU_LOADOP_DONT_CARE` for the color and depth targets whenever it wasn't clearing, which makes the previous contents undefined at the start of every such pass.

On immediate-mode desktop GPUs "don't care" resolves to "old contents still there," so the bug stayed invisible on Windows/Linux. Metal on Apple GPUs is tile-based: `MTLLoadActionDontCare` skips tile-memory initialization and the pass then *stores the garbage back*, actively overwriting every pixel the pass didn't draw — different garbage per tile per frame, hence the flicker. It also corrupted the mosaic's initial screen sampling, since the `Download` path opens and closes an empty pass before reading the framebuffer.

The fix uses `SDL_GPU_LOADOP_LOAD` when not clearing. Normal 3D frames always begin with a `Clear` (`LOADOP_CLEAR`), so gameplay rendering is unchanged. The remaining `DONT_CARE` in `Flip()`'s swapchain blit is safe because the blit covers the full drawable.

### Verification

Reproduced natively on macOS (Apple Silicon, SDL3 GPU HAL) by instrumenting `Flip()` to dump every presented frame and auto-triggering a mosaic transition in the Infocenter:

- **Before:** the 16 transition frames show mosaic blocks over black, speckle-corrupted garbage that changes every frame — matching the issue's video.
- **After:** classic progressive pixelation over the fully retained scene; the 3D scene renders normally.

As a negative control, a transition fired while the fullscreen intro movie was still playing showed no flicker even on the broken build (the movie repaints every pixel each frame), confirming the failure is specifically the loss of retained framebuffer contents.
