### PR TITLE
Start with default config when the web build's ini is unreadable

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -1192,8 +1192,20 @@ bool IsleApp::LoadConfig()
 		iniparser_freedict(dict);
 
 		if (m_iniPath) {
+#ifdef __EMSCRIPTEN__
+			SDL_Log("Invalid config path '%s', falling back to defaults", m_iniPath);
+			m_iniPath = NULL;
+			if (prefPath) {
+				iniConfig = prefPath;
+				iniConfig += "isle.ini";
+			}
+			else {
+				iniConfig = "isle.ini";
+			}
+#else
 			SDL_Log("Invalid config path '%s'", m_iniPath);
 			return false;
+#endif
 		}
 
 		SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Loading sane defaults");

--- a/LEGO1/lego/legoomni/src/main/legomain.cpp
+++ b/LEGO1/lego/legoomni/src/main/legomain.cpp
@@ -94,7 +94,9 @@ void LegoOmni::Destroy()
 {
 	AUTOLOCK(m_criticalSection);
 
-	m_notificationManager->Unregister(this);
+	if (m_notificationManager) {
+		m_notificationManager->Unregister(this);
+	}
 
 	if (m_worldList) {
 		delete m_worldList;


### PR DESCRIPTION
Fixes #828.

## Root cause

The isle.pizza frontend always launches the game with `--ini /config/isle.ini` (OPFS-backed). Two frontend defects could leave that file missing or empty:

1. The configure page called `getFileHandle()` with its default `create: true` just to *read* the config, creating an empty `isle.ini` before ever writing to it.
2. The actual config write goes through a worker using `createSyncAccessHandle`, and when it fails (quota exhaustion, broken storage), the failure was swallowed and the game launched anyway.

An empty or missing ini makes `iniparser_load` fail, `LoadConfig` treated that as fatal when `--ini` was passed, and startup died with the generic "failed to start / please quit all other applications" dialog. Since the renderer selection lives in that same unwritable ini, every renderer choice failed identically — matching the report exactly.

## Is this Momiji-specific?

No. The dialog reproduces in any browser once the OPFS config write fails; Momiji on a decade-old Mac (full disk / fragile storage) is just a likely victim. The crash-report DB shows the same silent `Game exited with code 1` startup failure across Chrome/Windows, ChromeOS, Android, and iOS (130 reports), including eight from the reporter's session on 2026-08-15 (Firefox/140 Intel Mac UA — Momiji reports itself as Firefox 140). The frontend defects above are being fixed separately in isle.pizza (don't create the file on read, don't pass `--ini` for a missing/empty config, surface failed saves), but the game side should not hard-fail on an unreadable config regardless.

## Changes

- `IsleApp::LoadConfig`: on Emscripten, an unreadable `--ini` path now logs and falls back to the existing sane-defaults flow (defaults written to the pref path) instead of returning failure. Native behavior is unchanged.
- `LegoOmni::Destroy`: startup failures this early tear down (via `ShowFatalError`, #869) a `LegoOmni` whose `Create()` never ran, and the unconditional `m_notificationManager->Unregister(this)` dereferenced NULL — on wasm this reads null-page garbage without trapping and hangs the web port at the loading screen with no dialog at all (on native it would crash). Guard it so early teardown is safe; registration only happens late in `LegoOmni::Create`, so the guard mirrors it.

## Verification

Reproduced and verified in a local rig driving the actual Momiji 140.13 browser (x86_64 build under Rosetta) headless against the isle.pizza frontend, with the OPFS write worker stubbed to fail like a quota-exhausted machine:

- Old build (`3b24e1bb`, what prod ran when #828 was filed): exact dialog from the report, character for character, on every renderer.
- Current master, same fault: silent hang at "Loading… 0%" (the `ShowFatalError` teardown regression fixed here).
- This branch, same fault: `Invalid config path '/config/isle.ini', falling back to defaults` → game boots to the Information Center.
- No fault injected: config is read from OPFS and honored as before; game boots normally. Native build compiles clean.