### PR TITLE
Guard two NULL dereferences reachable on slow machines

### DIFF
--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -2595,6 +2595,12 @@ MxBool LegoAnimationManager::FUN_10064120(LegoLocation::Boundary* p_boundary, Mx
 		}
 	}
 
+	if (local50 == NULL) {
+		// No edge faces the actor's direction (possible while the actor's
+		// orientation is still degenerate right after spawning).
+		return FALSE;
+	}
+
 	e = local50;
 	do {
 		e = (LegoOrientedEdge*) e->GetCounterclockwiseEdge(*boundary);

--- a/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
+++ b/LEGO1/lego/legoomni/src/common/legoanimationmanager.cpp
@@ -2596,8 +2596,6 @@ MxBool LegoAnimationManager::FUN_10064120(LegoLocation::Boundary* p_boundary, Mx
 	}
 
 	if (local50 == NULL) {
-		// No edge faces the actor's direction (possible while the actor's
-		// orientation is still degenerate right after spawning).
 		return FALSE;
 	}
 

--- a/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
@@ -586,9 +586,6 @@ MxResult RegistrationBook::Tickle()
 				}
 			}
 			else {
-				// The three surfaces stream in separately; blink only
-				// once all of them exist (slow machines can tickle in
-				// between).
 				CreateSurface();
 			}
 

--- a/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/registrationbook.cpp
@@ -573,7 +573,7 @@ MxResult RegistrationBook::Tickle()
 		if (g_checkboxBlinkTimer + 500 <= time) {
 			g_checkboxBlinkTimer = time;
 
-			if (m_checkboxHilite) {
+			if (m_checkboxHilite && m_checkboxSurface && m_checkboxNormal) {
 				DDBLTFX op;
 				op.dwSize = sizeof(op);
 				op.dwROP = SRCCOPY;
@@ -586,6 +586,9 @@ MxResult RegistrationBook::Tickle()
 				}
 			}
 			else {
+				// The three surfaces stream in separately; blink only
+				// once all of them exist (slow machines can tickle in
+				// between).
 				CreateSurface();
 			}
 


### PR DESCRIPTION
Two crashes we hit while testing under CPU emulation (QEMU PPC, Mac OS X Tiger guest), where streaming and tickle timing reach states fast machines skip past:

**RegistrationBook::Tickle** — the checkbox blink starts once `m_checkboxHilite` exists, but `CreateSurface` can return with only some of the three surfaces resolved while their presenters are still streaming in; the blink then calls `Blt` through a NULL `m_checkboxSurface`/`m_checkboxNormal`. Blink only when all three exist and keep retrying `CreateSurface` until then.

**LegoAnimationManager::FUN_10064120** — the walk over the boundary's edges picks the edge whose face normal best matches the user actor's direction, then iterates counterclockwise from it. When no edge has a positive dot product — reachable while the actor's orientation is still degenerate right after spawning into a world — the walk started from NULL. Return FALSE like the function's other precondition checks.

Both are timing windows measured in microseconds on period hardware, but they widen into reliable crashes under emulation, and the guards are correct regardless of speed.

When I get on my real Power Mac, we'll see what's up as QEMU running this pretty slow, but the facts? It sort of works.