### PR TITLE
Guard PutFrame against a presenter with no surface and no bitmap

### DIFF
--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -8,6 +8,7 @@
 #include "mxutilities.h"
 #include "mxvideomanager.h"
 
+#include <SDL3/SDL_error.h>
 #include <SDL3/SDL_log.h>
 #include <assert.h>
 #ifdef MINIWIN
@@ -716,6 +717,7 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 	ddsd.dwSize = sizeof(ddsd);
 
 	if (draw->GetDisplayMode(&ddsd)) {
+		SDL_Log("MxDisplaySurface::VTable0x44: GetDisplayMode failed");
 		return NULL;
 	}
 
@@ -748,6 +750,9 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 		else {
 			surface = NULL;
 		}
+		if (!surface) {
+			SDL_Log("MxDisplaySurface::VTable0x44: CreateSurface failed: %s", SDL_GetError());
+		}
 	}
 
 	if (surface) {
@@ -778,6 +783,7 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 		ddsd.dwSize = sizeof(ddsd);
 
 		if (surface->Lock(NULL, &ddsd, DDLOCK_WAIT | DDLOCK_WRITEONLY, 0) != DD_OK) {
+			SDL_Log("MxDisplaySurface::VTable0x44: Lock failed: %s", SDL_GetError());
 			surface->Release();
 			surface = NULL;
 		}

--- a/LEGO1/omni/src/video/mxdisplaysurface.cpp
+++ b/LEGO1/omni/src/video/mxdisplaysurface.cpp
@@ -751,7 +751,7 @@ LPDIRECTDRAWSURFACE MxDisplaySurface::VTable0x44(
 			surface = NULL;
 		}
 		if (!surface) {
-			SDL_Log("MxDisplaySurface::VTable0x44: CreateSurface failed: %s", SDL_GetError());
+			SDL_Log("MxDisplaySurface::VTable0x44: CreateSurface failed");
 		}
 	}
 

--- a/LEGO1/omni/src/video/mxvideopresenter.cpp
+++ b/LEGO1/omni/src/video/mxvideopresenter.cpp
@@ -219,8 +219,6 @@ inline MxS32 MxVideoPresenter::PrepareRects(RECT& p_rectDest, RECT& p_rectSrc)
 void MxVideoPresenter::PutFrame()
 {
 	if (!m_surface && !m_frameBitmap) {
-		// Neither a surface nor a decoded frame exists; every branch below
-		// would dereference one of them.
 		return;
 	}
 

--- a/LEGO1/omni/src/video/mxvideopresenter.cpp
+++ b/LEGO1/omni/src/video/mxvideopresenter.cpp
@@ -218,6 +218,12 @@ inline MxS32 MxVideoPresenter::PrepareRects(RECT& p_rectDest, RECT& p_rectSrc)
 // FUNCTION: LEGO1 0x100b2a70
 void MxVideoPresenter::PutFrame()
 {
+	if (!m_surface && !m_frameBitmap) {
+		// Neither a surface nor a decoded frame exists; every branch below
+		// would dereference one of them.
+		return;
+	}
+
 	MxDisplaySurface* displaySurface = MVideoManager()->GetDisplaySurface();
 	MxRegion* region = MVideoManager()->GetRegion();
 	MxRect32 rect(MxPoint32(0, 0), MxSize32(GetWidth(), GetHeight()));


### PR DESCRIPTION
`MxDisplaySurface::VTable0x44` can return NULL (GetDisplayMode, Lock, or allocation failure), and `MxStillPresenter::LoadFrame` frees `m_frameBitmap` regardless of that outcome — so a presenter can end up with neither a surface nor a decoded frame, and every branch of `MxVideoPresenter::PutFrame` then dereferences one of them. Skip the frame in that state, and log the reason on `VTable0x44`'s three failure paths, which previously failed silently into exactly that crash.

(Originally this PR also cleared the display-mode masks before the 8-bit surface requests and logged rejections in `DirectDrawImpl::CreateSurface` — dropped per review: SDL3 maps any bpp=8 mask combination to `INDEX8`, so those paths are unreachable in this tree. The failure I chased was my SDL2-subset shim keeping SDL2's stricter mask mapping; fixing the shim to match SDL3's semantics is the real cure on my side.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)