### PR TITLE
Add a game data import flow on iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -838,7 +838,10 @@ if (ISLE_BUILD_APP)
   if (IOS)
     target_sources(isle PRIVATE
       ISLE/ios/config.cpp
+      ISLE/ios/filepicker.mm
     )
+    set_source_files_properties(ISLE/ios/filepicker.mm PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
+    target_link_libraries(isle PRIVATE "-framework UIKit" "-weak_framework UniformTypeIdentifiers")
   endif()
   if (ANDROID)
     target_sources(isle PRIVATE

--- a/ISLE/ios/filepicker.h
+++ b/ISLE/ios/filepicker.h
@@ -1,0 +1,10 @@
+#ifndef IOS_FILEPICKER_H
+#define IOS_FILEPICKER_H
+
+#include <SDL3/SDL_video.h>
+
+// Asks the user to select the folder containing the game files and imports them
+// into the app's Documents storage at p_destRoot (the configured diskpath).
+bool IOS_TryImportGameFiles(SDL_Window* p_window, const char* p_destRoot);
+
+#endif // IOS_FILEPICKER_H

--- a/ISLE/ios/filepicker.mm
+++ b/ISLE/ios/filepicker.mm
@@ -1,0 +1,189 @@
+#include "filepicker.h"
+
+#include <SDL3/SDL.h>
+
+#import <UIKit/UIKit.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+@interface IsleFolderPickerDelegate : NSObject <UIDocumentPickerDelegate>
+@property(nonatomic, strong) NSURL* pickedURL;
+@property(nonatomic) BOOL done;
+@end
+
+@implementation IsleFolderPickerDelegate
+
+- (void)documentPicker:(UIDocumentPickerViewController*)controller didPickDocumentsAtURLs:(NSArray<NSURL*>*)urls
+{
+	self.pickedURL = urls.firstObject;
+	self.done = YES;
+}
+
+- (void)documentPickerWasCancelled:(UIDocumentPickerViewController*)controller
+{
+	self.done = YES;
+}
+
+@end
+
+static NSURL* ShowFolderPicker(SDL_Window* p_window) API_AVAILABLE(ios(14.0))
+{
+	UIWindow* uiwindow = (__bridge UIWindow*)
+		SDL_GetPointerProperty(SDL_GetWindowProperties(p_window), SDL_PROP_WINDOW_UIKIT_WINDOW_POINTER, NULL);
+	UIViewController* rootVC = uiwindow.rootViewController;
+	if (!rootVC) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No root view controller to present the folder picker");
+		return nil;
+	}
+
+	IsleFolderPickerDelegate* delegate = [[IsleFolderPickerDelegate alloc] init];
+	UIDocumentPickerViewController* picker =
+		[[UIDocumentPickerViewController alloc] initForOpeningContentTypes:@[ UTTypeFolder ]];
+	picker.delegate = delegate;
+	picker.allowsMultipleSelection = NO;
+
+	[rootVC presentViewController:picker animated:YES completion:nil];
+
+	while (!delegate.done) {
+		[[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+	}
+
+	return delegate.pickedURL;
+}
+
+static bool CopyDirectoryContents(NSURL* p_sourceDir, NSURL* p_destDir)
+{
+	NSFileManager* fm = [NSFileManager defaultManager];
+	NSError* error = nil;
+
+	if (![fm createDirectoryAtURL:p_destDir withIntermediateDirectories:YES attributes:nil error:&error]) {
+		SDL_LogError(
+			SDL_LOG_CATEGORY_APPLICATION,
+			"Failed to create '%s': %s",
+			p_destDir.path.UTF8String,
+			error.localizedDescription.UTF8String
+		);
+		return false;
+	}
+
+	NSArray<NSURL*>* items = [fm contentsOfDirectoryAtURL:p_sourceDir
+							   includingPropertiesForKeys:@[ NSURLIsDirectoryKey ]
+												  options:NSDirectoryEnumerationSkipsHiddenFiles
+													error:&error];
+	if (!items) {
+		SDL_LogError(
+			SDL_LOG_CATEGORY_APPLICATION,
+			"Failed to enumerate '%s': %s",
+			p_sourceDir.path.UTF8String,
+			error.localizedDescription.UTF8String
+		);
+		return false;
+	}
+
+	for (NSURL* item in items) {
+		NSNumber* isDirectory = nil;
+		[item getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:nil];
+
+		NSURL* dest = [p_destDir URLByAppendingPathComponent:item.lastPathComponent];
+		if (isDirectory.boolValue) {
+			if (!CopyDirectoryContents(item, dest)) {
+				return false;
+			}
+		}
+		else {
+			[fm removeItemAtURL:dest error:nil];
+			if (![fm copyItemAtURL:item toURL:dest error:&error]) {
+				SDL_LogError(
+					SDL_LOG_CATEGORY_APPLICATION,
+					"Failed to copy '%s': %s",
+					item.path.UTF8String,
+					error.localizedDescription.UTF8String
+				);
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+static bool ImportGameFiles(NSURL* p_sourceDir, const char* p_destRoot)
+{
+	NSURL* destRoot = [NSURL fileURLWithPath:@(p_destRoot)];
+
+	// If the user picked the game data folder itself (e.g. "LEGO") rather than
+	// the folder containing it, import it as <destRoot>/LEGO so the expected
+	// LEGO/Scripts and LEGO/data layout is preserved.
+	NSFileManager* fm = [NSFileManager defaultManager];
+	bool hasLegoDir = false;
+	bool hasScriptsDir = false;
+	NSArray<NSURL*>* items = [fm contentsOfDirectoryAtURL:p_sourceDir
+							   includingPropertiesForKeys:nil
+												  options:NSDirectoryEnumerationSkipsHiddenFiles
+													error:nil];
+	for (NSURL* item in items) {
+		NSString* name = item.lastPathComponent.lowercaseString;
+		if ([name isEqualToString:@"lego"]) {
+			hasLegoDir = true;
+		}
+		else if ([name isEqualToString:@"scripts"]) {
+			hasScriptsDir = true;
+		}
+	}
+
+	if (!hasLegoDir && hasScriptsDir) {
+		destRoot = [destRoot URLByAppendingPathComponent:@"LEGO"];
+	}
+
+	return CopyDirectoryContents(p_sourceDir, destRoot);
+}
+
+bool IOS_TryImportGameFiles(SDL_Window* p_window, const char* p_destRoot)
+{
+	if (@available(iOS 14.0, *)) {
+		const SDL_MessageBoxButtonData buttons[] = {
+			{SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Select folder"},
+			{SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, "Cancel"},
+		};
+		const SDL_MessageBoxData messageBox = {
+			SDL_MESSAGEBOX_INFORMATION,
+			p_window,
+			"LEGO® Island",
+			"The game files could not be found or read.\n\n"
+			"If you have a copy of the LEGO® Island files on this device (for example in the Files app or iCloud "
+			"Drive), you can select the folder containing them and they will be copied into this app's storage.",
+			SDL_arraysize(buttons),
+			buttons,
+			NULL
+		};
+
+		int button = 0;
+		if (!SDL_ShowMessageBox(&messageBox, &button) || button != 1) {
+			return false;
+		}
+
+		NSURL* pickedURL = ShowFolderPicker(p_window);
+		if (!pickedURL) {
+			return false;
+		}
+
+		bool imported = false;
+		bool secured = [pickedURL startAccessingSecurityScopedResource];
+		imported = ImportGameFiles(pickedURL, p_destRoot);
+		if (secured) {
+			[pickedURL stopAccessingSecurityScopedResource];
+		}
+
+		if (!imported) {
+			SDL_ShowSimpleMessageBox(
+				SDL_MESSAGEBOX_ERROR,
+				"LEGO® Island Error",
+				"The game files could not be imported; see logs for details.",
+				p_window
+			);
+		}
+
+		return imported;
+	}
+
+	return false;
+}

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -78,6 +78,7 @@
 
 #ifdef IOS
 #include "ios/config.h"
+#include "ios/filepicker.h"
 #endif
 
 #ifdef ANDROID
@@ -1557,6 +1558,13 @@ MxResult IsleApp::VerifyFilesystem()
 		if (!found) {
 #ifdef ANDROID
 			if (Android_TryImportGameFiles(reinterpret_cast<SDL_Window*>(m_windowHandle), m_iniPath, &m_hdPath)) {
+				MxOmni::SetHD(m_hdPath);
+				MxOmni::SetCD(m_cdPath);
+				return VerifyFilesystem();
+			}
+#endif
+#ifdef IOS
+			if (IOS_TryImportGameFiles(reinterpret_cast<SDL_Window*>(m_windowHandle), m_hdPath)) {
 				MxOmni::SetHD(m_hdPath);
 				MxOmni::SetCD(m_cdPath);
 				return VerifyFilesystem();


### PR DESCRIPTION
Mirrors the Android game data import flow (#830) on iOS: when the game files cannot be found at startup, the app now offers to import them. Selecting "Select folder" presents a `UIDocumentPickerViewController` (Files app), and the chosen folder's contents are copied into the app's `Documents/isle` storage with security-scoped access. If the user picked the game data folder itself (containing `Scripts`/`data`) rather than the folder containing `LEGO`, it is imported as `LEGO` so the expected layout is preserved. After the import the file index is rebuilt and the filesystem check runs again.

Previously, iOS users had to copy the files via Finder/iTunes file sharing before the game would start — the most common onboarding failure behind reports like #592/#654's setup problems. SDL has no dialog backend on iOS, so the picker is implemented natively (requires iOS 14+; older versions fall back to the plain error message).

Verified end-to-end on the iOS 26.5 simulator: with a wiped app container, the app offers the import, presents the picker, imports a 519 MB copy of the game data from "On My iPad", and then proceeds to boot the game successfully. Cancelling either dialog falls through to the existing error path.