### PR TITLE
Fix up the iOS Info.plist

### DIFF
--- a/packaging/ios/isle/Info.plist.in
+++ b/packaging/ios/isle/Info.plist.in
@@ -26,20 +26,14 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>@MACOSX_BUNDLE_BUNDLE_VERSION@</string>
-	<key>UILaunchStoryboardName</key>
-	<string/>
-	<key>NSHighResolutionCapable</key>
-	<true/>
-	<key>CSResourcesFileMapped</key>
-	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
 	<key>LSRequires@MACOSX_BUNDLE_REQUIRED_PLATFORM@</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>@MACOSX_BUNDLE_COPYRIGHT@</string>
 	<key>SDL_FILESYSTEM_BASE_DIR_TYPE</key>
 	<string>resource</string>
-	<key>NSSupportsAutomaticGraphicsSwitching</key>
-	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
@@ -54,6 +48,8 @@
 		<integer>2</integer>
 	</array>
 	<key>UIRequiresFullScreen</key>
+	<true/>
+	<key>UIDesignRequiresCompatibility</key>
 	<true/>
 	<key>UIStatusBarHidden</key>
 	<true/>
@@ -71,6 +67,18 @@
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>SDLSceneConfiguration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SDLUIKitSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
 	</dict>
 	<key>CFBundleAllowMixedLocalizations</key>
 	<true/>
@@ -78,9 +86,5 @@
 	<string>public.app-category.games</string>
 	<key>DTPlatformName</key>
 	<string>iphoneos</string>
-	<key>UIFileSharingEnabled</key>
-	<true/>
-	<key>LSSupportsOpeningDocumentsInPlace</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
- Replace the empty `UILaunchStoryboardName` with a modern empty `UILaunchScreen` dictionary. The empty-string storyboard name caused a UIStoryboard assertion failure on every launch (visible in the device log) and left the app on UIKit's legacy launch path.
- Declare the `SDLSceneConfiguration` UIScene configuration with SDL3's `SDLUIKitSceneDelegate`, silencing UIKit's "Info.plist contained no UIScene configuration dictionary" warning and properly opting into the UIScene life cycle SDL3 expects.
- Add `UIDesignRequiresCompatibility` for the iPadOS 26 windowing transition (orientation locks are otherwise ignored for apps built against the iOS 26 SDK).
- Remove duplicated keys (`UIFileSharingEnabled`, `LSSupportsOpeningDocumentsInPlace`) and macOS-only keys (`NSHighResolutionCapable`, `CSResourcesFileMapped`, `NSSupportsAutomaticGraphicsSwitching`).

Verified on the iOS 26.5 simulator: the UIStoryboard assertion and scene warning are gone, the game boots and renders correctly, and on iPhone the landscape-only orientation is now properly enforced (interface comes up landscape). On the iPad simulator the new iPadOS windowing model still presents the app in the device's current orientation with correct letterboxing.