### PR TITLE
Link isle-config against static Qt6 on MinGW

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
             ${{ matrix.msys-env }}-cmake
             ${{ matrix.msys-env }}-ninja
             ${{ matrix.msys-env }}-clang-tools-extra
-            ${{ (matrix.config && format('{0}-qt6-base', matrix.msys-env)) || '' }}
+            ${{ (matrix.config && format('{0}-qt6-static {0}-freetype {0}-harfbuzz {0}-graphite2 {0}-libpng {0}-libjpeg-turbo {0}-libtiff {0}-libwebp {0}-pcre2 {0}-zlib {0}-brotli {0}-bzip2', matrix.msys-env)) || '' }}
       - name: Install Qt
         if: ${{ !!matrix.msvc && matrix.config }}
         uses: jurplel/install-qt-action@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -902,6 +902,14 @@ if (ISLE_BUILD_CONFIG)
     list(APPEND CMAKE_PREFIX_PATH "$ENV{MSYSTEM_PREFIX}/qt6-static")
     set(ISLE_SAVED_FIND_LIBRARY_SUFFIXES "${CMAKE_FIND_LIBRARY_SUFFIXES}")
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+    # MSYS2's harfbuzz CMake package resolves to the import library; disable it so
+    # Qt's fallback (find_library, which honors the suffix override) is used instead
+    set(CMAKE_DISABLE_FIND_PACKAGE_harfbuzz TRUE)
+    # The static freetype and harfbuzz depend on each other and on brotli/bz2/graphite2,
+    # which Qt's link interface does not carry; resolve them at the end of the link line
+    string(APPEND CMAKE_CXX_STANDARD_LIBRARIES
+      " -Wl,--start-group -lfreetype -lharfbuzz -lgraphite2 -lbrotlidec -lbrotlicommon -lbz2 -Wl,--end-group -lrpcrt4"
+    )
   endif()
   find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
   if(ISLE_QT_STATIC)
@@ -922,6 +930,7 @@ if (ISLE_BUILD_CONFIG)
   if(ISLE_QT_STATIC)
     # Keep the static link lean: the dialog only uses PNG (built into QtGui) and SVG resources
     qt_import_plugins(isle-config EXCLUDE_BY_TYPE imageformats EXCLUDE_BY_TYPE networkinformation EXCLUDE_BY_TYPE tls)
+    target_link_options(isle-config PRIVATE -s)
   endif()
   set_property(TARGET isle-config PROPERTY AUTOMOC ON)
   set_property(TARGET isle-config PROPERTY AUTORCC ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -894,7 +894,19 @@ if (ISLE_BUILD_APP)
 endif()
 
 if (ISLE_BUILD_CONFIG)
+  # Prefer MSYS2's static Qt6 when available so isle-config does not depend on Qt DLLs.
+  # Restrict library resolution to static archives while Qt and its third-party
+  # dependencies are located, so import libraries (.dll.a) are not picked up.
+  if(MINGW AND EXISTS "$ENV{MSYSTEM_PREFIX}/qt6-static")
+    set(ISLE_QT_STATIC ON)
+    list(APPEND CMAKE_PREFIX_PATH "$ENV{MSYSTEM_PREFIX}/qt6-static")
+    set(ISLE_SAVED_FIND_LIBRARY_SUFFIXES "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+  endif()
   find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
+  if(ISLE_QT_STATIC)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES "${ISLE_SAVED_FIND_LIBRARY_SUFFIXES}")
+  endif()
   qt_standard_project_setup()
   qt_add_executable(isle-config WIN32
     LEGO1/mxdirectx/mxdirectxinfo.cpp
@@ -907,6 +919,10 @@ if (ISLE_BUILD_CONFIG)
     CONFIG/qt/res/config.qrc
   )
   target_link_libraries(isle-config PRIVATE Qt6::Core Qt6::Widgets)
+  if(ISLE_QT_STATIC)
+    # Keep the static link lean: the dialog only uses PNG (built into QtGui) and SVG resources
+    qt_import_plugins(isle-config EXCLUDE_BY_TYPE imageformats EXCLUDE_BY_TYPE networkinformation EXCLUDE_BY_TYPE tls)
+  endif()
   set_property(TARGET isle-config PROPERTY AUTOMOC ON)
   set_property(TARGET isle-config PROPERTY AUTORCC ON)
   set_property(TARGET isle-config PROPERTY AUTOUIC ON)
@@ -1056,7 +1072,8 @@ if (NOT (NINTENDO_3DS OR WINDOWS_STORE OR VITA))
   endif()
 endif()
 if (ISLE_BUILD_CONFIG)
-  if(WIN32)
+  get_target_property(ISLE_QT6_CORE_TYPE Qt6::Core TYPE)
+  if(WIN32 AND NOT ISLE_QT6_CORE_TYPE STREQUAL "STATIC_LIBRARY")
     find_program(WINDEPLOYQT_EXECUTABLE windeployqt)
     if(WINDEPLOYQT_EXECUTABLE)
       install(CODE "message(STATUS \"Running windeployqt with minimal dependencies\")


### PR DESCRIPTION
Closes #554.

The current MinGW64 package is broken for the config tool: windeployqt copies MSYS2's shared Qt DLLs into the package, but not the MSYS2 libraries those DLLs depend on (`libstdc++-6.dll`, `libwinpthread-1.dll`, `libicuin78.dll`, `zlib1.dll`, `libfreetype-6.dll`, `libharfbuzz-0.dll`, `libpcre2-16-0.dll`, `libzstd.dll`, and more — verified by parsing the PE import tables of a current CI artifact). `isle-config.exe` therefore cannot start on a machine without MSYS2 in `PATH`. The game binaries are unaffected since they link `-static -static-libgcc -static-libstdc++` on MinGW.

As suggested in #554, this switches the MinGW build to MSYS2's `qt6-static` package:

- CMake appends `$MSYSTEM_PREFIX/qt6-static` to `CMAKE_PREFIX_PATH` when it exists, so `find_package(Qt6)` picks the static Qt automatically (an explicit `Qt6_DIR`/prefix still wins).
- While Qt and its third-party dependencies are located, `CMAKE_FIND_LIBRARY_SUFFIXES` is restricted to `.a` — otherwise CMake resolves import libraries (`.dll.a`) and the DLL dependencies sneak back in. MSYS2's harfbuzz additionally ships a CMake config that hands back the import library regardless, so config-mode lookup is disabled for it (Qt then falls back to `find_library`).
- MSYS2's static Qt links *system* static freetype/harfbuzz, which depend on each other (mutually circular) and on brotli/bz2/graphite2 — none of which Qt's link interface carries. They are resolved in a `--start-group` at the end of the link line, plus `rpcrt4` for harfbuzz's uniscribe backend.
- Static plugin import excludes `imageformats`/`networkinformation`/`tls` (the dialog only uses PNG, which is built into QtGui, and SVG resources). The SVG icon engine now links in statically, which incidentally fixes the add/remove SVG button icons — the shared build never shipped qt6-svg, so they rendered blank.
- windeployqt is skipped when `Qt6::Core` is a static library; the MSVC/official-Qt path is unchanged (verified: its artifact still contains the deployed Qt DLLs).
- The static `isle-config.exe` is linked with `-s`; unstripped it is 54 MB, stripped 31 MB.
- CI installs `qt6-static` plus the static Qt's system dependencies (freetype, harfbuzz, graphite2, libpng, libjpeg-turbo, libtiff, libwebp, pcre2, zlib, brotli, bzip2 — the image format libraries are needed at configure time by Qt's plugin packages even though the plugins aren't linked).

Verified on CI (fork run of this exact branch): the MinGW64 package now contains only `isle.exe`, `isle-config.exe`, `lego1.dll`, `SDL3.dll` (25 files → 4), the compressed package is slightly smaller than before (18.20 MB vs 18.26 MB), and parsing `isle-config.exe`'s PE import table shows only Windows system DLLs plus the bundled `SDL3.dll`.