### PR TITLE
Fix startup error handling and window sizing on tiling window managers

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -108,7 +108,7 @@ MxU8 g_mousemoved = FALSE;
 // GLOBAL: ISLE 0x41003c
 MxS32 g_closed = FALSE;
 
-static MxBool g_startupErrorShown = FALSE;
+static char g_startupError[1024] = "";
 
 // GLOBAL: ISLE 0x410050
 MxS32 g_rmDisabled = FALSE;
@@ -234,7 +234,9 @@ IsleApp::IsleApp()
 IsleApp::~IsleApp()
 {
 	if (LegoOmni::GetInstance()) {
-		Close();
+		if (m_gameStarted) {
+			Close();
+		}
 		MxOmni::DestroyInstance();
 	}
 
@@ -332,6 +334,19 @@ void IsleApp::SetupVideoFlags(
 	}
 }
 
+static void ShowFatalError(const char* p_message)
+{
+	if (g_isle) {
+		delete g_isle;
+		g_isle = NULL;
+	}
+	if (window) {
+		SDL_DestroyWindow(window);
+		window = NULL;
+	}
+	Any_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "LEGO® Island Error", p_message, NULL);
+}
+
 SDL_AppResult SDL_AppInit(void** appstate, int argc, char** argv)
 {
 	*appstate = NULL;
@@ -413,15 +428,12 @@ SDL_AppResult SDL_AppInit(void** appstate, int argc, char** argv)
 
 	// Create window
 	if (g_isle->SetupWindow() != SUCCESS) {
-		if (!g_startupErrorShown) {
-			Any_ShowSimpleMessageBox(
-				SDL_MESSAGEBOX_ERROR,
-				"LEGO® Island Error",
-				"\"LEGO® Island\" failed to start.\nPlease quit all other applications and try again."
-				"\nFailed to initialize; see logs for details",
-				window
-			);
-		}
+		ShowFatalError(
+			g_startupError[0] != '\0'
+				? g_startupError
+				: "\"LEGO® Island\" failed to start.\nPlease quit all other applications and try again."
+				  "\nFailed to initialize; see logs for details"
+		);
 		return SDL_APP_FAILURE;
 	}
 
@@ -454,13 +466,8 @@ SDL_AppResult SDL_AppIterate(void* appstate)
 	}
 
 	if (!g_isle->Tick()) {
-		Any_ShowSimpleMessageBox(
-			SDL_MESSAGEBOX_ERROR,
-			"LEGO® Island Error",
-			"\"LEGO® Island\" failed to start.\nPlease quit all other applications and try again."
-			"\nFailed to initialize; see logs for details",
-			NULL
-		);
+		ShowFatalError("\"LEGO® Island\" failed to start.\nPlease quit all other applications and try again."
+					   "\nFailed to initialize; see logs for details");
 		return SDL_APP_FAILURE;
 	}
 
@@ -478,13 +485,8 @@ SDL_AppResult SDL_AppIterate(void* appstate)
 
 		if (g_mousedown && g_mousemoved && g_isle) {
 			if (!g_isle->Tick()) {
-				Any_ShowSimpleMessageBox(
-					SDL_MESSAGEBOX_ERROR,
-					"LEGO® Island Error",
-					"\"LEGO® Island\" failed to start.\nPlease quit all other applications and try again."
-					"\nFailed to initialize; see logs for details",
-					NULL
-				);
+				ShowFatalError("\"LEGO® Island\" failed to start.\nPlease quit all other applications and try again."
+							   "\nFailed to initialize; see logs for details");
 				return SDL_APP_FAILURE;
 			}
 		}
@@ -937,8 +939,9 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 
 void SDL_AppQuit(void* appstate, SDL_AppResult result)
 {
-	if (appstate != NULL) {
-		SDL_DestroyWindow((SDL_Window*) appstate);
+	if (window) {
+		SDL_DestroyWindow(window);
+		window = NULL;
 	}
 
 	SDL_Quit();
@@ -1016,6 +1019,9 @@ MxResult IsleApp::SetupWindow()
 	SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, WINDOW_TITLE);
 #ifndef __EMSCRIPTEN__
 	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, true);
+#endif
+#if defined(MINIWIN) && !defined(__EMSCRIPTEN__)
+	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_RESIZABLE_BOOLEAN, true);
 #endif
 #ifdef MINIWIN
 	Miniwin_SetupWindowCreateProperties(props);
@@ -1591,8 +1597,7 @@ MxResult IsleApp::VerifyFilesystem()
 			);
 
 			SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", buffer);
-			Any_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "LEGO® Island Error", buffer, NULL);
-			g_startupErrorShown = TRUE;
+			SDL_strlcpy(g_startupError, buffer, sizeof(g_startupError));
 			return FAILURE;
 		}
 	}


### PR DESCRIPTION
Closes #843. Addresses the isle side of #840 (the other half is an SDL bug — patch below, to be submitted upstream).

Both issues were reproduced and the fixes verified in a headless Sway rig (Docker, wlroots headless backend, 2560×1600 output at scale 1 and 2, real game data, both native Wayland and XWayland/X11 paths).

## #843 — game appears frozen after a startup error

The fullscreen window and the entire engine are created before `VerifyFilesystem()` runs. On failure, the error dialog was shown while the black fullscreen game window still held the workspace — and Sway renders fullscreen views *above* floating dialogs, so the dialog was invisible and the game looked frozen (reproduced and captured in the rig). In addition, `SDL_AppQuit` only destroyed the window via `appstate`, which is never set on the failure path.

Changes:
- New `ShowFatalError()` used by all fatal startup paths: delete `g_isle` (full engine teardown), destroy the window, *then* show the dialog. The dialog now appears on a normal desktop and the game exits as soon as it is dismissed.
- `VerifyFilesystem()` stashes its specific message (`g_startupError`) instead of showing it inline, so it can be displayed after teardown.
- `~IsleApp` only runs `Close()` when the game actually started — `Close()` saves the game and spins the tickle loop, both of which presuppose a booted game.
- `SDL_AppQuit` destroys the `window` global rather than casting `appstate` (which is the win32 HWND on non-miniwin builds, i.e. the wrong object).

Verified: missing assets → teardown → dialog visible on an empty workspace → OK → clean exit 1. Normal boot → WM close → `Close()` runs → exit 0. The wasm boot path is unchanged (`Emscripten_ShowSimpleMessageBox` ignores the window argument, and `VerifyFilesystem` uses the emscripten branch).

## #840 — window cannot be tiled on native Wayland

`SDL_PROP_WINDOW_CREATE_RESIZABLE_BOOLEAN` is now set on desktop miniwin builds. Without it, SDL's Wayland backend refuses the compositor's tiled configure for fixed-size windows ("always assume the configure is wrong"), leaving a 640×480 island in the tile slot. The miniwin device already handles arbitrary window sizes (letterboxing, input transforms, HiDPI), which is why externally forced resizes — Sway tiling the X11 window, snap tools on Windows — already worked. Excluded on the DX5 build (no resize handling there) and on emscripten (its own soft-fullscreen path).

## The remaining half of #840 is an SDL3 X11 bug

The reporter runs under XWayland (see #845 — SDL3 silently falls back to X11 when the compositor lacks `fifo-v1`). Reproduced with a minimal 40-line SDL client, independent of this repo: on X11 under Sway, a tiled window that calls `SDL_SetWindowFullscreen()` gets the WM fullscreen state, but the X11 window and drawable permanently keep the old tile size — Sway centers the small buffer on black, which is exactly the screenshot in #840.

Mechanism: when entering fullscreen, `X11_SetWindowFullscreenViaWM` sends `_NET_WM_STATE_FULLSCREEN` and then calls `X11_XMoveWindow()` even when the window is already on the target display. That client-side ConfigureRequest races the WM's own fullscreen configure, and Sway ends up re-asserting the stale pre-fullscreen geometry. The move exists for multi-display setups (SDL commits `4a6f3cf47`, `ad813a65e`); restricting it to the actual cross-display case preserves that intent and fixes the race — verified through repeated enter/leave cycles with both the minimal client and the game:

```diff
diff --git a/src/video/x11/SDL_x11window.c b/src/video/x11/SDL_x11window.c
index deaf67c48..c9a973be1 100644
--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -1910,7 +1910,7 @@ static SDL_FullscreenResult X11_SetWindowFullscreenViaWM(SDL_VideoDevice *_this,
             data->expected.h = _display->current_mode->h;
 
             // Only move the window if it isn't fullscreen or already on the target display.
-            if (!(window->flags & SDL_WINDOW_FULLSCREEN) || (!current || current != _display->id)) {
+            if (!current || current != _display->id) {
                 X11_XMoveWindow(display, data->xwindow, displaydata->x, displaydata->y);
                 data->pending_operation |= X11_PENDING_OP_MOVE;
             }
```

The patch is deliberately not carried in this repo; since the builds track SDL `main`, the continuous builds will pick the fix up once it lands upstream.