### PR TITLE
Use the circle pad as a cursor stick on 3DS

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -716,13 +716,38 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 			// Ignore small axis values
 			axisValue = event->gaxis.value;
 		}
+#ifdef __3DS__
+		// The circle pad (left stick) doubles as a cursor stick since only
+		// New 3DS models have a C-stick; both contribute to cursor movement
+		static MxS32 g_cpadX = 0, g_cpadY = 0, g_cstickX = 0, g_cstickY = 0;
+		switch (event->gaxis.axis) {
+		case SDL_GAMEPAD_AXIS_LEFTX:
+			g_cpadX = axisValue;
+			break;
+		case SDL_GAMEPAD_AXIS_LEFTY:
+			g_cpadY = axisValue;
+			break;
+		case SDL_GAMEPAD_AXIS_RIGHTX:
+			g_cstickX = axisValue;
+			break;
+		case SDL_GAMEPAD_AXIS_RIGHTY:
+			g_cstickY = axisValue;
+			break;
+		}
+		MxS32 combinedX = SDL_clamp(g_cpadX + g_cstickX, -SDL_JOYSTICK_AXIS_MAX, SDL_JOYSTICK_AXIS_MAX);
+		MxS32 combinedY = SDL_clamp(g_cpadY + g_cstickY, -SDL_JOYSTICK_AXIS_MAX, SDL_JOYSTICK_AXIS_MAX);
+		g_lastJoystickMouseX = ((MxFloat) combinedX) / SDL_JOYSTICK_AXIS_MAX * g_isle->GetCursorSensitivity();
+		g_lastJoystickMouseY = ((MxFloat) combinedY) / SDL_JOYSTICK_AXIS_MAX * g_isle->GetCursorSensitivity();
+#endif
+#ifndef __3DS__
 		if (event->gaxis.axis == SDL_GAMEPAD_AXIS_RIGHTX) {
 			g_lastJoystickMouseX = ((MxFloat) axisValue) / SDL_JOYSTICK_AXIS_MAX * g_isle->GetCursorSensitivity();
 		}
 		else if (event->gaxis.axis == SDL_GAMEPAD_AXIS_RIGHTY) {
 			g_lastJoystickMouseY = ((MxFloat) axisValue) / SDL_JOYSTICK_AXIS_MAX * g_isle->GetCursorSensitivity();
 		}
-		else if (event->gaxis.axis == SDL_GAMEPAD_AXIS_RIGHT_TRIGGER) {
+#endif
+		if (event->gaxis.axis == SDL_GAMEPAD_AXIS_RIGHT_TRIGGER) {
 			if (axisValue != 0 && !g_mousedown) {
 				g_mousedown = TRUE;
 

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -193,6 +193,7 @@ MxResult LegoInputManager::GetJoystickState(MxU32* p_joystickX, MxU32* p_joystic
 	}
 
 	MxS16 xPos = 0, yPos = 0;
+#ifndef __3DS__
 	for (const auto& [id, joystick] : m_joysticks) {
 		xPos = SDL_GetGamepadAxis(joystick.first, SDL_GAMEPAD_AXIS_LEFTX);
 		yPos = SDL_GetGamepadAxis(joystick.first, SDL_GAMEPAD_AXIS_LEFTY);
@@ -207,6 +208,7 @@ MxResult LegoInputManager::GetJoystickState(MxU32* p_joystickX, MxU32* p_joystic
 			break;
 		}
 	}
+#endif
 
 	if (!xPos && !yPos) {
 		xPos = m_touchVirtualThumb.x;


### PR DESCRIPTION
Closes #861. Implements the request in discussion #825.

## Root cause

SDL's 3DS joystick driver maps the circle pad to axes 0/1 (`LEFTX`/`LEFTY`) and the C-stick to axes 2/3 (`RIGHTX`/`RIGHTY`). The virtual mouse only reads `RIGHTX`/`RIGHTY` — on 3DS that's the C-stick, which only exists on New 3DS models (and is the barely-usable "nub" described in #825). The circle pad went to `LegoInputManager::GetJoystickState` (left-stick navigation) instead. So on an original 3DS/2DS no analog input moves the cursor at all, and only the d-pad works — exactly as reported.

## Change

- On 3DS, both sticks now drive the cursor: the handler tracks per-stick contributions (circle pad and C-stick) and sums them, so a release/zero event from one stick can't clobber the other's input. New 3DS users keep the C-stick behavior they have today, and the circle pad works everywhere, on every model.
- `GetJoystickState` no longer reads the gamepad left stick on 3DS (the touch virtual-thumb path is untouched), so the circle pad doesn't simultaneously steer the actor while moving the cursor. In-world movement works the standard mouse way — hold the click button and steer with the cursor — which is also how the touchscreen mouse scheme plays.

Combined with #873, cursor speed on 3DS is framerate-independent and matches the other ports.

## Verification

Reproduced and verified in Azahar (Citra successor) with a devkitARM build of this branch, using an in-game instrumented harness (not part of this PR):

- Pre-fix: deflecting `LEFTX`/`LEFTY` to max delivered gamepad axis events to the app but the cursor never moved; only the d-pad moved it — reproducing the report.
- Post-fix: full circle-pad deflection moves the cursor at the standard speed across the full screen, X and Y verified independently (cursor telemetry logged from inside the game: 320→640 on X, 240→480 on Y, clean stop on release).
- The C-stick path (raw `RIGHTX`/`RIGHTY`) still contributes through the same summing, and its initial zero-value axis events no longer zero out circle-pad movement (this ordering clobber is why a naive axis remap doesn't work).

The "cursor graphic is messed up" remark in #861 is a separate rendering matter and is not addressed here (the emulator rig currently shows no video output for the 3DS port at all, so it needs investigation on hardware or a deeper emulator dig).