### PR TITLE
Fix list corruption in MxDSObjectList::FindInternal

### DIFF
--- a/LEGO1/omni/src/action/mxdsobject.cpp
+++ b/LEGO1/omni/src/action/mxdsobject.cpp
@@ -180,6 +180,7 @@ MxDSObject* MxDSObjectList::FindInternal(MxDSObject* p_action, MxBool p_delete)
 	// DECOMP ALPHA 0x1008b99d ?
 
 	MxDSObject* found = NULL;
+	iterator foundIt;
 
 #ifdef COMPAT_MODE
 	iterator it;
@@ -191,6 +192,7 @@ MxDSObject* MxDSObjectList::FindInternal(MxDSObject* p_action, MxBool p_delete)
 			if (p_action->GetUnknown24() == -2 || p_action->GetUnknown24() == -3 ||
 				p_action->GetUnknown24() == (*it)->GetUnknown24()) {
 				found = *it;
+				foundIt = it;
 				if (p_action->GetUnknown24() != -3) {
 					break;
 				}
@@ -199,7 +201,7 @@ MxDSObject* MxDSObjectList::FindInternal(MxDSObject* p_action, MxBool p_delete)
 	}
 
 	if (p_delete && found != NULL) {
-		erase(it);
+		erase(foundIt);
 	}
 
 	return found;


### PR DESCRIPTION
Hardening, not a crash fix: with `unknown24 == -3`, `FindInternal` deliberately scans the whole list for the last match, so the loop iterator sits at `end()` after the loop — and the erase would erase `end()`, which is UB on `std::list`. Unreachable with current callers (the only `-3` writer wraps a non-deleting `Find` and restores the value immediately); the change tracks the found node's iterator and erases that instead, so behavior is identical on every reachable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)