### PR TITLE
BETA10-only assertion on Brickster pathfinding failure

### DIFF
--- a/LEGO1/lego/legoomni/src/actors/act3actors.cpp
+++ b/LEGO1/lego/legoomni/src/actors/act3actors.cpp
@@ -953,7 +953,9 @@ MxResult Act3Brickster::FUN_100417c0()
 				}
 
 				grec = NULL;
+#ifdef BETA10
 				assert(0);
+#endif
 			}
 		}
 		else {


### PR DESCRIPTION
Fixes #338

`Act3Brickster::FUN_100417c0` aborts with `assert(0)` whenever `LegoPathController::FindPath` fails to route the Brickster to his next target building. This failure is legitimately reachable in gameplay:

- The ACT3 path network contains 15 boundaries that cannot reach any building under the directional edge mask `FindPath` uses (`INV_01`-`INV_08`, `USR_40/46/47/49`, `EDG00_44/47/48`), verified by an exhaustive in-game audit of all 444 boundaries × 16 target buildings (240/7104 pairs fail, all from these 15).
- `USR_01`/`USR_51` are exit-only gateways into the dead `USR_*` cluster, geometrically adjacent to land (`INT39`, `EDG00_45`) with fully crossable edge masks. The Brickster's cop-flee logic (`FUN_10042300`, triggered when a cop is within 15 units straight-line distance) selects flee edges checking only `GetMask0x03()` rather than the directional check, so chained flees can push him through a gateway into the dead pockets — consistent with the crowded-cops-around-donuts situation in the original report. Reproduced directly: placing the Brickster on `USR_47` and triggering the seek hits the exact assert.

Retail tolerates the failure silently (`grec` stays NULL and the Brickster retries on the next state change), so this makes the assertion BETA10-only, following the existing convention for data-dependent assertions (cf. `Act3Cop::ParseAction`). Verified with a debug build: pre-change the seek aborts; post-change it returns gracefully and the game continues.