### PR TITLE
Render at native resolution on high-DPI displays

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -1006,6 +1006,9 @@ MxResult IsleApp::SetupWindow()
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, g_targetHeight);
 	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_FULLSCREEN_BOOLEAN, m_fullScreen);
 	SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, WINDOW_TITLE);
+#ifndef __EMSCRIPTEN__
+	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, true);
+#endif
 #if defined(MINIWIN) && (defined(USE_OPENGL1) || defined(USE_OPENGLES2) || defined(USE_OPENGLES3)) &&                  \
 	!defined(__3DS__) && !defined(WINDOWS_STORE) && !defined(__vita__) && !defined(__DJGPP__)
 	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_OPENGL_BOOLEAN, true);

--- a/miniwin/src/d3drm/d3drmdevice.cpp
+++ b/miniwin/src/d3drm/d3drmdevice.cpp
@@ -157,6 +157,7 @@ void Direct3DRMDevice2Impl::Resize()
 	m_windowWidth = 320; // We are on the lower screen
 	m_windowHeight = 240;
 #endif
+	SDL_Log("Render resolution: %dx%d", m_windowWidth, m_windowHeight);
 	m_viewportTransform = CalculateViewportTransform(m_virtualWidth, m_virtualHeight, m_windowWidth, m_windowHeight);
 	m_renderer->Resize(m_windowWidth, m_windowHeight, m_viewportTransform);
 	m_renderer->Clear(0, 0, 0);
@@ -171,20 +172,25 @@ void Direct3DRMDevice2Impl::Resize()
 
 bool Direct3DRMDevice2Impl::ConvertEventToRenderCoordinates(SDL_Event* event)
 {
+	float density = SDL_GetWindowPixelDensity(DDWindow);
+	if (density == 0.0f) {
+		density = 1.0f;
+	}
+
 	switch (event->type) {
 	case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED: {
 		Resize();
 		break;
 	}
 	case SDL_EVENT_MOUSE_MOTION: {
-		event->motion.x = (event->motion.x - m_viewportTransform.offsetX) / m_viewportTransform.scale;
-		event->motion.y = (event->motion.y - m_viewportTransform.offsetY) / m_viewportTransform.scale;
+		event->motion.x = (event->motion.x * density - m_viewportTransform.offsetX) / m_viewportTransform.scale;
+		event->motion.y = (event->motion.y * density - m_viewportTransform.offsetY) / m_viewportTransform.scale;
 		break;
 	}
 	case SDL_EVENT_MOUSE_BUTTON_DOWN:
 	case SDL_EVENT_MOUSE_BUTTON_UP: {
-		event->button.x = (event->button.x - m_viewportTransform.offsetX) / m_viewportTransform.scale;
-		event->button.y = (event->button.y - m_viewportTransform.offsetY) / m_viewportTransform.scale;
+		event->button.x = (event->button.x * density - m_viewportTransform.offsetX) / m_viewportTransform.scale;
+		event->button.y = (event->button.y * density - m_viewportTransform.offsetY) / m_viewportTransform.scale;
 		break;
 	}
 	case SDL_EVENT_FINGER_MOTION:
@@ -204,8 +210,13 @@ bool Direct3DRMDevice2Impl::ConvertEventToRenderCoordinates(SDL_Event* event)
 
 bool Direct3DRMDevice2Impl::ConvertRenderToWindowCoordinates(Sint32 inX, Sint32 inY, Sint32& outX, Sint32& outY)
 {
-	outX = static_cast<Sint32>(inX * m_viewportTransform.scale + m_viewportTransform.offsetX);
-	outY = static_cast<Sint32>(inY * m_viewportTransform.scale + m_viewportTransform.offsetY);
+	float density = SDL_GetWindowPixelDensity(DDWindow);
+	if (density == 0.0f) {
+		density = 1.0f;
+	}
+
+	outX = static_cast<Sint32>((inX * m_viewportTransform.scale + m_viewportTransform.offsetX) / density);
+	outY = static_cast<Sint32>((inY * m_viewportTransform.scale + m_viewportTransform.offsetY) / density);
 
 	return true;
 }


### PR DESCRIPTION
Fixes #846.

On Wayland (and macOS) with display scaling, SDL3 window sizes are in logical coordinates: a fullscreen window on a 2560x1600 display at 200% scaling gets a 1280x800 backing store that the compositor upscales, so the game really does render at a quarter of the native resolution. X11, Windows, and Android always deal in physical pixels, which is why this was never visible there.

The fix requests `SDL_WINDOW_HIGH_PIXEL_DENSITY` at window creation. The render pipeline already sizes itself from `SDL_GetWindowSizeInPixels()` and `SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED`, so it picks up the full-resolution backing store with no further changes. Mouse events, however, arrive in window coordinates while the viewport transform lives in pixel space, so `ConvertEventToRenderCoordinates` now scales event coordinates by `SDL_GetWindowPixelDensity()` (and `ConvertRenderToWindowCoordinates` divides by it for the joystick-driven cursor warp). Finger events are normalized and multiplied by the pixel size, so they were already correct. `Resize()` also logs the effective render resolution now, since the issue notes it's not obvious whether the game runs at full resolution.

Per SDL's high-DPI docs the pixel density is always 1.0 on Windows, X11, and Android, making this a no-op there. The flag is not set for Emscripten: the web port manages canvas resolution itself through `emscripten_enter_soft_fullscreen` with `EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_HIDEF`, which already multiplies by `devicePixelRatio`.

Tested:
- macOS built-in Retina display (2x): a 640x480 window now logs `Render resolution: 1280x960` (previously 640x480) and the game plays normally; on a 1x external monitor behavior is unchanged (density 1.0).
- Web build in headless Chrome with `--force-device-scale-factor=2` against the isle.pizza frontend, confirming Emscripten needs no change: "Original (640x480)" renders 640x480 as designed, and "Maximum" already renders at full native resolution (`Render resolution: 2168x1626` for a 1084x813 CSS canvas at DPR 2, and 1084x813 at DPR 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CVAycW6CZioD9CXSb1AS4