### PR TITLE
Tolerate unreadable directories when indexing game files (#813)

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -1530,6 +1530,7 @@ MxResult IsleApp::VerifyFilesystem()
 	for (const char* file : g_files) {
 		const char* searchPaths[] = {".", m_hdPath, m_cdPath};
 		bool found = false;
+		MxString attempts;
 
 		for (const char* base : searchPaths) {
 			MxString path(base);
@@ -1540,6 +1541,12 @@ MxResult IsleApp::VerifyFilesystem()
 				found = true;
 				break;
 			}
+
+			attempts += "\n";
+			attempts += path.GetData();
+			attempts += " (";
+			attempts += SDL_GetError();
+			attempts += ")";
 		}
 
 		if (!found) {
@@ -1548,11 +1555,12 @@ MxResult IsleApp::VerifyFilesystem()
 				buffer,
 				sizeof(buffer),
 				"\"LEGO® Island\" failed to start.\nPlease make sure the file %s is located in either diskpath or "
-				"cdpath.\nSDL error: %s",
+				"cdpath.%s",
 				file,
-				SDL_GetError()
+				attempts.GetData()
 			);
 
+			SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", buffer);
 			Any_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "LEGO® Island Error", buffer, NULL);
 			return FAILURE;
 		}

--- a/LEGO1/omni/src/main/mxmain.cpp
+++ b/LEGO1/omni/src/main/mxmain.cpp
@@ -440,25 +440,51 @@ void MxOmni::Resume()
 	}
 }
 
+static SDL_EnumerationResult SDLCALL CollectDirectoryEntries(void* p_userdata, const char*, const char* p_fname)
+{
+	static_cast<vector<MxString>*>(p_userdata)->emplace_back(p_fname);
+	return SDL_ENUM_CONTINUE;
+}
+
 vector<MxString> MxOmni::GlobIsleFiles(const MxString& p_path)
 {
-	int count;
-	char** files = SDL_GlobDirectory(p_path.GetData(), NULL, 0, &count);
 	vector<MxString> result;
+	vector<MxString> entries;
 
-	if (files == NULL) {
+	if (!SDL_EnumerateDirectory(p_path.GetData(), CollectDirectoryEntries, &entries)) {
 		SDL_Log("Error enumerating files for path %s (%s)", p_path.GetData(), SDL_GetError());
 		return result;
 	}
 
-	for (int i = 0; i < count; i++) {
-		if (!SDL_strncasecmp(files[i], "lego", 4)) {
-			result.emplace_back(files[i]);
+	vector<MxString> pending;
+	for (const MxString& entry : entries) {
+		if (!SDL_strncasecmp(entry.GetData(), "lego", 4)) {
+			pending.push_back(entry);
 		}
 	}
 
-	SDL_Log("Found %d game files in %s", count, p_path.GetData());
+	while (!pending.empty()) {
+		MxString relative = pending.back();
+		pending.pop_back();
+		result.push_back(relative);
 
-	SDL_free(files);
+		MxString absolute = p_path + "/" + relative.GetData();
+		SDL_PathInfo info;
+		if (!SDL_GetPathInfo(absolute.GetData(), &info) || info.type != SDL_PATHTYPE_DIRECTORY) {
+			continue;
+		}
+
+		vector<MxString> children;
+		if (!SDL_EnumerateDirectory(absolute.GetData(), CollectDirectoryEntries, &children)) {
+			SDL_Log("Error enumerating files for path %s (%s)", absolute.GetData(), SDL_GetError());
+			continue;
+		}
+
+		for (const MxString& child : children) {
+			pending.push_back(relative + "/" + child.GetData());
+		}
+	}
+
+	SDL_Log("Found %d game files in %s", (int) result.size(), p_path.GetData());
 	return result;
 }


### PR DESCRIPTION
Reproduced the "LEGO Island failed to start" reports from #813 on an Android 13 emulator (arm64, `google_apis` image) and root-caused the internal-storage failure mode.

### Root cause

`MxOmni::GlobIsleFiles` builds the case-mapping file index with `SDL_GlobDirectory`, which is all-or-nothing: if any subdirectory under diskpath can be stat'ed but not opened, SDL abandons the entire enumeration and returns `NULL`. One unopenable directory anywhere under `files/` empties the index, `MxString::MapPathToFilesystem` silently becomes a no-op, and `VerifyFilesystem` ends up doing a literal, case-sensitive stat of `/LEGO/Scripts/CREDITS.SI`. A `Lego/…` layout (as in the reporters' directory trees) then fails with exactly the dialog from the issue, "No such file or directory" included — even though every game file is present and readable.

The trigger is practically Android-only: getting files into `Android/data/<pkg>/files` requires privileged intermediaries (MTP from a PC, Shizuku/shell-uid file managers, adb), which can leave entries with foreign ownership or SELinux labels that the app can list but not open. Verified concretely on the emulator: adb-pushed files produce `avc: denied` plus the exact reported dialog, and a single `root:root` mode-0700 directory under `files/` produces `Error enumerating files … Permission denied` followed by the same startup failure. Windows never hits this (the index is unused there and NTFS is case-insensitive), and macOS/Linux desktops don't either (case-insensitive APFS default; self-copied files can't be unopenable by their owner).

### Fix

- `GlobIsleFiles` walks the tree itself with `SDL_EnumerateDirectory`, logging and skipping unreadable subtrees instead of discarding everything, and only descends into `lego*`-prefixed top-level entries, so unrelated directories can no longer poison the index. The index format is unchanged (relative `/`-separated paths, `lego*`-filtered, files and directories), so healthy installs behave identically on all platforms.
- The `VerifyFilesystem` failure dialog and log now list every attempted path with its per-path error instead of one stale `SDL_GetError()` result, making future reports self-diagnosing.

### Verification

| Scenario | Before | After |
|---|---|---|
| Android 13 emulator, `Lego/` layout + unopenable subdir in `files/` | glob aborts, startup fails with the issue's dialog | 58 files indexed, game boots into the intro |
| Android 13, clean layout / MTP-style `media_rw` ownership | works | works |
| macOS native, normal case-insensitive path | works | works |
| macOS native, case-sensitive APFS volume + unreadable dir | glob aborts, startup fails | 58 files indexed, game starts |

Not addressed here: files placed on a physical SD card's `Android/data/...` are still never found, since only `SDL_GetAndroidExternalStoragePath()` (primary external storage) is consulted — that part of #813 (the AYN THOR SD-card attempts) needs a separate decision.
