### PR TITLE
Point PTATCAM animations at the player in third-person camera

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           brew update
           brew uninstall cmake || true
-          brew install cmake ninja llvm ${{ !matrix.qt-action && 'qt6' || '' }}
+          brew install cmake ninja ${{ matrix.clang-tidy && 'llvm' || '' }} ${{ !matrix.qt-action && 'qt6' || '' }}
           echo "LLVM_ROOT=$(brew --prefix llvm)/bin" >> $GITHUB_ENV
       
       - name: Use latest Xcode

--- a/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
+++ b/LEGO1/lego/legoomni/src/video/legoanimpresenter.cpp
@@ -3,6 +3,7 @@
 #include "3dmanager/lego3dmanager.h"
 #include "anim/legoanim.h"
 #include "define.h"
+#include "extensions/thirdpersoncamera.h"
 #include "legoanimactor.h"
 #include "legoanimationmanager.h"
 #include "legoanimmmpresenter.h"
@@ -35,6 +36,8 @@ DECOMP_SIZE_ASSERT(LegoLoopingAnimPresenter, 0xc0)
 DECOMP_SIZE_ASSERT(LegoLocomotionAnimPresenter, 0xd8)
 DECOMP_SIZE_ASSERT(LegoHideAnimPresenter, 0xc4)
 DECOMP_SIZE_ASSERT(LegoHideAnimStruct, 0x08)
+
+using namespace Extensions;
 
 // FUNCTION: LEGO1 0x10068420
 // FUNCTION: BETA10 0x1004e5f0
@@ -665,6 +668,11 @@ void LegoAnimPresenter::PutFrame()
 		ApplyTransformWithVisibilityAndCam(m_anim, time, m_transform);
 
 		if (m_ptAtCamROI != NULL && m_currentWorld != NULL && m_currentWorld->GetCameraController() != NULL) {
+			Mx3DPointFloat target;
+			if (!Extension<ThirdPersonCameraExt>::Call(TP::HandlePtAtCamTarget, target).value_or(FALSE)) {
+				target = m_currentWorld->GetCameraController()->GetWorldLocation();
+			}
+
 			for (MxS32 i = 0; i < m_ptAtCamCount; i++) {
 				if (m_ptAtCamROI[i] != NULL) {
 					MxMatrix mat(m_ptAtCamROI[i]->GetLocal2World());
@@ -680,7 +688,7 @@ void LegoAnimPresenter::PutFrame()
 
 					up = und;
 
-					up -= m_currentWorld->GetCameraController()->GetWorldLocation();
+					up -= target;
 					dir /= dirsqr;
 					pos.EqualsCross(dir, up);
 					pos.Unitize();
@@ -1302,6 +1310,11 @@ void LegoLoopingAnimPresenter::PutFrame()
 	ApplyTransformWithVisibilityAndCam(m_anim, time, m_transform);
 
 	if (m_ptAtCamROI != NULL && m_currentWorld != NULL && m_currentWorld->GetCameraController() != NULL) {
+		Mx3DPointFloat target;
+		if (!Extension<ThirdPersonCameraExt>::Call(TP::HandlePtAtCamTarget, target).value_or(FALSE)) {
+			target = m_currentWorld->GetCameraController()->GetWorldLocation();
+		}
+
 		for (MxS32 i = 0; i < m_ptAtCamCount; i++) {
 			if (m_ptAtCamROI[i] != NULL) {
 				MxMatrix mat(m_ptAtCamROI[i]->GetLocal2World());
@@ -1317,7 +1330,7 @@ void LegoLoopingAnimPresenter::PutFrame()
 
 				up = und;
 
-				up -= m_currentWorld->GetCameraController()->GetWorldLocation();
+				up -= target;
 				dir /= dirsqr;
 				pos.EqualsCross(dir, up);
 				pos.Unitize();

--- a/extensions/include/extensions/thirdpersoncamera.h
+++ b/extensions/include/extensions/thirdpersoncamera.h
@@ -42,6 +42,7 @@ public:
 		float p_deltaTime
 	);
 	static MxBool HandleWorldEnable(LegoWorld* p_world, MxBool p_enable);
+	static MxBool HandlePtAtCamTarget(Vector3& p_target);
 
 	static MxBool HandleROIClick(LegoROI* p_rootROI, LegoEventNotificationParam& p_param);
 	static MxBool IsClonedCharacter(const char* p_name);
@@ -73,6 +74,7 @@ constexpr auto HandleTouchInput = &ThirdPersonCameraExt::HandleTouchInput;
 constexpr auto HandleNavOverride = &ThirdPersonCameraExt::HandleNavOverride;
 constexpr auto HandleROIClick = &ThirdPersonCameraExt::HandleROIClick;
 constexpr auto IsClonedCharacter = &ThirdPersonCameraExt::IsClonedCharacter;
+constexpr auto HandlePtAtCamTarget = &ThirdPersonCameraExt::HandlePtAtCamTarget;
 #else
 constexpr decltype(&ThirdPersonCameraExt::HandleCreate) HandleCreate = nullptr;
 constexpr decltype(&ThirdPersonCameraExt::HandleWorldEnable) HandleWorldEnable = nullptr;
@@ -85,6 +87,7 @@ constexpr decltype(&ThirdPersonCameraExt::HandleTouchInput) HandleTouchInput = n
 constexpr decltype(&ThirdPersonCameraExt::HandleNavOverride) HandleNavOverride = nullptr;
 constexpr decltype(&ThirdPersonCameraExt::HandleROIClick) HandleROIClick = nullptr;
 constexpr decltype(&ThirdPersonCameraExt::IsClonedCharacter) IsClonedCharacter = nullptr;
+constexpr decltype(&ThirdPersonCameraExt::HandlePtAtCamTarget) HandlePtAtCamTarget = nullptr;
 #endif
 } // namespace TP
 

--- a/extensions/src/thirdpersoncamera.cpp
+++ b/extensions/src/thirdpersoncamera.cpp
@@ -222,6 +222,16 @@ MxBool ThirdPersonCameraExt::HandleNavOverride(
 	return s_camera->HandleCameraRelativeMovement(p_nav, p_curPos, p_curDir, p_newPos, p_newDir, p_deltaTime);
 }
 
+MxBool ThirdPersonCameraExt::HandlePtAtCamTarget(Vector3& p_target)
+{
+	if (!s_camera || !s_camera->IsActive() || !s_camera->GetPlayerROI()) {
+		return FALSE;
+	}
+
+	p_target = s_camera->GetPlayerROI()->GetWorldPosition();
+	return TRUE;
+}
+
 MxBool ThirdPersonCameraExt::HandleROIClick(LegoROI* p_rootROI, LegoEventNotificationParam& p_param)
 {
 	if (!s_camera) {


### PR DESCRIPTION
Animations that carry a `PTATCAM` directive turn the listed ROIs toward the camera every frame. With the third-person camera extension active, the camera orbits the player, so those characters looked past the player at the orbit position instead of at them.

## Change

- `ThirdPersonCameraExt` gains a `HandlePtAtCamTarget(Vector3&)` hook. It returns TRUE and writes the player ROI's world position while the third-person camera is active and has a player ROI, and FALSE otherwise.
- `LegoAnimPresenter::PutFrame` and `LegoLoopingAnimPresenter::PutFrame` resolve the facing target once per frame through the hook and fall back to the camera controller's world location when it declines. The facing math is unchanged.

## Unaffected

Multiplayer reenactments apply their own PTATCAM pass in `ScenePlayer::ApplyPtAtCam` (targeting the spectator participant) and never go through these presenters.

## CI: macOS (Intel) brew step

Homebrew's `llvm` formula moved to 23.1.1 without an x86_64 macOS bottle, so the macOS (Intel) job began compiling LLVM from source in the brew step (two attempts cancelled after 25 and 13 minutes on `cmake --build .` inside the llvm formula; the step took 2 to 4 minutes on every earlier master run). `LLVM_ROOT` is only consumed by the clang-tidy lookup, and no macOS job enables clang-tidy, so the second commit gates the llvm install on the matrix `clang-tidy` flag, the same way `qt6` is already gated.

## Verification

- Web (Emscripten) Release build and native Debug build compile and link cleanly.
- The local target copy was checked to hold its own storage rather than alias the temporary returned by `GetWorldLocation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ED5f7A2zaZxVBimhxXFok
