### PR TITLE
Enumerate the paletted software renderer before the RGB software renderer

### DIFF
--- a/miniwin/src/d3drm/d3drmrenderer.cpp
+++ b/miniwin/src/d3drm/d3drmrenderer.cpp
@@ -120,11 +120,11 @@ void Direct3DRMRenderer_EnumDevices(const IDirect3DMiniwin* d3d, LPD3DENUMDEVICE
 #ifdef USE_DIRECTX9
 	DirectX9Renderer_EnumDevice(cb, ctx);
 #endif
-#ifdef USE_SOFTWARE_RENDER
-	Direct3DRMSoftware_EnumDevice(cb, ctx);
-#endif
 #ifdef USE_PALETTE_SW_RENDER
 	Direct3DRMPaletteSW_EnumDevice(cb, ctx);
+#endif
+#ifdef USE_SOFTWARE_RENDER
+	Direct3DRMSoftware_EnumDevice(cb, ctx);
 #endif
 #ifdef USE_GLIDE
 	Direct3DRMGlide_EnumDevice(cb, ctx);


### PR DESCRIPTION
When no hardware-capable renderer is available, `LegoDeviceEnumerate::GetBestDevice` falls back to the *last* enumerated HEL device. Because the paletted software renderer was enumerated after the RGB software renderer, platforms without a working hardware backend ended up on the 8-bit paletted renderer and its palette-quantized output (grey-speckled terrain textures) instead of the full-color software renderer.

This affects iOS devices whose Metal GPU fails SDL_GPU's `MTLGPUFamilyApple3` requirement (A8 and older, e.g. the iPad mini 4 from #654) as well as the iOS simulator, where the paravirtualized Metal device also fails that check.

Enumerating the paletted renderer first makes the retail fallback logic land on the RGB software renderer. Platforms that only build the paletted renderer (DOS) are unaffected, and hardware-capable devices are unaffected since `GetBestDevice` returns the first hardware device regardless of order. Saved `3D Device ID` configs still resolve via the GUID fallback in `ParseDeviceName`.

Verified on the iOS 26.5 simulator: the game now selects "Miniwin Emulation" instead of "Miniwin Paletted Software", with visibly correct terrain colors.