### PR TITLE
Skip the generic startup failure dialog when a specific error was already shown

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -107,6 +107,8 @@ MxU8 g_mousemoved = FALSE;
 // GLOBAL: ISLE 0x41003c
 MxS32 g_closed = FALSE;
 
+static MxBool g_startupErrorShown = FALSE;
+
 // GLOBAL: ISLE 0x410050
 MxS32 g_rmDisabled = FALSE;
 
@@ -408,13 +410,15 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char** argv)
 
 	// Create window
 	if (g_isle->SetupWindow() != SUCCESS) {
-		Any_ShowSimpleMessageBox(
-			SDL_MESSAGEBOX_ERROR,
-			"LEGO® Island Error",
-			"\"LEGO® Island\" failed to start.\nPlease quit all other applications and try again."
-			"\nFailed to initialize; see logs for details",
-			window
-		);
+		if (!g_startupErrorShown) {
+			Any_ShowSimpleMessageBox(
+				SDL_MESSAGEBOX_ERROR,
+				"LEGO® Island Error",
+				"\"LEGO® Island\" failed to start.\nPlease quit all other applications and try again."
+				"\nFailed to initialize; see logs for details",
+				window
+			);
+		}
 		return SDL_APP_FAILURE;
 	}
 
@@ -1575,6 +1579,7 @@ MxResult IsleApp::VerifyFilesystem()
 
 			SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", buffer);
 			Any_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "LEGO® Island Error", buffer, NULL);
+			g_startupErrorShown = TRUE;
 			return FAILURE;
 		}
 	}


### PR DESCRIPTION
When the game data is missing, `VerifyFilesystem` shows a detailed error dialog, and then `SDL_AppInit` showed a second, generic "failed to start" dialog for the same failure before exiting. Reporters experienced this as "click OK, it pops up again, then it crashes" (#592).

Track whether a specific startup error dialog was already presented and skip the redundant generic one. Mid-game failures without a preceding dialog still show the generic message.

Verified on the iOS 26.5 simulator: with the game data absent, exactly one dialog appears, and confirming it exits the app cleanly.