### PR TITLE
Initialize gamepad axis values in GetJoystickState

### DIFF
--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -192,7 +192,7 @@ MxResult LegoInputManager::GetJoystickState(MxU32* p_joystickX, MxU32* p_joystic
 		return FAILURE;
 	}
 
-	MxS16 xPos, yPos = 0;
+	MxS16 xPos = 0, yPos = 0;
 	for (const auto& [id, joystick] : m_joysticks) {
 		xPos = SDL_GetGamepadAxis(joystick.first, SDL_GAMEPAD_AXIS_LEFTX);
 		yPos = SDL_GetGamepadAxis(joystick.first, SDL_GAMEPAD_AXIS_LEFTY);


### PR DESCRIPTION
Fixes #654

`GetJoystickState` declared `MxS16 xPos, yPos = 0;`, initializing only `yPos`. When no physical gamepad is connected, the loop that assigns both values from `SDL_GetGamepadAxis` never executes, so `xPos` is read uninitialized. The `if (!xPos && !yPos)` fallback that feeds the touch virtual thumbstick (touch scheme 2, the default) then almost never engages, and the returned Y axis stays pinned to center — making movement impossible via touch.

This also explains why the same virtual gamepad works on the web port but not on iOS/native: WebAssembly locals are zero-initialized by spec, so the uninitialized read happens to yield 0 there, while on native ARM64 it reads whatever garbage is in the register/stack slot.