### PR TITLE
Delegate renderer-specific window property setup to miniwin

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -1017,11 +1017,8 @@ MxResult IsleApp::SetupWindow()
 #ifndef __EMSCRIPTEN__
 	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, true);
 #endif
-#if defined(MINIWIN) && (defined(USE_OPENGL1) || defined(USE_OPENGLES2) || defined(USE_OPENGLES3)) &&                  \
-	!defined(__3DS__) && !defined(WINDOWS_STORE) && !defined(__vita__) && !defined(__DJGPP__)
-	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_OPENGL_BOOLEAN, true);
-	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+#ifdef MINIWIN
+	Miniwin_SetupWindowCreateProperties(props);
 #endif
 
 	window = SDL_CreateWindowWithProperties(props);

--- a/miniwin/CMakeLists.txt
+++ b/miniwin/CMakeLists.txt
@@ -178,7 +178,7 @@ target_link_libraries(miniwin PUBLIC miniwin-headers)
 
 target_link_libraries(miniwin PRIVATE SDL3::SDL3)
 
-target_compile_definitions(miniwin PUBLIC ${GRAPHICS_BACKENDS})
+target_compile_definitions(miniwin PRIVATE ${GRAPHICS_BACKENDS})
 
 
 # Shader stuff

--- a/miniwin/include/miniwin/miniwindevice.h
+++ b/miniwin/include/miniwin/miniwindevice.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SDL3/SDL_events.h>
+#include <SDL3/SDL_properties.h>
 
 DEFINE_GUID(IID_IDirect3DRMMiniwinDevice, 0x6eb09673, 0x8d30, 0x4d8a, 0x8d, 0x81, 0x34, 0xea, 0x69, 0x30, 0x12, 0x01);
 
@@ -8,3 +9,5 @@ struct IDirect3DRMMiniwinDevice : virtual public IUnknown {
 	virtual bool ConvertEventToRenderCoordinates(SDL_Event* event) = 0;
 	virtual bool ConvertRenderToWindowCoordinates(Sint32 inX, Sint32 inY, Sint32& outX, Sint32& outY) = 0;
 };
+
+void Miniwin_SetupWindowCreateProperties(SDL_PropertiesID props);

--- a/miniwin/src/d3drm/d3drmrenderer.cpp
+++ b/miniwin/src/d3drm/d3drmrenderer.cpp
@@ -30,6 +30,16 @@
 #include "d3drmrenderer_glide.h"
 #endif
 
+void Miniwin_SetupWindowCreateProperties(SDL_PropertiesID props)
+{
+#if (defined(USE_OPENGL1) || defined(USE_OPENGLES2) || defined(USE_OPENGLES3)) && !defined(__3DS__) &&                 \
+	!defined(WINDOWS_STORE) && !defined(__vita__) && !defined(__DJGPP__)
+	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_OPENGL_BOOLEAN, true);
+	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+#endif
+}
+
 Direct3DRMRenderer* CreateDirect3DRMRenderer(
 	const IDirect3DMiniwin* d3d,
 	const DDSURFACEDESC& DDSDesc,


### PR DESCRIPTION
Closes #534.

Moves the renderer-specific SDL window creation setup (the `SDL_PROP_WINDOW_CREATE_OPENGL_BOOLEAN` property and the pre-creation `SDL_GL_SetAttribute` calls) out of `IsleApp::SetupWindow` and into a new miniwin API:

```cpp
void Miniwin_SetupWindowCreateProperties(SDL_PropertiesID props);
```

declared in `miniwin/miniwindevice.h` and implemented in `d3drmrenderer.cpp`, where the graphics backend defines are available. The app now just calls this under `#ifdef MINIWIN` before `SDL_CreateWindowWithProperties`.

Since this was the only consumer of the backend defines outside of miniwin, `GRAPHICS_BACKENDS` (`USE_OPENGL1`, `USE_SDL_GPU`, etc.) is now a PRIVATE compile definition of the miniwin target — ISLE no longer knows which backends are compiled in.

The DJGPP `INDEX8` fullscreen-mode block was deliberately left in `isleapp.cpp`: it runs post-creation and is interlocked with the app's exclusive-fullscreen config logic (the `#else` branch), so moving it would change behavior if exclusive fullscreen were ever configured on DOS.

Verified on macOS (native build): game boots to gameplay on both the SDL3 GPU (Metal) device and the OpenGL 1.1 HAL device — the latter exercises the moved code, since GL context creation requires the window to have been created with the OPENGL flag.