### PR TITLE
Keep the installer laid out correctly when opened from another app on mobile

### DIFF
--- a/installer/index.html
+++ b/installer/index.html
@@ -858,8 +858,19 @@
   var useZoom = 'zoom' in document.documentElement.style;
   var scale = 1, portrait = false, stageW = 640, stageH = 480;
   var stagePos = $('stagepos'), stage = $('stage');
+  // The visual viewport is what the user actually sees (Safari's toolbars and a stale
+  // innerHeight right after launching from another app are excluded); the window size is
+  // the fallback when the page is pinch-zoomed or the visual viewport is not available.
+  function viewportSize() {
+    var vv = window.visualViewport, w = window.innerWidth, h = window.innerHeight;
+    if (vv && vv.width > 0 && vv.height > 0 && Math.abs((vv.scale || 1) - 1) < 0.01) { w = vv.width; h = vv.height; }
+    return { w: Math.round(w), h: Math.round(h) };
+  }
+  var lastFit = '';
   function fit() {
-    var vw = +query.vw || window.innerWidth, vh = +query.vh || window.innerHeight, dpr = +query.dpr || window.devicePixelRatio || 1;
+    var vp = viewportSize();
+    var vw = +query.vw || vp.w, vh = +query.vh || vp.h, dpr = +query.dpr || window.devicePixelRatio || 1;
+    lastFit = vw + 'x' + vh + '@' + dpr;
     function crispScale(L) {
       var k = Math.floor(Math.min(vw / (L.x1 - L.x0), vh / (L.y1 - L.y0)) * dpr);
       return k / dpr;
@@ -892,7 +903,21 @@
     raf(function () { fitPending = false; fit(); });
   }
   window.addEventListener('resize', scheduleFit);
-  if (window.visualViewport) window.visualViewport.addEventListener('resize', scheduleFit);
+  window.addEventListener('orientationchange', scheduleFit);
+  window.addEventListener('pageshow', scheduleFit);
+  window.addEventListener('focus', scheduleFit);
+  document.addEventListener('visibilitychange', scheduleFit);
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', scheduleFit);
+    window.visualViewport.addEventListener('scroll', scheduleFit);
+  }
+  // Mobile browsers can settle their viewport after load without firing resize (Safari opened
+  // from another app), so re-fit whenever the measured size changes during the first seconds.
+  (function settle(ticks) {
+    var vp = viewportSize();
+    if (vp.w + 'x' + vp.h + '@' + (window.devicePixelRatio || 1) !== lastFit && !query.vw && !query.vh) fit();
+    if (ticks > 0) setTimeout(function () { settle(ticks - 1); }, 250);
+  })(16);
 
   // Windows can be dragged around by their title bar, like the real thing.
   (function () {


### PR DESCRIPTION
Follow-up to #885.

On iOS (reported with Chrome for iOS), opening the installer from a link in another app showed the scene positioned for a much shorter viewport: the dialog's title bar sat under the browser's address bar and the black page background showed at the bottom. Switching apps and back fixed it, which points at a stale window size at load time with no resize event afterwards.

- `fit()` now measures the visual viewport when the page is not pinch-zoomed, falling back to the window size.
- The layout is re-fitted on `pageshow`, `focus`, `visibilitychange`, `orientationchange`, and on visual viewport scroll/resize, in addition to `resize`.
- For the first four seconds after load the viewport size is polled and the layout re-fitted if it changed, covering browsers that settle their viewport silently.

The layout self-check is clean on desktop and on ten emulated devices; keyboard and drag tests pass. Safari in the iOS Simulator does not reproduce the original problem, so this needs a check on a real device with Chrome for iOS after deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ED5f7A2zaZxVBimhxXFok
