### PR TITLE
Fix 3DS cursor transparency, distant texture corruption, and d-pad movement

### DIFF
--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -1730,6 +1730,7 @@ void IsleApp::MoveVirtualMouseViaJoystick()
 	float dpadX = 0.0f;
 	float dpadY = 0.0f;
 
+#ifndef __3DS__
 	if (g_dpadLeft) {
 		dpadX -= m_cursorSensitivity;
 	}
@@ -1742,6 +1743,7 @@ void IsleApp::MoveVirtualMouseViaJoystick()
 	if (g_dpadDown) {
 		dpadY += m_cursorSensitivity;
 	}
+#endif
 
 	// Use joystick axis if non-zero, else fall back to dpad
 	float moveX = ((g_lastJoystickMouseX != 0) ? g_lastJoystickMouseX : dpadX) * frames;

--- a/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
+++ b/LEGO1/lego/legoomni/src/input/legoinputmanager.cpp
@@ -208,6 +208,28 @@ MxResult LegoInputManager::GetJoystickState(MxU32* p_joystickX, MxU32* p_joystic
 			break;
 		}
 	}
+#else
+	// The circle pad doubles as the cursor stick, so the d-pad is used for
+	// direct movement instead
+	for (const auto& [id, joystick] : m_joysticks) {
+		if (SDL_GetGamepadButton(joystick.first, SDL_GAMEPAD_BUTTON_DPAD_LEFT)) {
+			xPos = SDL_JOYSTICK_AXIS_MIN;
+		}
+		else if (SDL_GetGamepadButton(joystick.first, SDL_GAMEPAD_BUTTON_DPAD_RIGHT)) {
+			xPos = SDL_JOYSTICK_AXIS_MAX;
+		}
+
+		if (SDL_GetGamepadButton(joystick.first, SDL_GAMEPAD_BUTTON_DPAD_UP)) {
+			yPos = SDL_JOYSTICK_AXIS_MIN;
+		}
+		else if (SDL_GetGamepadButton(joystick.first, SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
+			yPos = SDL_JOYSTICK_AXIS_MAX;
+		}
+
+		if (xPos || yPos) {
+			break;
+		}
+	}
 #endif
 
 	if (!xPos && !yPos) {

--- a/miniwin/src/d3drm/backends/citro3d/renderer.cpp
+++ b/miniwin/src/d3drm/backends/citro3d/renderer.cpp
@@ -194,11 +194,21 @@ static bool ConvertAndUploadTexture(C3D_Tex* tex, SDL_Surface* originalSurface, 
 	int width = resized->w;
 	int height = resized->h;
 
+	// The PICA200 cannot address mipmap levels smaller than 8x8, and
+	// C3D_TexGenerateMipmap leaves such levels untouched, so clamp the
+	// mipmap chain to levels of at least 8x8
+	int maxLevel = 0;
+	if (!isUI) {
+		while (maxLevel < 4 && (width >> (maxLevel + 1)) >= 8 && (height >> (maxLevel + 1)) >= 8) {
+			maxLevel++;
+		}
+	}
+
 	C3D_TexInitParams params = {};
 	params.width = width;
 	params.height = height;
 	params.format = GPU_RGBA8;
-	params.maxLevel = isUI ? 0 : 4;
+	params.maxLevel = maxLevel;
 	params.type = GPU_TEX_2D;
 	if (!C3D_TexInitWithParams(tex, nullptr, params)) {
 		if (resized != originalSurface) {
@@ -553,7 +563,14 @@ void Citro3DRenderer::Flip()
 
 void Citro3DRenderer::Draw2DImage(Uint32 textureId, const SDL_Rect& srcRect, const SDL_Rect& dstRect, FColor color)
 {
-	C3D_AlphaBlend(GPU_BLEND_ADD, GPU_BLEND_ADD, GPU_ONE, GPU_ONE_MINUS_SRC_ALPHA, GPU_ONE, GPU_ONE_MINUS_SRC_ALPHA);
+	C3D_AlphaBlend(
+		GPU_BLEND_ADD,
+		GPU_BLEND_ADD,
+		GPU_SRC_ALPHA,
+		GPU_ONE_MINUS_SRC_ALPHA,
+		GPU_SRC_ALPHA,
+		GPU_ONE_MINUS_SRC_ALPHA
+	);
 	StartFrame();
 	C3D_DepthTest(false, GPU_GREATER, GPU_WRITE_COLOR);
 


### PR DESCRIPTION
Closes #877. All three problems reproduced and verified in Azahar (with the game dumping its rendered bottom-screen framebuffer to the SD card, same mechanism as the reporter's screenshot).

**Opaque white box around the cursor**: `Draw2DImage` blends with premultiplied-alpha factors (`GPU_ONE`, `GPU_ONE_MINUS_SRC_ALPHA`), but the textures carry straight alpha. Instrumentation showed the converted cursor texture is correct in memory — color-keyed texels are palette gray `c3c3c3` with alpha 0 — yet with a source factor of `GPU_ONE` those texels still add their full RGB to the framebuffer, which produces exactly the observed artifact: a light-gray box that saturates to white over the sky, with the background bleeding through additively. Switched to straight-alpha blending; the cursor now renders with a fully transparent background.

**Rainbow colors in the distance**: every world texture was created with `maxLevel = 4`, but citro3d's `C3D_TexGenerateMipmap` cannot generate levels smaller than 8x8 — its inner loops simply don't execute (`dst_height/8 == 0`) and the levels are left as uninitialized `linearAlloc` memory. A 64x64 texture therefore samples garbage in its 4x4 level at high minification, which is why the corruption appears specifically on distant geometry (in the emulator the unwritten levels read back as zeros; on hardware they contain heap garbage, hence the rainbow noise). Verified live: pre-fix, the deepest level of a 64x64 texture was unwritten; post-fix the chain stops at a properly generated 8x8 level and distant geometry renders clean.

**No way to move outside the touch schemes**: #874 turned the circle pad into the cursor stick, and the d-pad only duplicated cursor movement. The d-pad now feeds the joystick navigation path as full-deflection digital axes (the same path the circle pad drove before #874), so d-pad up/down walks and left/right turns, as requested in the issue. Verified end-to-end via a virtual gamepad: holding d-pad up ramps the nav controller's linear velocity and advances the position; holding right produces the full rotational velocity.