### PR TITLE
Set org.legoisland.Isle as the app id on the game and config windows

### DIFF
--- a/CONFIG/qt/config.cpp
+++ b/CONFIG/qt/config.cpp
@@ -470,6 +470,7 @@ CConfigApp g_theApp;
 int main(int argc, char* argv[])
 {
 	QApplication app(argc, argv);
+	QGuiApplication::setDesktopFileName("org.legoisland.Isle");
 	QCoreApplication::setApplicationName("Isle-Config");
 	QCoreApplication::setApplicationVersion("2.0");
 

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -347,6 +347,8 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char** argv)
 		);
 	}
 
+	SDL_SetAppMetadata("Isle Portable", NULL, "org.legoisland.Isle");
+
 	SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
 	SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 #ifdef __DJGPP__

--- a/packaging/linux/isledecomp.desktop.in
+++ b/packaging/linux/isledecomp.desktop.in
@@ -21,7 +21,7 @@ Keywords[ru]=LEGO;lego;Остров LEGO
 Keywords[uk_UA]=LEGO;lego;LEGO острів
 
 SingleMainWindow=true
-StartupWMClass=isle
+StartupWMClass=@APP_ID@
 
 TryExec=isle
 Exec=isle


### PR DESCRIPTION
Fixes #502.

Sets the reverse-DNS app id (`org.legoisland.Isle`, matching the installed desktop file and the Flatpak id) on both windows so Linux compositors can associate them with the desktop entry's icon and name regardless of the binary's file name:

- Game: `SDL_SetAppMetadata` in `SDL_AppInit`. SDL3 resolves the Wayland `app_id` and the X11 `WM_CLASS` class from the metadata identifier (`SDL_GetAppID()` falls back from `SDL_HINT_APP_ID` to `SDL_PROP_APP_METADATA_IDENTIFIER_STRING` before resorting to the executable name), and the metadata name also gives audio streams and D-Bus interactions a proper label instead of the binary name.
- Config: `QGuiApplication::setDesktopFileName`, which Qt uses for the Wayland `app_id` and the xcb `WM_CLASS`.

The desktop file's `StartupWMClass` is updated from `isle` to `@APP_ID@` rather than dropped: on Wayland the compositor derives the association from the desktop file's name, but on X11 an exact `StartupWMClass` match is still the most reliable path for window-to-app matching across desktop environments, and it now also covers the config window since both share the same class. Happy to drop it instead if that's preferred.

Verified that both `isle` and `isle-config` build with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CVAycW6CZioD9CXSb1AS4