### PR TITLE
Fix SDL3 GPU depth artifacts on geometry close to the camera

### DIFF
--- a/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
+++ b/miniwin/src/d3drm/backends/sdl3gpu/renderer.cpp
@@ -400,6 +400,18 @@ void Direct3DRMSDL3GPURenderer::SetProjection(const D3DRMMATRIX4D& projection, D
 	m_front = front;
 	m_back = back;
 	memcpy(&m_projection, projection, sizeof(D3DRMMATRIX4D));
+
+	// The fragment shader writes 1 / clip.w to SV_Depth. Scale the clip-space output so that
+	// this becomes front / viewZ, which stays within SV_Depth's [0, 1] clamp range for the
+	// entire [front, back] frustum instead of saturating at 1.0 for geometry closer than one
+	// world unit. Uniformly scaling all four clip components leaves the NDC unchanged.
+	if (front > 0.0f) {
+		for (int row = 0; row < 4; ++row) {
+			for (int col = 0; col < 4; ++col) {
+				m_projection[row][col] /= front;
+			}
+		}
+	}
 }
 
 void Direct3DRMSDL3GPURenderer::WaitForPendingUpload()


### PR DESCRIPTION
Fixes #282

## Root cause

The SDL3 GPU fragment shader implements w-buffering by writing `SV_Depth = input.Position.w`. In the fragment stage, `SV_Position.w` holds **1 / clip.w = 1 / viewZ**, so the depth buffer holds a reversed hyperbolic depth (near = large, far = small) — which is why the pipeline correctly uses `SDL_GPU_COMPAREOP_GREATER` with `clear_depth = 0` (#260).

However, `1 / viewZ > 1.0` for **any geometry closer than 1.0 world units to the camera**, and a fragment-shader depth output is clamped to the viewport depth range `[0, 1]` (D3D12/Metal clamp; Vulkan makes out-of-range values undefined without `VK_EXT_depth_range_unrestricted`). Every fragment within 1 unit of the camera therefore writes the same depth `1.0`, the strict `GREATER` test fails for all subsequent fragments at those pixels, and depth resolution degenerates to "first drawn wins". That is exactly the artifact in the issue screenshots: during close-up cutscenes (pizza delivery gag, "All's quiet on the eastern side of the island"), a minifig's own parts render in submission order — neck brick over the face, hat through the head — and farther scenery pokes through near geometry. The rest of the scene is unaffected, which is why it only shows up close. It affects every SDL GPU backend (Vulkan/D3D12/Metal), not just one platform.

## Fix

Uniformly scale the projection matrix by `1 / front` in `SetProjection`. Scaling all four clip components leaves the NDC (and thus rasterization, clipping and interpolation) unchanged, but the fragment stage now sees `1 / clip.w = front / viewZ`, which spans `(front/back, 1]` across the whole frustum — always inside the clamp range, still reversed and hyperbolic, so `GREATER` + `clear_depth = 0` remain correct and no shader change or regeneration is needed.

## Verification (native macOS, Metal)

- Reproduced deterministically by parking the camera 0.6 units from Mama during the pizzeria gag: her bonnet and neck brick rendered through her head, background objects punched through her torso — matching all three screenshots in #282.
- With the fix, the same viewpoint renders with correct occlusion, and matches an OpenGL ES 3.0 reference capture of the same scene.
- Regression check: full-scene captures at the pizzeria before/after the fix differ only in the artifact regions; a broken-vs-GLES3 pixel diff of a normal street view was already near-zero (104/786k pixels) and stays that way with the fix.
- Runtime-verified the depth math: logged `viewZ → ndcZ` confirms NDC depth increases with distance while the written `SV_Depth` decreases, saturating at 1.0 inside 1 unit without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E55aR6NurCUmzJZb4PMdCx