### PR TITLE
Stop downloading the iOS simulator runtime in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,12 +106,6 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
           xcode-version: latest-stable
-      
-      - name: Install iOS components
-        if: ${{ matrix.ios }}
-        run: |
-          xcrun simctl list > /dev/null
-          xcodebuild -downloadPlatform iOS
 
       - name: Setup Emscripten
         uses: emscripten-core/setup-emsdk@v15


### PR DESCRIPTION
The "Install iOS components" step runs `xcodebuild -downloadPlatform iOS`, which downloads the multi-GB iOS **simulator runtime** on every run (2.2 minutes in the last completed run). CI builds for the device SDK, which ships inside Xcode, and never boots a simulator — the runtime is dead weight. The step was added in #718 to work around the Xcode 15.0-era "iOS platform missing" build error, which no longer applies to the Xcode versions on current runners; this PR's own iOS job validates that the build succeeds without it.

For reference, the iOS job currently spends its 15.5 minutes roughly as: 10.4 min CMake configure, 2.2 min simulator runtime download, 1.6 min brew, 1.0 min actual build. The configure time is dominated by the Xcode generator running every `try_compile` probe through `xcodebuild` (SDL ≈ 6.5 min, libwebsockets+mbedtls ≈ 3.5 min) plus full git clones. Cutting that meaningfully needs one of: moving the iOS job to Ninja with explicit asset-catalog compilation, trimming libwebsockets/mbedtls from the iOS build, or pinning SDL to enable safe dependency caching — each a bigger change than belongs in this PR. (ccache would not help here: actual compilation is only ~1 minute.)