### PR TITLE
Add a DPI-aware manifest on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -766,6 +766,9 @@ if (ISLE_BUILD_APP)
     ${CMAKE_SOURCE_DIR}/ISLE/res/no_bmp.h
   )
   list(APPEND isle_targets isle)
+  if (MSVC AND NOT WINDOWS_STORE)
+    target_sources(isle PRIVATE ISLE/res/isle.exe.manifest)
+  endif()
   if (WIN32)
     add_custom_command(TARGET isle POST_BUILD
       COMMAND "${CMAKE_COMMAND}" -E copy $<TARGET_RUNTIME_DLLS:isle> "$<TARGET_FILE_DIR:isle>"

--- a/ISLE/res/isle.exe.manifest
+++ b/ISLE/res/isle.exe.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+	<asmv3:application>
+		<asmv3:windowsSettings>
+			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+		</asmv3:windowsSettings>
+	</asmv3:application>
+</assembly>

--- a/ISLE/res/isle.rc
+++ b/ISLE/res/isle.rc
@@ -1,5 +1,10 @@
 #include "resource.h"
 
+#ifdef __MINGW32__
+#include "winuser.h"
+1 RT_MANIFEST "isle.exe.manifest"
+#endif
+
 ISLE_ARROW 	CURSOR 	"arrow.cur"
 ISLE_NO 		CURSOR 	"no.cur"
 ISLE_BUSY 	CURSOR 	"busy.cur"


### PR DESCRIPTION
Fixes #382.

Declares per-monitor DPI awareness (`PerMonitorV2`, with a `true/pm` fallback for pre-1703 Windows) through an application manifest, following the DevilutionX reference from the issue. SDL3 no longer offers a programmatic way to opt into DPI awareness on Windows (SDL2's `SDL_HINT_WINDOWS_DPI_AWARENESS` was removed), so the manifest is the only way to keep the window from being bitmap-stretched on scaled displays. This also makes the `SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN` flag from #853 effective on Windows.

Embedding covers both toolchains without conflicting:
- MSVC: the `.manifest` file is added as a target source, which CMake merges into the linker-generated embedded manifest via `mt.exe`. Excluded for `WINDOWS_STORE`, which has its own appxmanifest.
- MinGW: `windres` doesn't participate in the MSVC manifest merge, so the manifest is embedded as an `RT_MANIFEST` resource in `isle.rc`, guarded by `__MINGW32__` to avoid a duplicate resource under MSVC.

Verified with `x86_64-w64-mingw32-windres`: `isle.rc` compiles and the resulting object contains the manifest XML. The MSVC side is the standard CMake behavior for `.manifest` sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CVAycW6CZioD9CXSb1AS4