### PR TITLE
Re-derive config paths on every launch on iOS

### DIFF
--- a/ISLE/ios/config.cpp
+++ b/ISLE/ios/config.cpp
@@ -22,4 +22,6 @@ void IOS_SetupDefaultConfigOverrides(dictionary* p_dictionary)
 
 	iniparser_set(p_dictionary, "isle:diskpath", documentFolder.GetData());
 	iniparser_set(p_dictionary, "isle:cdpath", documentFolder.GetData());
+	iniparser_set(p_dictionary, "isle:mediapath", SDL_GetBasePath());
+	iniparser_set(p_dictionary, "isle:savepath", SDL_GetUserFolder(SDL_FOLDER_DOCUMENTS));
 }

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -1275,6 +1275,12 @@ bool IsleApp::LoadConfig()
 #ifdef __EMSCRIPTEN__
 	Emscripten_SetupDefaultConfigOverrides(dict);
 #endif
+#ifdef IOS
+	// [library:config]
+	// iOS relocates both the app bundle and the data container on every app update,
+	// so absolute paths stored in the config go stale. Re-derive them on every launch.
+	IOS_SetupDefaultConfigOverrides(dict);
+#endif
 
 	MxOmni::SetHD((m_hdPath = SDL_strdup(iniparser_getstring(dict, "isle:diskpath", SDL_GetBasePath()))));
 	MxOmni::SetCD((m_cdPath = SDL_strdup(iniparser_getstring(dict, "isle:cdpath", MxOmni::GetCD()))));


### PR DESCRIPTION
iOS relocates both the app bundle and the data container (new UUIDs) on every app update or reinstall — and sideloading tools like SideStore re-sign and reinstall the app every 7 days. Since `isle.ini` stores absolute paths, `diskpath`/`cdpath`/`mediapath`/`savepath` all go stale on the first update after setup: the game data survives the migration, but the config points into the dead container, so startup fails with the missing-data-file dialog followed by the generic startup-failure dialog and an exit. Under LiveContainer/SideStore this presents as a crash, which is very likely the failure mode reported in #592.

Fix: apply the iOS config overrides unconditionally after the config is loaded (same pattern Emscripten already uses), so the paths are re-derived from the current container on every launch, and extend the override to cover `mediapath` and `savepath` (the bundle path changes on update too). User-visible settings are unaffected.

Reproduced and verified on the iOS 26.5 simulator: reinstalling the app migrates the container and leaves stale absolute paths in `isle.ini`; without this change the game fails to start, with it the paths heal and the game boots normally.