### PR TITLE
Lay the installer out in the small viewport so Chrome for iOS shows all of it

### DIFF
--- a/installer/index.html
+++ b/installer/index.html
@@ -24,7 +24,10 @@
   body { touch-action: manipulation; }
 
   /* ---- 640x480 stage, scaled to the viewport ---- */
-  #viewport { position: fixed; top: 0; right: 0; bottom: 0; left: 0; inset: 0; overflow: hidden; }
+  /* Anchored to the bottom and sized to the small viewport: Chrome for iOS can size its web
+     view as if its toolbars were hidden while they are still shown, and then only the bottom
+     100svh of the window is actually visible. */
+  #viewport { position: fixed; right: 0; bottom: 0; left: 0; height: 100%; height: 100svh; overflow: hidden; }
   #stagepos { position: absolute; left: 0; top: 0; }
   #stage {
     position: relative; width: 640px; height: 480px;
@@ -859,7 +862,8 @@
   var scale = 1, portrait = false, stageW = 640, stageH = 480;
   var stagePos = $('stagepos'), stage = $('stage');
   function fit() {
-    var vw = +query.vw || window.innerWidth, vh = +query.vh || window.innerHeight, dpr = +query.dpr || window.devicePixelRatio || 1;
+    var root = document.documentElement;
+    var vw = +query.vw || root.clientWidth || window.innerWidth, vh = +query.vh || root.clientHeight || window.innerHeight, dpr = +query.dpr || window.devicePixelRatio || 1;
     function crispScale(L) {
       var k = Math.floor(Math.min(vw / (L.x1 - L.x0), vh / (L.y1 - L.y0)) * dpr);
       return k / dpr;


### PR DESCRIPTION
Fixes the Chrome-for-iOS mis-layout when the installer is opened from a link in another app (title bar under the address bar, black band above the bottom toolbar).

A diagnostic page opened on the affected phone showed the mechanism: `innerHeight` and `visualViewport.height` were 824 while `documentElement.clientHeight` and `100svh` were 716, with all scroll offsets at 0. Chrome had sized its web view as if its toolbars were hidden while they were still shown, so only the bottom 716 px of the 824 px page were visible. Re-measuring the window (the approach of the reverted #886) cannot see that; the small viewport can.

- The fixed container is now `height: 100svh` (fallback `100%`) and anchored to the bottom of the window, so in that state it covers exactly the visible area; in a normal state it is unchanged.
- `fit()` measures the root element (`clientWidth/clientHeight`) instead of the window.

Desktop rendering is pixel-identical to before; the layout self-check is clean on desktop and on ten emulated devices; Simulator Safari renders normally. A standalone probe with the same container change is at https://foxtacles.github.io/probe2.html for confirmation on the phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ED5f7A2zaZxVBimhxXFok
