### PR TITLE
Improve the gamepad scheme: conventional select button, Start pauses, framerate-independent cursor

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -501,6 +501,15 @@ SDL_AppResult SDL_AppIterate(void* appstate)
 	return SDL_APP_CONTINUE;
 }
 
+static SDL_GamepadButton GetGamepadClickButton(SDL_JoystickID p_joystickID)
+{
+	SDL_Gamepad* gamepad = SDL_GetGamepadFromID(p_joystickID);
+	if (gamepad && SDL_GetGamepadButtonLabel(gamepad, SDL_GAMEPAD_BUTTON_EAST) == SDL_GAMEPAD_BUTTON_LABEL_A) {
+		return SDL_GAMEPAD_BUTTON_EAST;
+	}
+	return SDL_GAMEPAD_BUTTON_SOUTH;
+}
+
 SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 {
 	if (!g_isle) {
@@ -634,33 +643,37 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 			g_dpadRight = true;
 			break;
 		case SDL_GAMEPAD_BUTTON_EAST:
-			g_mousedown = TRUE;
-			if (InputManager()) {
-				InputManager()->QueueEvent(
-					c_notificationButtonDown,
-					LegoEventNotificationParam::c_lButtonState,
-					g_lastMouseX,
-					g_lastMouseY,
-					0
-				);
-			}
-			break;
-
 		case SDL_GAMEPAD_BUTTON_SOUTH:
-			if (InputManager()) {
+			if (event->gbutton.button == GetGamepadClickButton(event->gbutton.which)) {
+				g_mousedown = TRUE;
+				if (InputManager()) {
+					InputManager()->QueueEvent(
+						c_notificationButtonDown,
+						LegoEventNotificationParam::c_lButtonState,
+						g_lastMouseX,
+						g_lastMouseY,
+						0
+					);
+				}
+			}
+			else if (InputManager()) {
 				InputManager()->QueueEvent(c_notificationKeyPress, SDLK_SPACE, 0, 0, SDLK_SPACE);
 			}
 			break;
 
-#ifdef __vita__ // conflicts with screenshot button combination
 		case SDL_GAMEPAD_BUTTON_BACK:
-#else
-		case SDL_GAMEPAD_BUTTON_START:
-#endif
 			if (InputManager()) {
 				InputManager()->QueueEvent(c_notificationKeyPress, SDLK_ESCAPE, 0, 0, SDLK_ESCAPE);
 			}
 			break;
+
+#ifndef __vita__ // conflicts with screenshot button combination
+		case SDL_GAMEPAD_BUTTON_START:
+			if (InputManager()) {
+				InputManager()->QueueEvent(c_notificationKeyPress, 0, 0, 0, SDLK_PAUSE);
+			}
+			break;
+#endif
 		}
 		break;
 	}
@@ -680,15 +693,18 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 			g_dpadRight = false;
 			break;
 		case SDL_GAMEPAD_BUTTON_EAST:
-			g_mousedown = FALSE;
-			if (InputManager()) {
-				InputManager()->QueueEvent(
-					c_notificationButtonUp,
-					LegoEventNotificationParam::c_lButtonState,
-					g_lastMouseX,
-					g_lastMouseY,
-					0
-				);
+		case SDL_GAMEPAD_BUTTON_SOUTH:
+			if (event->gbutton.button == GetGamepadClickButton(event->gbutton.which)) {
+				g_mousedown = FALSE;
+				if (InputManager()) {
+					InputManager()->QueueEvent(
+						c_notificationButtonUp,
+						LegoEventNotificationParam::c_lButtonState,
+						g_lastMouseX,
+						g_lastMouseY,
+						0
+					);
+				}
 			}
 			break;
 		}
@@ -1677,6 +1693,15 @@ IDirect3DRMMiniwinDevice* GetD3DRMMiniwinDevice()
 
 void IsleApp::MoveVirtualMouseViaJoystick()
 {
+	// Cursor sensitivity is expressed in pixels per 60 Hz frame
+	static Uint64 g_lastMoveTime = 0;
+	Uint64 now = SDL_GetTicksNS();
+	float frames = 1.0f;
+	if (g_lastMoveTime != 0) {
+		frames = SDL_min((float) (now - g_lastMoveTime), SDL_NS_PER_SECOND / 10.0f) * (60.0f / SDL_NS_PER_SECOND);
+	}
+	g_lastMoveTime = now;
+
 	float dpadX = 0.0f;
 	float dpadY = 0.0f;
 
@@ -1694,8 +1719,8 @@ void IsleApp::MoveVirtualMouseViaJoystick()
 	}
 
 	// Use joystick axis if non-zero, else fall back to dpad
-	float moveX = (g_lastJoystickMouseX != 0) ? g_lastJoystickMouseX : dpadX;
-	float moveY = (g_lastJoystickMouseY != 0) ? g_lastJoystickMouseY : dpadY;
+	float moveX = ((g_lastJoystickMouseX != 0) ? g_lastJoystickMouseX : dpadX) * frames;
+	float moveY = ((g_lastJoystickMouseY != 0) ? g_lastJoystickMouseY : dpadY) * frames;
 
 	if (moveX != 0 || moveY != 0) {
 		g_mousemoved = TRUE;


### PR DESCRIPTION
Closes #839.

All three complaints reproduced and the fixes verified without controller hardware, by attaching SDL *virtual* joysticks carrying real VID/PIDs (DualShock 3 `054C:0268`, Xbox 360 `045E:028E`, Switch Pro `057E:2009`) inside the running game — SDL then reports the genuine gamepad types, face-button labels and controller-DB mappings, so the full event path behaves as with a physical pad.

## Circle/B selects instead of Cross/A

Click was mapped to the positional `SDL_GAMEPAD_BUTTON_EAST` — Circle on PlayStation pads and B on Xbox pads. Click now goes to SOUTH (Cross/A), except on pads whose EAST button is *labeled* "A" (`SDL_GetGamepadButtonLabel`), i.e. Nintendo-style layouts, which keep A as select. The other face button takes over Space (skip/interrupt animations) — and during skippable animations a click is converted to Space anyway (`LegoInputManager::ProcessOneEvent`), so the select button still skips cutscenes like before.

Verified per type: DS3 → type PS3, south=CROSS/east=CIRCLE → click on **Cross**; Xbox 360 → click on **A**; Switch Pro → south=B/east=A → click stays on **A** (east). Generic pads SDL doesn't recognize default to Xbox-style labels → bottom-button select. GameCube pads (AXBY face style) also resolve to their physical A.

## Start opens the "leave LEGO Island?" flow

Start sent Escape (return to Infocenter, exit query from the Infocenter) — jarring on the button people reach for to pause. Escape now lives on BACK/Select, matching the back/exit convention and unifying with the Vita port (which already used BACK because Start conflicts with its screenshot combo). Start maps to the game's own `SDLK_PAUSE` toggle; the input manager explicitly lets that key through while paused (`legoinputmanager.cpp` `ProcessOneEvent`), so it resumes as well. Verified in-game via virtual pad: first Start press → `IsPaused()` true, second → false; Cross press/release → left-button down/up delivered; Circle press → no click.

## Virtual mouse speed far faster than isle.pizza

`MoveVirtualMouseViaJoystick()` applied `m_cursorSensitivity` (default 4 px) once per `SDL_AppIterate` — and SDL3's native main-callback loop runs *uncapped* by default, while the web build is capped at ~60 Hz by requestAnimationFrame. Cursor speed therefore scaled with the host's iterate rate; measured 40 px/s at a forced 10 Hz and 120 px/s at 30 Hz (macOS throttling an unfocused window) — perfectly proportional, so an unthrottled machine easily reaches thousands of px/s. This also explains why it reproduces on some machines and not others regardless of controller.

The movement is now scaled by elapsed time against a 60 Hz reference, keeping the sensitivity semantics (pixels per 60 Hz frame) and making every platform match the web build: measured a constant 240.0 px/s at full deflection at both 10 Hz and 30 Hz after the change. High-refresh displays on the web build are normalized by the same fix. `Cursor Sensitivity` in the ini still scales the speed. The d-pad cursor path gets the same treatment.