### PR TITLE
Delete vehicle actors still parked in Act1State when the state is destroyed

### DIFF
--- a/LEGO1/lego/legoomni/include/isle.h
+++ b/LEGO1/lego/legoomni/include/isle.h
@@ -51,6 +51,7 @@ public:
 	};
 
 	Act1State();
+	~Act1State() override;
 
 	// FUNCTION: LEGO1 0x100338a0
 	// FUNCTION: BETA10 0x10036040

--- a/LEGO1/lego/legoomni/src/worlds/isle.cpp
+++ b/LEGO1/lego/legoomni/src/worlds/isle.cpp
@@ -1350,6 +1350,11 @@ Act1State::Act1State()
 	Reset();
 }
 
+Act1State::~Act1State()
+{
+	Reset();
+}
+
 // FUNCTION: LEGO1 0x10033ac0
 // FUNCTION: BETA10 0x1003524f
 MxResult Act1State::Serialize(LegoStorage* p_storage)


### PR DESCRIPTION
Fixes #119.

## Root cause

The `~ViewLODList(): m_refCount == 0` assertion on shutdown is the canary for leaked `LegoROI`s: every `ViewROI` holds a reference on its `ViewLODList`, so a ROI that is never deleted keeps its lists alive, and `~ViewLODListManager`'s force-delete then trips the assert. The leaked ROIs are the act 1 vehicles (`Helicopter`/`Jetski`/`DuneBuggy`/`RaceCar`).

These actors deliberately survive world switches by being detached from every world and parked in `Act1State`'s raw pointers:

- `Isle::Enable(FALSE)` → `Act1State::RemoveActors()` removes them from the Isle world (`RemoveActor` + `RemoveVehicle`) and stores them in `m_helicopter`/`m_jetski`/`m_dunebuggy`/`m_racecar`.
- `RegistrationBook::HandlePathStruct()` does the same after `LoadVehicles()` starts them in the registration book when a loaded save has vehicle planes present.

While parked there, `Act1State` is the sole owner. `Act1State::PlaceActors()` hands them back to the Isle world and nulls the pointers, and `Act1State::Reset()` deletes them — so every runtime path is balanced (`LegoGameState::DeleteState()` runs `Reset()`). The one hole is shutdown: `~LegoGameState` deletes each state with a plain `delete`, and `Act1State` has no destructor, so vehicles still parked in the state leak — along with their ROIs and `ViewLODList` references.

This explains all the observations in the thread:

- It only happens "sometimes": you need a copter/jetski/dunebuggy/racecar to be in the parked state at exit.
- Loading a save via the blue book triggers it without ever entering the island (the save's vehicles are started and immediately parked in the registration book), while launching and exiting immediately stays clean.
- The racecar-build → Infocenter → green-brick-exit repro is the `Isle::Enable(FALSE)` flavor of the same thing.
- `m_refCount` sticks at exactly 1: the one reference held by each leaked child ROI.
- It's not a stray `delete` of a `ViewLODList` — it's a `Release()` that never happens because the ROI holding the reference is never destroyed. The assertion itself is sound and stays.

## Reproduction

Scripted the reported flow in a debug build (macOS arm64): boot to the Infocenter, switch to the registration book, load a save, start a vehicle actor the way `LoadVehicles()` does, return to the Infocenter, quit. Instrumented `~ViewLODListManager` to dump surviving lists and live ROIs:

```
live LegoROI name='chtrblad' parent='chptr'
live LegoROI name='chtrbody' parent='chptr'
live LegoROI name='chtrshld' parent='chptr'
live LegoROI name='chptr'
leaked ViewLODList 'chtrshld' refCount=1 size=3
leaked ViewLODList 'chtrbody' refCount=1 size=3
leaked ViewLODList 'chtrblad' refCount=1 size=3
Assertion failed: (m_refCount == 0), function ~ViewLODList, file viewlodlist.h, line 211.
```

## Fix

Give `Act1State` a destructor that runs `Reset()` — the state's own cleanup, which already deletes the parked vehicles (and the serialized vehicle textures, which leaked the same way). With the fix, the same repro exits cleanly with zero surviving `ViewLODList`s, and the baseline/no-vehicle flows are unchanged.

Deleting the vehicles at that point is safe: `LegoOmni::Destroy()` tears down the game state before the input, video, and character managers, so everything the vehicle destructors touch (`ControlManager()`, the 3D manager, `IslePathActor::Exit()`'s camera paths, which already null-check `CurrentWorld()`) is still alive — and it's the same code path `Reset()` already runs during gameplay via `DeleteState()`. When a vehicle was handed back to a world, the state's pointer is already NULL, so there is no double delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
