### PR TITLE
Fix three web crash-report families rooted in browser lifecycle handling

### DIFF
--- a/ISLE/emscripten/emscripten.patch
+++ b/ISLE/emscripten/emscripten.patch
@@ -2,7 +2,7 @@ diff --git a/src/lib/libhtml5.js b/src/lib/libhtml5.js
 index da08765e7..24e5da22e 100644
 --- a/src/lib/libhtml5.js
 +++ b/src/lib/libhtml5.js
-@@ -1182,6 +1182,7 @@ var LibraryHTML5 = {
+@@ -1182,6 +1182,7 @@
  
    $registerRestoreOldStyle__deps: ['$getCanvasElementSize', '$setCanvasElementSize', '$currentFullscreenStrategy'],
    $registerRestoreOldStyle: (canvas) => {
@@ -10,7 +10,7 @@ index da08765e7..24e5da22e 100644
      var canvasSize = getCanvasElementSize(canvas);
      var oldWidth = canvasSize[0];
      var oldHeight = canvasSize[1];
-@@ -1326,9 +1327,9 @@ var LibraryHTML5 = {
+@@ -1326,9 +1327,9 @@
      var topMargin;
  
      if (inAspectRatioFixedFullscreenMode) {
@@ -23,6 +23,15 @@ index da08765e7..24e5da22e 100644
      }
  
      if (inPixelPerfectFullscreenMode) {
+@@ -2196,7 +2197,7 @@
+       if (canvas.GLctxObject?.GLctx) {
+         var prevViewport = canvas.GLctxObject.GLctx.getParameter(0xBA2 /* GL_VIEWPORT */);
+         // TODO: Perhaps autoResizeViewport should only be true if FBO 0 is currently active?
+-        autoResizeViewport = (prevViewport[0] === 0 && prevViewport[1] === 0 && prevViewport[2] === canvas.width && prevViewport[3] === canvas.height);
++        autoResizeViewport = !!prevViewport && (prevViewport[0] === 0 && prevViewport[1] === 0 && prevViewport[2] === canvas.width && prevViewport[3] === canvas.height);
+ #if GL_DEBUG
+         dbg(`Resizing canvas from ${canvas.width}x${canvas.height} to ${width}x${height}. Previous GL viewport size was ${prevViewport}, so autoResizeViewport=${autoResizeViewport}`);
+ #endif
 diff --git a/src/lib/libpthread.js b/src/lib/libpthread.js
 index 6d979627e..97e3f8684 100644
 --- a/src/lib/libpthread.js
@@ -184,7 +193,7 @@ diff --git a/src/preamble.js b/src/preamble.js
 index 572694517..44e65c823 100644
 --- a/src/preamble.js
 +++ b/src/preamble.js
-@@ -1062,3 +1062,19 @@ function getCompilerSetting(name) {
+@@ -1015,3 +1015,37 @@
  // dynamic linker as symbols are loaded.
  var asyncifyStubs = {};
  #endif
@@ -202,5 +211,23 @@ index 572694517..44e65c823 100644
 +
 +  Module["disableOffscreenCanvases"] ||= !document.createElement('canvas').getContext('webgl2');
 +  console.log("disableOffscreenCanvases: " + Module["disableOffscreenCanvases"]);
++
++  if (!Module["disableOffscreenCanvases"] && typeof Worker !== "undefined" && typeof OffscreenCanvas !== "undefined") {
++    try {
++      const probe = new Worker(URL.createObjectURL(new Blob([
++        "try { postMessage(!!new OffscreenCanvas(1, 1).getContext('webgl2')); } catch (e) { postMessage(false); }"
++      ], { type: "text/javascript" })));
++      const disable = () => {
++        probe.terminate();
++        Module["disableOffscreenCanvases"] = true;
++        console.log("disableOffscreenCanvases: true (no WebGL2 in workers)");
++      };
++      probe.onmessage = (e) => e.data ? probe.terminate() : disable();
++      probe.onerror = disable;
++    } catch (e) {
++      Module["disableOffscreenCanvases"] = true;
++      console.log("disableOffscreenCanvases: true (worker probe failed)");
++    }
++  }
 +}
 +

--- a/ISLE/isleapp.cpp
+++ b/ISLE/isleapp.cpp
@@ -59,6 +59,8 @@
 #include "emscripten/haptic.h"
 #include "emscripten/messagebox.h"
 #include "emscripten/window.h"
+
+#include <emscripten/threading.h>
 #endif
 
 #ifdef __3DS__
@@ -512,6 +514,11 @@ static SDL_GamepadButton GetGamepadClickButton(SDL_JoystickID p_joystickID)
 
 SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event)
 {
+#ifdef __EMSCRIPTEN__
+	if (emscripten_is_main_browser_thread()) {
+		return SDL_APP_CONTINUE;
+	}
+#endif
 	if (!g_isle) {
 		return SDL_APP_CONTINUE;
 	}


### PR DESCRIPTION
Three isle.pizza crash-report families, each reproduced locally in headless Chrome against a harness build, root-caused, fixed, and re-verified with the same scenario.

## 1. `bindFramebuffer`: GLctx is undefined during beforeunload (Firefox report 3490 and the wider GL-teardown family)

**Cause.** On `beforeunload`, SDL's Emscripten backend calls `SDL_SendAppEvent(SDL_EVENT_TERMINATING)` on the browser main thread. SDL's main-callbacks event watcher treats the terminating event as dispatch-immediately and first drains every queued event into `SDL_AppEvent` on that same thread. A queued `SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED` then reaches `Direct3DRMDevice2Impl::Resize` from a thread that owns no GL context.

**Repro.** Harness hook pushes a pixel-size event and sleeps the game thread, then the page dispatches a synthetic `beforeunload`. Unfixed: abort with the exact wild stack (`_glBindFramebuffer ← OpenGLES3Renderer::Resize ← ... ← SDL_AppEvent ← SDL_DispatchMainCallbackEvents ← SDL_MainCallbackEventWatcher ← Emscripten_HandleBeforeUnload`) and a crash POST. Fixed: no abort, and the game thread still quits cleanly on the terminating event.

**Fix.** `SDL_AppEvent` returns early when called on the browser main thread. The existing event watch that saves the game state on terminating is unaffected.

## 2. `Cannot read properties of null (reading '0')` in the canvas resize helper (reports 3480, 3494, 3496, 3447, 3448, 3453)

**Cause.** `setCanvasElementSizeCallingThread` reads `getParameter(GL_VIEWPORT)` from the canvas's context. When the WebGL context has been *lost* (as opposed to deleted, which clears `GLctxObject`), that returns `null`. The path is `SDL_AppQuit → SDL_DestroyWindow → Emscripten_SetWindowFillDocument`, which only leaves the renderer's context alive when the app exits through `SDL_APP_FAILURE` at startup. So these were startup failures with a lost context, reported as TypeErrors instead of exit code 1.

**Repro.** Attach to the game worker via CDP, call `WEBGL_lose_context.loseContext()` on its context, then force `SDL_APP_FAILURE`. Unfixed: identical stack and crash POST. Fixed: "Game exited with code 1".

**Fix.** Null-check the viewport in the `libhtml5.js` hunk of `emscripten.patch`.

## 3. Safari `InvalidStateError` from `getContext('2d')` at start (12 reports, one user who never got in)

**Cause.** The preamble probe checks WebGL2 on the main thread only. On that Safari, WebGL2 works on the main thread but not in workers (the frontend's thumbnails worker logged the same failure in the console tail). The canvas is transferred offscreen, the worker's context creation fails, SDL falls back to its 2D framebuffer on the DOM canvas, and a transferred canvas can never hand out a 2D context.

**Repro.** CDP auto-attach with `waitForDebuggerOnStart`, patch `OffscreenCanvas.prototype.getContext` to return null for WebGL in every worker. Unfixed: `SDL_GL_CreateContext: Could not create webgl context` followed by the InvalidStateError abort. Fixed: the probe flips `disableOffscreenCanvases`, and the game proceeds on the software path with no abort.

**Fix.** Add a worker-side WebGL2 probe to the preamble hunk of `emscripten.patch`. The probe runs at script load, long before the user starts the game.

## Verification

- `emscripten.patch` applies cleanly to pristine emscripten 4.0.10 and reproduces the patched SDK files byte for byte.
- Web build and native ASan build compile from the clean tree.
- Same scenarios on the fixed builds: no crash POST in any of the three.

## Investigated, not fixed (no local reproduction)

- Report 3478 (`null function` in `Isle::CheckAreaExiting`): code walk found several flows that null the user actor, but each restores it before the Isle re-enables (the race world is stopped on infocenter entry, and the Act 3 re-enable restores the copter). Scenarios for car race, jetski race, Act 2 and Act 3 all survive under ASan.
- `GetExtraActor` strcasecmp in `LegoAnimPresenter::EndAction` (6 reports across 4 builds): managed-ROI lifetime instrumentation found no freed ROI in island, Act 2 or Act 3 scenarios.
- Firefox `deleteTexture` at quit in `LegoOmni::Destroy`: a per-instance lifetime log showed no destroy callbacks after the renderer destructor in Chrome, including native-resolution mode with resizes; a headless Firefox quit was clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ED5f7A2zaZxVBimhxXFok
