### PR TITLE
Use the vdpm client the Vita bootstrap installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           export VITASDK=$HOME/vitasdk
           export VDPM_NONINTERACTIVE=1
           ./bootstrap-vitasdk.sh
-          ./vdpm install taihen
+          "$VITASDK/bin/vdpm" install taihen
           echo "VITASDK=$VITASDK" >> $GITHUB_ENV
           echo "$VITASDK/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
The Vita job has been failing again since 2026-08-21, aborting in `Setup vitasdk` before the checkout even happens:

```
VitaSDK installed at /home/runner/vitasdk
vdpm: package client is not executable: /home/runner/vitasdk/bin/pacman
##[error]Process completed with exit code 1
```

vitasdk/vdpm commit `e5c242d` ("pacman: install off PATH, at libexec/vdpm") moved the pacman binary from `$VITASDK/bin/pacman` to `$VITASDK/libexec/vdpm/pacman`. It updated the C client that the bootstrap installs as `$VITASDK/bin/vdpm`:

```c
/* src/vdpm.c:53 */
#define PACKAGE_CLIENT "libexec/vdpm/pacman"
```

but not the legacy bash wrapper still sitting in the repo root, which is what the job invoked as `./vdpm`:

```bash
# vdpm:38
pacman=${VDPM_PACMAN:-$VITASDK/bin/pacman}
[[ -x $pacman ]] || die "package client is not executable: $pacman"
```

The `vdpm:` prefix in the CI error is that script's own `die()`; the C client would have named the `libexec` path instead, so the message identifies which one ran. Upstream's README now documents only the installed client (`vdpm install zlib sdl2`) and uses the checkout for `bootstrap-vitasdk.sh` alone — the bash wrapper is superseded but still shipped.

Fix: call the client the bootstrap installs. It resolves `libexec/vdpm/pacman` and honors `VDPM_NONINTERACTIVE` identically (`src/vdpm.c:1035`). The path is spelled out rather than relying on `PATH` because `$GITHUB_PATH` only affects subsequent steps.

Pinning the vdpm checkout to a tag would not have helped: `vdpm` is byte-identical between `v0.1.4` and `main`, so the wrapper is broken at the tag too.

Verified locally against a real 2026.08 SDK (darwin/arm64): the current step reproduces the CI error verbatim; the installed layout has no `bin/pacman` and does have `libexec/vdpm/pacman`; `"$VITASDK/bin/vdpm" install taihen` succeeds and lands `arm-vita-eabi/lib/libtaihen_stub.a`, which is what `miniwin/CMakeLists.txt:106` links; and `cmake --toolchain $VITASDK/share/vita.toolchain.cmake` with the job's flag set configures cleanly. A full Vita build is not reproducible on a macOS host (the nested `psp2cxml-tool` host build inherits `-Wl,-q`, which Apple's `ld` rejects), so this PR's own Vita job is the real check.

Worth reporting upstream separately: the repo-root bash `vdpm` should be deleted or repointed at `libexec/vdpm/pacman`.
