### PR TITLE
Add an in-app game file picker on Android; remove the title bar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -843,6 +843,7 @@ if (ISLE_BUILD_APP)
   if (ANDROID)
     target_sources(isle PRIVATE
             ISLE/android/config.cpp
+            ISLE/android/filepicker.cpp
     )
   endif()
   if(VITA)

--- a/ISLE/android/filepicker.cpp
+++ b/ISLE/android/filepicker.cpp
@@ -1,0 +1,175 @@
+#include "filepicker.h"
+
+#include <SDL3/SDL.h>
+#include <errno.h>
+#include <iniparser.h>
+#include <jni.h>
+#include <stdio.h>
+#include <string.h>
+
+struct FolderDialogResult {
+	SDL_Mutex* m_mutex;
+	bool m_done;
+	char* m_path;
+};
+
+static void SDLCALL OnFolderSelected(void* p_userdata, const char* const* p_filelist, int p_filter)
+{
+	FolderDialogResult* result = static_cast<FolderDialogResult*>(p_userdata);
+
+	SDL_LockMutex(result->m_mutex);
+	if (p_filelist && p_filelist[0]) {
+		result->m_path = SDL_strdup(p_filelist[0]);
+	}
+	else if (!p_filelist) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Folder dialog error: %s", SDL_GetError());
+	}
+	result->m_done = true;
+	SDL_UnlockMutex(result->m_mutex);
+}
+
+static char* ShowFolderDialog(SDL_Window* p_window)
+{
+	FolderDialogResult result = {SDL_CreateMutex(), false, NULL};
+	SDL_ShowOpenFolderDialog(OnFolderSelected, &result, p_window, NULL, false);
+
+	for (;;) {
+		SDL_PumpEvents();
+		SDL_LockMutex(result.m_mutex);
+		bool done = result.m_done;
+		SDL_UnlockMutex(result.m_mutex);
+		if (done) {
+			break;
+		}
+		SDL_Delay(100);
+	}
+
+	SDL_DestroyMutex(result.m_mutex);
+	return result.m_path;
+}
+
+static char* ImportGameFiles(const char* p_treeUri)
+{
+	JNIEnv* env = static_cast<JNIEnv*>(SDL_GetAndroidJNIEnv());
+	jobject activity = static_cast<jobject>(SDL_GetAndroidActivity());
+	char* importedRoot = NULL;
+
+	if (env && activity) {
+		jclass activityClass = env->GetObjectClass(activity);
+		jmethodID importGameFiles =
+			env->GetMethodID(activityClass, "importGameFiles", "(Ljava/lang/String;)Ljava/lang/String;");
+
+		if (importGameFiles) {
+			jstring treeUri = env->NewStringUTF(p_treeUri);
+			jstring destRoot = static_cast<jstring>(env->CallObjectMethod(activity, importGameFiles, treeUri));
+			if (env->ExceptionCheck()) {
+				env->ExceptionDescribe();
+				env->ExceptionClear();
+				destRoot = NULL;
+			}
+
+			if (destRoot) {
+				const char* utf = env->GetStringUTFChars(destRoot, NULL);
+				if (utf) {
+					importedRoot = SDL_strdup(utf);
+					env->ReleaseStringUTFChars(destRoot, utf);
+				}
+				env->DeleteLocalRef(destRoot);
+			}
+
+			env->DeleteLocalRef(treeUri);
+		}
+		else {
+			SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "IsleActivity.importGameFiles not found");
+			env->ExceptionClear();
+		}
+
+		env->DeleteLocalRef(activityClass);
+		env->DeleteLocalRef(activity);
+	}
+
+	return importedRoot;
+}
+
+static void UpdateConfigDiskPath(const char* p_iniPath, const char* p_diskPath)
+{
+	char* iniConfig;
+	if (p_iniPath) {
+		iniConfig = SDL_strdup(p_iniPath);
+	}
+	else {
+		SDL_asprintf(&iniConfig, "%s/isle.ini", SDL_GetAndroidExternalStoragePath());
+	}
+
+	dictionary* dict = iniparser_load(iniConfig);
+	if (dict) {
+		FILE* iniFP = fopen(iniConfig, "wb");
+		if (iniFP) {
+			iniparser_set(dict, "isle:diskpath", p_diskPath);
+			iniparser_dump_ini(dict, iniFP);
+			fclose(iniFP);
+			SDL_Log("Updated diskpath to '%s' in config at '%s'", p_diskPath, iniConfig);
+		}
+		else {
+			SDL_LogError(
+				SDL_LOG_CATEGORY_APPLICATION,
+				"Failed to write config at '%s': %s",
+				iniConfig,
+				strerror(errno)
+			);
+		}
+		iniparser_freedict(dict);
+	}
+	else {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load config at '%s'", iniConfig);
+	}
+
+	SDL_free(iniConfig);
+}
+
+bool Android_TryImportGameFiles(SDL_Window* p_window, const char* p_iniPath, char** p_hdPath)
+{
+	const SDL_MessageBoxButtonData buttons[] = {
+		{SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Select folder"},
+		{SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, "Cancel"},
+	};
+	const SDL_MessageBoxData messageBox = {
+		SDL_MESSAGEBOX_INFORMATION,
+		p_window,
+		"LEGO® Island",
+		"The game files could not be found or read.\n\n"
+		"If you have a copy of the LEGO® Island files on this device (in a regular folder such as Download), "
+		"you can select the folder containing them and they will be copied into this app's storage.",
+		SDL_arraysize(buttons),
+		buttons,
+		NULL
+	};
+
+	int button = 0;
+	if (!SDL_ShowMessageBox(&messageBox, &button) || button != 1) {
+		return false;
+	}
+
+	char* treeUri = ShowFolderDialog(p_window);
+	if (!treeUri) {
+		return false;
+	}
+
+	char* importedRoot = ImportGameFiles(treeUri);
+	SDL_free(treeUri);
+
+	if (!importedRoot) {
+		return false;
+	}
+
+	if (SDL_strcmp(importedRoot, *p_hdPath) != 0) {
+		SDL_free(*p_hdPath);
+		*p_hdPath = importedRoot;
+		UpdateConfigDiskPath(p_iniPath, importedRoot);
+	}
+	else {
+		SDL_free(importedRoot);
+	}
+
+	return true;
+}

--- a/ISLE/android/filepicker.h
+++ b/ISLE/android/filepicker.h
@@ -1,0 +1,12 @@
+#ifndef ANDROID_FILEPICKER_H
+#define ANDROID_FILEPICKER_H
+
+#include <SDL3/SDL_video.h>
+
+// Asks the user to select the folder containing the game files and imports them
+// into the app's storage. On success, *p_hdPath is updated to the directory the
+// files were imported into (freeing the previous value) and the new diskpath is
+// persisted to the config at p_iniPath (or the default location if NULL).
+bool Android_TryImportGameFiles(SDL_Window* p_window, const char* p_iniPath, char** p_hdPath);
+
+#endif // ANDROID_FILEPICKER_H

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -82,6 +82,7 @@
 
 #ifdef ANDROID
 #include "android/config.h"
+#include "android/filepicker.h"
 #endif
 
 #ifdef __vita__
@@ -1551,6 +1552,14 @@ MxResult IsleApp::VerifyFilesystem()
 		}
 
 		if (!found) {
+#ifdef ANDROID
+			if (Android_TryImportGameFiles(reinterpret_cast<SDL_Window*>(m_windowHandle), m_iniPath, &m_hdPath)) {
+				MxOmni::SetHD(m_hdPath);
+				MxOmni::SetCD(m_cdPath);
+				return VerifyFilesystem();
+			}
+#endif
+
 			char buffer[1024];
 			SDL_snprintf(
 				buffer,

--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -44,7 +44,7 @@ android {
         release {
             minifyEnabled true
             signingConfig = signingConfigs.getByName("release")
-//             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {

--- a/android-project/app/proguard-rules.pro
+++ b/android-project/app/proguard-rules.pro
@@ -1,0 +1,4 @@
+# Methods called from native code via JNI (see ISLE/android/filepicker.cpp)
+-keep class org.legoisland.isle.IsleActivity {
+    java.lang.String importGameFiles(java.lang.String);
+}

--- a/android-project/app/src/main/AndroidManifest.xml
+++ b/android-project/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
         tools:targetApi="31">
         <activity
             android:name="org.legoisland.isle.IsleActivity"
+            android:theme="@style/AppTheme"
             android:exported="true"
             android:configChanges="layoutDirection|locale|orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"
             android:preferMinimalPostProcessing="true"

--- a/android-project/app/src/main/java/org/legoisland/isle/IsleActivity.java
+++ b/android-project/app/src/main/java/org/legoisland/isle/IsleActivity.java
@@ -1,9 +1,176 @@
 package org.legoisland.isle;
 
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.DocumentsContract;
+import android.util.Log;
+import android.widget.Toast;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Locale;
+
 import org.libsdl.app.SDLActivity;
 
 public class IsleActivity extends SDLActivity {
+    private static final String TAG = "IsleActivity";
+
     protected String[] getLibraries() {
         return new String[] { "SDL3", "lego1", "isle" };
+    }
+
+    /**
+     * Called from native code (see ISLE/android/filepicker.cpp); kept by proguard-rules.pro.
+     * Copies the game files from the document tree selected by the user into the app's
+     * external files directory, so they are owned and readable by this app. Returns the
+     * root directory the files were imported into, or null on failure.
+     */
+    public String importGameFiles(String treeUri) {
+        try {
+            showToast("Copying game files. This may take a while...");
+
+            Uri tree = Uri.parse(treeUri);
+            ContentResolver resolver = getContentResolver();
+            String rootId = DocumentsContract.getTreeDocumentId(tree);
+            boolean bareGameRoot = !containsGameDirectory(resolver, tree, rootId);
+            File filesDir = getExternalFilesDir(null);
+
+            String destRoot = tryImport(resolver, tree, rootId, bareGameRoot, filesDir);
+            if (destRoot == null) {
+                // Unreadable leftovers (copied by a privileged intermediary with foreign
+                // ownership) can block the default location and cannot be deleted or
+                // renamed by this app; import into a fresh directory instead.
+                File fallback = new File(filesDir, "imported-" + System.currentTimeMillis());
+                destRoot = tryImport(resolver, tree, rootId, bareGameRoot, fallback);
+            }
+
+            showToast(destRoot != null ? "Game files copied" : "Copying game files failed");
+            return destRoot;
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to import game files from " + treeUri, e);
+            showToast("Copying game files failed");
+            return null;
+        }
+    }
+
+    private String tryImport(ContentResolver resolver, Uri tree, String rootId, boolean bareGameRoot, File root) {
+        File dest = bareGameRoot ? new File(root, "LEGO") : root;
+        if (copyDocumentTree(resolver, tree, rootId, dest)) {
+            return root.getAbsolutePath();
+        }
+        return null;
+    }
+
+    private boolean containsGameDirectory(ContentResolver resolver, Uri tree, String rootId) {
+        Uri children = DocumentsContract.buildChildDocumentsUriUsingTree(tree, rootId);
+        String[] columns = {
+            DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+            DocumentsContract.Document.COLUMN_MIME_TYPE
+        };
+
+        Cursor cursor = resolver.query(children, columns, null, null, null);
+        if (cursor == null) {
+            return false;
+        }
+
+        try {
+            while (cursor.moveToNext()) {
+                String name = cursor.getString(0);
+                String mime = cursor.getString(1);
+                if (name != null && DocumentsContract.Document.MIME_TYPE_DIR.equals(mime) &&
+                        name.toLowerCase(Locale.ROOT).startsWith("lego")) {
+                    return true;
+                }
+            }
+        } finally {
+            cursor.close();
+        }
+
+        return false;
+    }
+
+    private boolean copyDocumentTree(ContentResolver resolver, Uri tree, String docId, File dest) {
+        if (dest.exists() && (!dest.isDirectory() || dest.list() == null || !dest.canWrite())) {
+            // An unreadable leftover (e.g. copied by a privileged intermediary with foreign
+            // ownership) cannot be deleted by this app, but it can be renamed aside.
+            File moved = new File(dest.getParent(), dest.getName() + ".unreadable." + System.currentTimeMillis());
+            if (!dest.renameTo(moved)) {
+                Log.e(TAG, "Failed to move unreadable " + dest + " aside");
+                return false;
+            }
+            Log.w(TAG, "Moved unreadable " + dest + " aside to " + moved);
+        }
+
+        if (!dest.isDirectory() && !dest.mkdirs()) {
+            Log.e(TAG, "Failed to create directory " + dest);
+            return false;
+        }
+
+        Uri children = DocumentsContract.buildChildDocumentsUriUsingTree(tree, docId);
+        String[] columns = {
+            DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+            DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+            DocumentsContract.Document.COLUMN_MIME_TYPE
+        };
+
+        Cursor cursor = resolver.query(children, columns, null, null, null);
+        if (cursor == null) {
+            Log.e(TAG, "Failed to list children of " + docId);
+            return false;
+        }
+
+        boolean copied = true;
+        try {
+            while (cursor.moveToNext()) {
+                String childId = cursor.getString(0);
+                String name = cursor.getString(1);
+                String mime = cursor.getString(2);
+
+                if (name == null || name.startsWith(".")) {
+                    continue;
+                }
+
+                if (DocumentsContract.Document.MIME_TYPE_DIR.equals(mime)) {
+                    copied &= copyDocumentTree(resolver, tree, childId, new File(dest, name));
+                }
+                else {
+                    Uri document = DocumentsContract.buildDocumentUriUsingTree(tree, childId);
+                    copied &= copyDocumentFile(resolver, document, new File(dest, name));
+                }
+            }
+        } finally {
+            cursor.close();
+        }
+
+        return copied;
+    }
+
+    private boolean copyDocumentFile(ContentResolver resolver, Uri document, File dest) {
+        try (InputStream in = resolver.openInputStream(document);
+                OutputStream out = new FileOutputStream(dest)) {
+            if (in == null) {
+                Log.e(TAG, "Failed to open " + document);
+                return false;
+            }
+
+            byte[] buffer = new byte[1 << 16];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+
+            Log.i(TAG, "Copied " + document + " to " + dest);
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to copy " + document + " to " + dest, e);
+            return false;
+        }
+    }
+
+    private void showToast(final String message) {
+        runOnUiThread(() -> Toast.makeText(this, message, Toast.LENGTH_LONG).show());
     }
 }

--- a/android-project/app/src/main/res/values/styles.xml
+++ b/android-project/app/src/main/res/values/styles.xml
@@ -1,8 +1,11 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
+    <style name="AppTheme" parent="android:Theme.NoTitleBar">
+        <!-- Allow drawing under status & nav bars -->
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Reproduced both remaining Android reports on an Android 13 emulator (arm64, `google_apis` image) and root-caused them; this PR fixes both.

Fixes #813
Fixes #851

## #813 — game files present but invisible to the app

### Root cause

The remaining "failed to start" reports (after #830) come from game files that were copied into the app's own `Android/data/<pkg>/files` by a privileged intermediary that does not perform MediaProvider's owner fixup — the AYN THOR's MTP/file-manager stack in the reports, `adb push` as root in the repro. The files land on the lower filesystem with foreign ownership (e.g. `root:root`, mode 770). On Android 11+ an app reaches its own external-files dir through a pass-through bind mount of the raw lower filesystem, so plain kernel DAC applies: the app cannot traverse `files/LEGO` at all. Directory enumeration fails with `Permission denied` and stats of the children report `No such file or directory` — byte-for-byte the dialog in the issue — while the user's PC (which browses through the privileged MediaProvider view) happily lists every file. `restorecon` and `chown media_rw` do not help; only owner = app uid does, which is why regular PC-MTP copies work on most devices. The app cannot self-repair such a directory: it can't read it, can't delete it, and (verified live) even `rename()` of it is refused.

Also verified: the "app-debug works, app-release doesn't" observation from the thread is a red herring. The native libraries in the two continuous APKs are byte-identical (CI passes `-DCMAKE_BUILD_TYPE=Release` to both flavors), the manifests differ only in `debuggable`, and an A/B on identical broken file state fails identically in both. Switching flavors "fixes" it because the signature mismatch forces an uninstall, which wipes `Android/data`, and the subsequent re-copy happens to get sane ownership.

### Fix

When `VerifyFilesystem` fails on Android, the game now offers to locate the files instead of only erroring out:

- `ISLE/android/filepicker.cpp` (new): a message box offers "Select folder"; `SDL_ShowOpenFolderDialog` opens the system document-tree picker; the selected `content://` tree is handed to `IsleActivity.importGameFiles` via JNI; on success the new root is applied to diskpath and persisted to `isle.ini`, and `VerifyFilesystem` re-runs.
- `IsleActivity.importGameFiles` walks the selected tree with `DocumentsContract` (no new dependencies) and copies it into the app's external files dir, so the imported files are owned by the app by construction. SAF reads go through the privileged provider, so even sources the app itself couldn't read import fine. If the picked folder is the game root itself (contains `data`/`Scripts` rather than a `LEGO`-ish dir), it is imported as `files/LEGO`. Unusable leftover directories are renamed aside best-effort; when even that is refused (the reported state), the import falls back to a fresh `files/imported-<millis>` root and diskpath follows it.
- Release builds: the `proguardFiles` line in `app/build.gradle` was commented out, so R8 ran with only the AAR consumer rules; it is now enabled with a `proguard-rules.pro` keeping the JNI-called `importGameFiles`.

This also gives the SD-card placements from the original report a working path: pick the folder on the SD card once and the files are copied into internal app storage.

### Verification

| Scenario (Android 13 emulator) | Before | After |
|---|---|---|
| Foreign-owned (`root:root`) files under `files/LEGO` | exact dialog from the issue, both flavors | dialog offers picker → import falls back to `files/imported-*` → 58 files indexed → game boots into the intro |
| Restart after import | — | boots directly from persisted diskpath, no dialog |
| Cancel at the message box or picker | — | previous detailed error dialog, unchanged |
| Healthy install | works | works (import path never triggers) |
| R8 release build (`packageRelease`, signed) | — | same full flow, `importGameFiles` kept |

## #851 — title bar covering the top of the viewport

### Root cause

The manifest assigned no `android:theme` to `IsleActivity`, so the device-default theme applied — including a window decor title bar showing "LEGO®". SDL's immersive fullscreen only hides the *system* bars, never the activity's own decor, so the bar stayed on screen (SDL window 2340x948 on a 2340x1080 display in the repro; on the reporter's Samsung it overlays the viewport and eats the touches, hence the Info Center soft-lock). The `AppTheme` in `styles.xml` was a stale `Holo.Light.DarkActionBar` and referenced by nothing.

### Fix

Reference `@style/AppTheme` from the activity and align the theme with SDL3's own android-project template: parent `android:Theme.NoTitleBar` plus transparent status/navigation bar colors. Verified on the emulator: the bar is gone and the SDL window is the full 2340x1080.
