### PR TITLE
Fix the WasmFS fetch-backend language race and stop the rabbits composite from re-streaming

### DIFF
--- a/ISLE/emscripten/emscripten.patch
+++ b/ISLE/emscripten/emscripten.patch
@@ -37,10 +37,26 @@ index 6d979627e..97e3f8684 100644
      dbg(`pthread_create: transferredCanvasNames="${transferredCanvasNames}"`);
  #endif
 diff --git a/src/lib/libwasmfs_fetch.js b/src/lib/libwasmfs_fetch.js
-index e8c9f7e21..caf1971d2 100644
+index e8c9f7e..aaa6c42 100644
 --- a/src/lib/libwasmfs_fetch.js
 +++ b/src/lib/libwasmfs_fetch.js
-@@ -38,36 +38,7 @@ addToLibrary({
+@@ -6,6 +6,7 @@
+ 
+ addToLibrary({
+   $wasmFS$JSMemoryRanges: {},
++  $wasmFS$language: null,
+ 
+   // Fetch backend: On first access of the file (either a read or a getSize), it
+   // will fetch() the data from the network asynchronously. Otherwise, after
+@@ -14,6 +15,7 @@ addToLibrary({
+   _wasmfs_create_fetch_backend_js__deps: [
+     '$wasmFS$backends',
+     '$wasmFS$JSMemoryRanges',
++    '$wasmFS$language',
+     '_wasmfs_fetch_get_file_url',
+     '_wasmfs_fetch_get_chunk_size',
+   ],
+@@ -38,36 +40,7 @@ addToLibrary({
        var chunkSize = __wasmfs_fetch_get_chunk_size(file);
        offset ??= 0;
        len ??= chunkSize;
@@ -78,7 +94,7 @@ index e8c9f7e21..caf1971d2 100644
        var firstChunk = (offset / chunkSize) | 0;
        // In which chunk does the seeked range end?  E.g., 5-14 with chunksize 8 will end in chunk 1, as will 5-16 (since byte 16 isn't requested).
        // This will always give us a chunk >= firstChunk since len > 0.
-@@ -76,7 +47,7 @@ addToLibrary({
+@@ -76,7 +49,7 @@ addToLibrary({
        var i;
        // Do we have all the chunks already?  If so, we don't need to do any fetches.
        for (i = firstChunk; i <= lastChunk; i++) {
@@ -87,7 +103,7 @@ index e8c9f7e21..caf1971d2 100644
            allPresent = false;
            break;
          }
-@@ -90,16 +61,37 @@ addToLibrary({
+@@ -90,16 +63,37 @@ addToLibrary({
        // one request for all the chunks we need, rather than one
        // request per chunk.
        var start = firstChunk * chunkSize;
@@ -100,7 +116,7 @@ index e8c9f7e21..caf1971d2 100644
        // We must fetch *up to* the last byte of the last chunk.
        var end = (lastChunk+1) * chunkSize;
 -      var response = await fetch(url, {headers:{'Range': `bytes=${start}-${end-1}`}});
-+      var response = await fetch(url, {headers:{'Range': `bytes=${start}-${end-1}`, 'Accept-Language': wasmFS$language}});
++      var response = await fetch(url, {headers:{'Range': `bytes=${start}-${end-1}`, 'Accept-Language': await wasmFS$language}});
        if (!response.ok) {
          throw response;
        }
@@ -127,7 +143,7 @@ index e8c9f7e21..caf1971d2 100644
        return Promise.resolve();
      }
  
-@@ -156,14 +148,31 @@ addToLibrary({
+@@ -156,14 +150,31 @@ addToLibrary({
          return readLength;
        },
        getSize: async (file) => {
@@ -146,7 +162,7 @@ index e8c9f7e21..caf1971d2 100644
        },
      };
 + 
-+    wasmFS$language = await (async () => {
++    wasmFS$language = (async () => {
 +      try {
 +        const fileHandle = await (await navigator.storage.getDirectory()).getFileHandle('isle.ini');
 +        const content = await (await fileHandle.getFile()).text();

--- a/assets/main.cpp
+++ b/assets/main.cpp
@@ -431,7 +431,7 @@ void CreateRabbits()
 	composite->id_ = 2;
 	composite->type_ = si::MxOb::Presenter;
 	composite->presenter_ = "LegoAnimMMPresenter";
-	composite->flags_ = MxDSAction::c_enabled | MxDSAction::c_bit3;
+	composite->flags_ = MxDSAction::c_enabled;
 	composite->loops_ = 1;
 	composite->extra_ = si::bytearray(extra.c_str(), extra.length() + 1);
 	composite->name_ = "rabbits_composite";


### PR DESCRIPTION
Two independent fixes surfaced while investigating freezes with the Rabbits extra on the web build.

## Startup race in the WasmFS fetch backend (emscripten patch)

The patch to `src/lib/libwasmfs_fetch.js` reads the language from `isle.ini` in OPFS and sends it as `Accept-Language` on every range request. It assigned `wasmFS$language`, an undeclared implicit global, only after that async OPFS read completed, while the backend was already registered. Any file read issued before the read finished threw `ReferenceError` inside `getFileRange`; `read()` then returned `EBADF` and `getSize()` returned 0. Extra SI files loaded at startup (widescreen, rabbits) are the first fetch-backend reads whenever HD textures are off, so they failed intermittently with `Could not load SI file`. With HD textures on, the texture preload loop absorbs the race, which is why production rarely showed it.

Fix (four lines in the patch): declare `$wasmFS$language`, store the pending language promise in it synchronously during backend creation, and `await` it when building the request headers. The first request already carries the configured language, with `en` as the fallback. Verified with a header-logging server driven through the real config UI (`Language=de`: every game-file request, including the first, carried `de`) and by regenerating the hunk against pristine emscripten 4.0.10.

## Rabbits composite re-streaming forever (asset generator)

The rabbits composite carried `c_bit3` (libweaver `LoopStream`) while its looping animation child has an infinite duration. On the composite's end chunk `MxDSBuffer::ParseChunk` therefore rewound the stream to the object's offset instead of ending it, re-reading and re-parsing the object 55–90 times per second for as long as the Isle world was enabled (measured natively, in Chrome, and in the iOS simulator). The animation loops in memory in `LegoLoopingAnimPresenter::PutFrame`, so the flag only drove the streamer. Dropping it leaves the animation looping (frame counter and 40 s wrap verified) with the stream read once.

`rabbits.si` needs to be regenerated and redeployed for this part to reach users.