### PR TITLE
Make the SDL GPU and software renderer backends optional

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -1006,7 +1006,8 @@ MxResult IsleApp::SetupWindow()
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, g_targetHeight);
 	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_FULLSCREEN_BOOLEAN, m_fullScreen);
 	SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, WINDOW_TITLE);
-#if defined(MINIWIN) && !defined(__3DS__) && !defined(WINDOWS_STORE) && !defined(__vita__) && !defined(__DJGPP__)
+#if defined(MINIWIN) && (defined(USE_OPENGL1) || defined(USE_OPENGLES2) || defined(USE_OPENGLES3)) &&                  \
+	!defined(__3DS__) && !defined(WINDOWS_STORE) && !defined(__vita__) && !defined(__DJGPP__)
 	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_OPENGL_BOOLEAN, true);
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);

--- a/miniwin/CMakeLists.txt
+++ b/miniwin/CMakeLists.txt
@@ -27,8 +27,14 @@ target_compile_definitions(miniwin PRIVATE
     $<$<CONFIG:Debug>:DEBUG>
 )
 
-list(APPEND GRAPHICS_BACKENDS USE_SOFTWARE_RENDER)
-list(APPEND GRAPHICS_BACKENDS USE_SDL_GPU)
+option(ISLE_RENDERER_SOFTWARE "Build the software (SDL_Renderer) backend" ON)
+option(ISLE_RENDERER_SDLGPU "Build the SDL GPU backend" ON)
+if(ISLE_RENDERER_SOFTWARE)
+  list(APPEND GRAPHICS_BACKENDS USE_SOFTWARE_RENDER)
+endif()
+if(ISLE_RENDERER_SDLGPU)
+  list(APPEND GRAPHICS_BACKENDS USE_SDL_GPU)
+endif()
 
 if(NOT (VITA OR WINDOWS_STORE))
   find_package(OpenGL)


### PR DESCRIPTION
Two new CMake options, `ISLE_RENDERER_SDLGPU` and `ISLE_RENDERER_SOFTWARE` (both ON by default, so existing builds are unchanged), let a platform without SDL_GPU or SDL_Renderer support build the remaining backends. Alongside that, the app only requests an OpenGL-capable window when a GL backend (opengl1, GLES2, or GLES3) is actually compiled in, so GL-less and headless builds (dummy video driver) can create their window.

Behavior note: for an existing MINIWIN build where `find_package(OpenGL)` and both GLES probes fail, this does change behavior — the window is no longer requested as OpenGL-capable where it previously was. That's the intent: such a build has no backend that could use the GL context.

Context: we're porting to big-endian PowerPC Mac OS X Tiger through an SDL3-subset compatibility layer over SDL 2.0.3, which has no SDL_GPU and no usable SDL_Renderer path — these options are what let the opengl1 + paletted backends build there, and they also enable headless runs under the dummy video driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)